### PR TITLE
Add a script to extract information from source system

### DIFF
--- a/scripts/system-info/README.md
+++ b/scripts/system-info/README.md
@@ -1,0 +1,260 @@
+# System Information Extractor
+
+This script, written in Python, collects various hardware and software information from the host system.
+It can be useful for extracting and referencing the configuration of the source computing environment in cloud migration projects.
+This script helps to quickly understand the current state of the system and diagnose issues.
+It is useful for checking and referencing the configuration of the source computing environment for the cloud migrator project.
+
+
+## Dependencies
+
+- `psutil`
+- `prettytable`
+- `netifaces`
+- `pyyaml`
+- `GPUtil`
+
+## Execution
+
+```bash
+python3 system_info.py
+```
+
+## Features
+
+### 1. OS Information Collection
+Collects OS name, version, architecture, platform, boot time, currently logged-in user, kernel version, and distribution information.
+
+```python
+def get_os_info():
+    """Fetch Operating System information."""
+    ...
+    return "OS", [
+        ("Name", platform.system()),
+        ...
+    ]
+```
+
+### 2. CPU Information Collection
+Collects CPU brand, core count, current frequency, context switches, interrupts, architecture, user time, system time, and idle time.
+
+```python
+def get_cpu_info():
+    """Fetch CPU information."""
+    ...
+    return "CPU", [
+        ("Brand", platform.processor()),
+        ...
+    ]
+```
+
+### 3. Memory Information Collection
+Collects total memory, available memory, used memory, cached memory, and swap memory information.
+
+```python
+def get_memory_info():
+    """Fetch Memory information."""
+    ...
+    return "Memory", [
+        ("Total (GB)", bytes_to_gb(virtual_memory.total)),
+        ...
+    ]
+```
+
+### 4. Disk Information Collection
+Collects total disk capacity, available capacity, used capacity, read and write count.
+
+```python
+def get_disk_info():
+    """Fetch Disk information."""
+    ...
+    return "Disk", [
+        ("Total (GB)", bytes_to_gb(disk_info.total)),
+        ...
+    ]
+```
+
+### 5. Network Information Collection
+Collects host name, IP address, MAC address, active network interfaces, gateway, and DNS information.
+
+```python
+def get_network_info():
+    """Fetch Network information."""
+    ...
+    return "Network", [
+        ("Hostname", socket.gethostname()),
+        ...
+    ]
+```
+
+### 6. Advanced Network Information Collection
+Collects IP address, netmask, broadcast, and MAC address of each network interface.
+
+```python
+def get_advanced_network_info():
+    """Fetch advanced network information using netifaces."""
+    ...
+    return "Advanced Network", iface_info
+```
+
+### 7. GPU Information Collection
+Collects GPU name and driver version (if GPUtil is installed).
+
+```python
+def get_gpu_info():
+    """Fetch GPU information if available."""
+    ...
+    return "GPU", info_list
+```
+
+### 8. Graphic Card Information Collection
+Collects VGA compatible controller information.
+
+```python
+def get_graphic_card_info():
+    ...
+    return "Graphic Card", info_list
+```
+
+### 9. Process Information Collection
+Collects information on all running processes and users on the system.
+
+```python
+def get_process_info():
+    """Fetch Process information."""
+    ...
+    return "Process", sorted(process_list)
+```
+
+### 10. Data Saving
+Saves all collected system information to a YAML file.
+
+```python
+def save_to_yaml(data):
+    """Save dictionary data to YAML file."""
+    ...
+```
+
+## Output
+The collected information is printed to the console in a neat table format, and is also saved to a `system_info.yaml` file.
+
+Example
+```
+System Information:
++-------+--------------+-----------------------+----------------------------------------------------------+
+| Index |    Group     |        Category       |                           Info                           |
++-------+--------------+-----------------------+----------------------------------------------------------+
+|   1   |      OS      |          Name         |                          Linux                           |
+|   2   |      OS      |        Version        |       #224-Ubuntu SMP Mon Jun 19 13:30:12 UTC 2023       |
+|   3   |      OS      |      Architecture     |                     ('64bit', 'ELF')                     |
+|   4   |      OS      |        Platform       | Linux-4.15.0-213-generic-x86_64-with-Ubuntu-18.04-bionic |
+|   5   |      OS      |       Boot Time       |                   2023-09-18 11:11:51                    |
+|   6   |      OS      |      Logged User      |                           son                            |
+|   7   |      OS      |     Kernel Version    |                    4.15.0-213-generic                    |
+|   8   |      OS      |      Distribution     |                   Ubuntu 18.04 bionic                    |
+|   9   |     CPU      |         Brand         |                          x86_64                          |
+|   10  |     CPU      |  Core Count (Logical) |                            4                             |
+|   11  |     CPU      | Core Count (Physical) |                            4                             |
+|   12  |     CPU      |   Current Frequency   |                        3600.0 MHz                        |
+|   13  |     CPU      |    Context Switches   |                        3132898179                        |
+|   14  |     CPU      |       Interrupts      |                        1738814431                        |
+|   15  |     CPU      |      Architecture     |                          x86_64                          |
+|   16  |     CPU      |     User Time (%)     |                           17.0                           |
+|   17  |     CPU      |    System Time (%)    |                           0.0                            |
+|   18  |     CPU      |     Idle Time (%)     |                           21.0                           |
+|   19  |    Memory    |       Total (GB)      |                           7.79                           |
+|   20  |    Memory    |     Available (GB)    |                           2.22                           |
+|   21  |    Memory    |       Used (GB)       |                           4.85                           |
+|   22  |    Memory    |      Cached (GB)      |                           1.95                           |
+|   23  |    Memory    |    Swap Total (GB)    |                           2.0                            |
+|   24  |    Memory    |     Swap Free (GB)    |                           0.86                           |
+|   25  |    Memory    |     Swap Used (GB)    |                           1.14                           |
+|   26  |     Disk     |       Total (GB)      |                          97.87                           |
+|   27  |     Disk     |       Free (GB)       |                           3.95                           |
+|   28  |     Disk     |       Used (GB)       |                          88.91                           |
+|   29  |     Disk     |       Read Count      |                         5742877                          |
+|   30  |     Disk     |      Write Count      |                         23171054                         |
+|   31  |   Network    |        Hostname       |                           son                            |
+|   32  |   Network    |       IP Address      |                        127.0.1.1                         |
+|   33  |   Network    |      MAC Address      |                    aa:83:85:16:60:d5                     |
+|   34  |   Network    |   Active Interfaces   |             lo, docker0, enp0s3, veth6c9eb12             |
+|   35  |   Network    |        Gateway        |                        127.0.1.1                         |
+|   36  |   Network    |          DNS          |                        127.0.1.1                         |
+|   37  | Graphic Card |         Status        |                      Not Available                       |
++-------+--------------+-----------------------+----------------------------------------------------------+
+
+Advanced Network Information:
++-----------------+------------+---------------+----------------+-------------------+
+|    Interface    | IP Address |    Netmask    |   Broadcast    |    MAC Address    |
++-----------------+------------+---------------+----------------+-------------------+
+|        lo       | 127.0.0.1  |   255.0.0.0   |      N/A       | 00:00:00:00:00:00 |
+|      enp0s3     | 10.0.2.15  | 255.255.255.0 |   10.0.2.255   | 08:00:27:bd:9c:3e |
+| br-3ede32bcf02b | 172.18.0.1 |  255.255.0.0  | 172.18.255.255 | 02:42:ca:27:eb:e0 |
+|     docker0     | 172.17.0.1 |  255.255.0.0  | 172.17.255.255 | 02:42:a6:17:95:87 |
++-----------------+------------+---------------+----------------+-------------------+
+
+Process Information:
++-----------------+--------------------------------------------------------------------------------+
+|       User      |                                 Process Names                                  |
++-----------------+--------------------------------------------------------------------------------+
+|      avahi      |                                  avahi-daemon                                  |
+| aws-replication |                                      java                                      |
+| aws-replication |                    run_linux_migration_scripts_periodically                    |
+| aws-replication |                                  tail, tailer                                  |
+| aws-replication |                             update_onprem_volumes                              |
+|      colord     |                                     colord                                     |
+|       gdm       |                                    (sd-pam)                                    |
+|       gdm       |                                    Xwayland                                    |
+|       gdm       |                     at-spi-bus-launcher, at-spi2-registryd                     |
+|       gdm       |                                  dbus-daemon                                   |
+|       gdm       |                              gdm-wayland-session                               |
+|       gdm       |                       gnome-session-binary, gnome-shell                        |
+|       gdm       |  gsd-a11y-settings, gsd-clipboard, gsd-color, gsd-datetime, gsd-housekeeping   |
+|       gdm       |  gsd-keyboard, gsd-media-keys, gsd-mouse, gsd-power, gsd-print-notifications   |
+|       gdm       |    gsd-rfkill, gsd-screensaver-proxy, gsd-sharing, gsd-smartcard, gsd-sound    |
+...
+|       root      |                                      ksmd                                      |
+|       root      |               ksoftirqd/0, ksoftirqd/1, ksoftirqd/2, ksoftirqd/3               |
+|       root      |                                     kstrp                                      |
+|       root      |                                    kswapd0                                     |
+|       root      |                               kthreadd, kthrotld                               |
+|       root      | kworker/0:0, kworker/0:0H, kworker/0:1, kworker/0:1H, kworker/0:2, kworker/0:3 |
+|       root      | kworker/1:0, kworker/1:0H, kworker/1:1, kworker/1:1H, kworker/1:2, kworker/1:3 |
+|       root      | kworker/2:0, kworker/2:0H, kworker/2:1, kworker/2:1H, kworker/2:2, kworker/3:0 |
+|       root      |       kworker/3:0H, kworker/3:1, kworker/3:1H, kworker/3:2, kworker/u8:0       |
+|       root      |             kworker/u8:1, kworker/u8:3, kworker/u8:4, kworker/u9:0             |
+|       root      |  loop0, loop1, loop10, loop11, loop12, loop13, loop14, loop15, loop16, loop17  |
+|       root      | loop18, loop19, loop2, loop20, loop21, loop22, loop23, loop24, loop25, loop26  |
+|       root      | loop27, loop28, loop29, loop3, loop30, loop31, loop32, loop33, loop34, loop35  |
+|       root      |    loop36, loop37, loop38, loop39, loop4, loop5, loop6, loop7, loop8, loop9    |
+|       root      |                                       md                                       |
+|       root      |               migration/0, migration/1, migration/2, migration/3               |
+|       root      |                                  mm_percpu_wq                                  |
+|       root      |                                     netns                                      |
+|       root      |                                networkd-dispat                                 |
+|       root      |                                   oom_reaper                                   |
+|       root      |                                  packagekitd                                   |
+|       root      |                                    polkitd                                     |
+|       root      |                       rcu_bh, rcu_sched, rcu_tasks_kthre                       |
+|       root      |      scsi_eh_0, scsi_eh_1, scsi_eh_2, scsi_tmf_0, scsi_tmf_1, scsi_tmf_2       |
+|       root      |                                     snapd                                      |
+|       root      |                                      sshd                                      |
+|       root      |                                      sudo                                      |
+|       root      |            systemd, systemd-journald, systemd-logind, systemd-udevd            |
+...
+|       son       |       evolution-calendar-factory, evolution-calendar-factory-subprocess        |
+|       son       |                           evolution-source-registry                            |
+|       son       |                                 gdm-x-session                                  |
+|       son       |            gnome-keyring-daemon, gnome-session-binary, gnome-shell             |
+|       son       |       gnome-shell-calendar-server, gnome-software, gnome-terminal-server       |
+|       son       |                        goa-daemon, goa-identity-service                        |
+...
+|       son       |                                    systemd                                     |
+|       son       |                        update-manager, update-notifier                         |
+|       son       |        xdg-desktop-portal, xdg-desktop-portal-gtk, xdg-document-portal         |
+|       son       |                              xdg-permission-store                              |
+|      syslog     |                                    rsyslogd                                    |
+| systemd-resolve |                                systemd-resolved                                |
+|     whoopsie    |                                    whoopsie                                    |
++-----------------+--------------------------------------------------------------------------------+
+```

--- a/scripts/system-info/system_info.py
+++ b/scripts/system-info/system_info.py
@@ -1,0 +1,274 @@
+import platform
+import socket
+import psutil
+import subprocess
+from prettytable import PrettyTable
+from datetime import datetime
+from collections import defaultdict
+import os
+import netifaces
+import yaml  # Required for YAML file operations
+
+# Optional packages for GPU and Graphic Card information
+try:
+    import GPUtil
+    GPU_AVAILABLE = True
+except ImportError:
+    GPU_AVAILABLE = False
+
+def bytes_to_gb(bytes_value):
+    """Convert bytes to gigabytes."""
+    return round(bytes_value / (1024 ** 3), 2)
+
+def get_os_info():
+    """Fetch Operating System information."""
+    boot_time = datetime.fromtimestamp(psutil.boot_time()).strftime("%Y-%m-%d %H:%M:%S")
+    logged_user = os.getlogin()
+    uname_info = platform.uname()
+    return "OS", [
+        ("Name", platform.system()),
+        ("Version", platform.version()),
+        ("Architecture", platform.architecture()),
+        ("Platform", platform.platform()),
+        ("Boot Time", boot_time),
+        ("Logged User", logged_user),
+        ("Kernel Version", uname_info.release),
+        ("Distribution", ' '.join(platform.linux_distribution()))
+    ]
+
+def get_cpu_info():
+    """Fetch CPU information."""
+    cpu_info = psutil.cpu_freq()
+    cpu_stats = psutil.cpu_stats()
+    cpu_times_percent = psutil.cpu_times_percent()
+    return "CPU", [
+        ("Brand", platform.processor()),
+        ("Core Count (Logical)", psutil.cpu_count(logical=True)),
+        ("Core Count (Physical)", psutil.cpu_count(logical=False)),
+        ("Current Frequency", f"{cpu_info.current} MHz"),
+        ("Context Switches", cpu_stats.ctx_switches),
+        ("Interrupts", cpu_stats.interrupts),
+        ("Architecture", platform.machine()),
+        ("User Time (%)", cpu_times_percent.user),
+        ("System Time (%)", cpu_times_percent.system),
+        ("Idle Time (%)", cpu_times_percent.idle)
+    ]
+
+def get_memory_info():
+    """Fetch Memory information."""
+    virtual_memory = psutil.virtual_memory()
+    swap_memory = psutil.swap_memory()
+    return "Memory", [
+        ("Total (GB)", bytes_to_gb(virtual_memory.total)),
+        ("Available (GB)", bytes_to_gb(virtual_memory.available)),
+        ("Used (GB)", bytes_to_gb(virtual_memory.used)),
+        ("Cached (GB)", bytes_to_gb(virtual_memory.cached)),
+        ("Swap Total (GB)", bytes_to_gb(swap_memory.total)),
+        ("Swap Free (GB)", bytes_to_gb(swap_memory.free)),
+        ("Swap Used (GB)", bytes_to_gb(swap_memory.used))
+    ]
+
+def get_disk_info():
+    """Fetch Disk information."""
+    disk_info = psutil.disk_usage('/')
+    disk_io = psutil.disk_io_counters()
+    partitions = psutil.disk_partitions()
+    partition_info = ', '.join([p.device for p in partitions])
+    return "Disk", [
+        ("Total (GB)", bytes_to_gb(disk_info.total)),
+        ("Free (GB)", bytes_to_gb(disk_info.free)),
+        ("Used (GB)", bytes_to_gb(disk_info.used)),
+        ("Read Count", disk_io.read_count),
+        ("Write Count", disk_io.write_count)
+        #("Partitions", partition_info),
+        #("File System Types", ', '.join([p.fstype for p in partitions]))
+    ]
+
+def get_network_info():
+    """Fetch Network information."""
+    net_info = psutil.net_if_addrs()
+    net_stats = psutil.net_if_stats()
+    active_interfaces = [k for k, v in net_stats.items() if v.isup]
+    mac_address = 'Unknown'
+    for interface, addrs in net_info.items():
+        for addr in addrs:
+            if addr.family == psutil.AF_LINK:
+                mac_address = addr.address
+                break
+    return "Network", [
+        ("Hostname", socket.gethostname()),
+        ("IP Address", socket.gethostbyname(socket.gethostname())),
+        ("MAC Address", mac_address),
+        ("Active Interfaces", ', '.join(active_interfaces)),
+        ("Gateway", socket.gethostbyname(socket.gethostname())),
+        ("DNS", socket.gethostbyname(socket.getfqdn()))
+    ]
+
+# IP and MAC addresses using netifaces
+def get_advanced_network_info():
+    """Fetch advanced network information using netifaces."""
+    # Add a function using netifaces
+    interfaces = netifaces.interfaces()
+    iface_info = []
+    for iface in interfaces:
+        addresses = netifaces.ifaddresses(iface)
+        if netifaces.AF_INET in addresses:
+            ip_info = addresses[netifaces.AF_INET][0]
+            ip = ip_info.get('addr', 'N/A')
+            netmask = ip_info.get('netmask', 'N/A')
+            broadcast = ip_info.get('broadcast', 'N/A')
+            if netifaces.AF_LINK in addresses:
+                mac_info = addresses[netifaces.AF_LINK][0]
+                mac = mac_info.get('addr', 'N/A')
+                iface_info.append((iface, ip, netmask, broadcast, mac))
+            else:
+                iface_info.append((iface, ip, netmask, broadcast, 'N/A'))
+    return "Advanced Network", iface_info
+
+def get_gpu_info():
+    """Fetch GPU information if available."""
+    info_list = []
+    if GPU_AVAILABLE:
+        gpus = GPUtil.getGPUs()
+        for gpu in gpus:
+            info_list.append((f"{gpu.name}", f"Driver Version: {gpu.driver_version}"))
+    else:
+        info_list.append(("Status", "Not Available"))
+    return "GPU", info_list
+
+def get_graphic_card_info():
+    try:
+        lspci_output = subprocess.check_output("lspci | grep VGA", shell=True, text=True)
+        info_list = [("VGA Compatible Controller", line.split(":")[-1].strip()) for line in lspci_output.split("\n") if line]
+    except Exception:
+        info_list = [("Status", "Not Available")]
+
+    return "Graphic Card", info_list
+
+# New function to get IP and MAC addresses using netifaces
+def get_advanced_network_info():
+    """Fetch advanced network information using netifaces."""
+    # Add a function using netifaces
+    interfaces = netifaces.interfaces()
+    iface_info = []
+    for iface in interfaces:
+        addresses = netifaces.ifaddresses(iface)
+        if netifaces.AF_INET in addresses:
+            ip_info = addresses[netifaces.AF_INET][0]
+            ip = ip_info.get('addr', 'N/A')
+            netmask = ip_info.get('netmask', 'N/A')
+            broadcast = ip_info.get('broadcast', 'N/A')
+            if netifaces.AF_LINK in addresses:
+                mac_info = addresses[netifaces.AF_LINK][0]
+                mac = mac_info.get('addr', 'N/A')
+                iface_info.append((iface, ip, netmask, broadcast, mac))
+            else:
+                iface_info.append((iface, ip, netmask, broadcast, 'N/A'))
+    return "Advanced Network", iface_info
+
+def get_process_info():
+    """Fetch Process information."""
+    process_dict = defaultdict(list)
+
+    for proc in psutil.process_iter(['name', 'username']):
+        process_dict[proc.info['username']].append(proc.info['name'])
+
+    # Sorting and grouping by username
+    sorted_process = defaultdict(list)
+    for username, names in sorted(process_dict.items()):
+        sorted_names = sorted(set(names))
+        sorted_process[username].extend(sorted_names)
+
+    # Group by prefix and limit to 80 characters per line
+    grouped_process = defaultdict(list)
+    for username, processes in sorted_process.items():
+        temp = defaultdict(list)
+        for proc in processes:
+            prefix = proc[:4]
+            temp[prefix].append(proc)
+
+        for prefix, names in temp.items():
+            line = ""
+            for name in names:
+                if len(line + name + ', ') > 80:
+                    grouped_process[username].append(line[:-2])
+                    line = ""
+                line += name + ', '
+            
+            if line:
+                grouped_process[username].append(line[:-2])
+
+    # Convert to list of tuples
+    process_list = []
+    for username, processes in grouped_process.items():
+        for proc in processes:
+            process_list.append((username, proc))
+
+    return "Process", sorted(process_list)
+
+# New function to save system information to a YAML file
+def save_to_yaml(data):
+    """Save dictionary data to YAML file."""
+    with open('system_info.yaml', 'w') as file:
+        yaml.dump(data, file, default_flow_style=False)
+
+def main():
+    """Main function to collect and print all system information and save it to YAML."""
+    system_table = PrettyTable()
+    system_table.field_names = ["Index", "Group", "Category", "Info"]
+
+    index = 1
+    system_info = {}  # Dictionary to store all system info
+
+    info_functions = [
+        get_os_info,
+        get_cpu_info,
+        get_memory_info,
+        get_disk_info,
+        get_network_info,
+        get_gpu_info,
+        get_graphic_card_info
+    ]
+
+    for func in info_functions:
+        group, info_func = func()
+        system_info[group] = {category: info for category, info in info_func}
+        for category, info in info_func:
+            system_table.add_row([index, group, category, info])
+            index += 1
+
+    print("System Information:")
+    print(system_table)
+
+    # Fetch advanced network information using netifaces
+    advanced_network_table = PrettyTable()
+    advanced_network_table.field_names = ["Interface", "IP Address", "Netmask", "Broadcast", "MAC Address"]
+    
+    _, advanced_network_info = get_advanced_network_info()
+    advanced_network_data = []
+    for row in advanced_network_info:
+        advanced_network_table.add_row(row)
+        advanced_network_data.append({"Interface": row[0], "IP Address": row[1], "Netmask": row[2], "Broadcast": row[3], "MAC Address": row[4]})
+    
+    print("\nAdvanced Network Information:")
+    print(advanced_network_table)
+    system_info["Advanced Network"] = advanced_network_data  # Add to system info dictionary
+
+    # Fetch process information
+    process_table = PrettyTable()
+    process_table.field_names = ["User", "Process Names"]
+
+    _, process_info = get_process_info()
+    process_data = []
+    for username, grouped_name in process_info:
+        process_table.add_row([username, grouped_name])
+        process_data.append({username: grouped_name})
+
+    print("\nProcess Information:")
+    print(process_table)
+    system_info["Process"] = process_data  # Add to system info dictionary
+
+    save_to_yaml(system_info)  # Save all gathered info to a YAML file
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR provides a System Information Extractor in a Python script.


# System Information Extractor

This script, written in Python, collects various hardware and software information from the host system.
It can be useful for extracting and referencing the configuration of the source computing environment in cloud migration projects.
This script helps to quickly understand the current state of the system and diagnose issues.
It is useful for checking and referencing the configuration of the source computing environment for the cloud migrator project.


## Dependencies

- `psutil`
- `prettytable`
- `netifaces`
- `pyyaml`
- `GPUtil`

## Execution

```bash
python3 system_info.py
```

## Features

### 1. OS Information Collection
Collects OS name, version, architecture, platform, boot time, currently logged-in user, kernel version, and distribution information.

```python
def get_os_info():
    """Fetch Operating System information."""
    ...
    return "OS", [
        ("Name", platform.system()),
        ...
    ]
```

### 2. CPU Information Collection
Collects CPU brand, core count, current frequency, context switches, interrupts, architecture, user time, system time, and idle time.

```python
def get_cpu_info():
    """Fetch CPU information."""
    ...
    return "CPU", [
        ("Brand", platform.processor()),
        ...
    ]
```

### 3. Memory Information Collection
Collects total memory, available memory, used memory, cached memory, and swap memory information.

```python
def get_memory_info():
    """Fetch Memory information."""
    ...
    return "Memory", [
        ("Total (GB)", bytes_to_gb(virtual_memory.total)),
        ...
    ]
```

### 4. Disk Information Collection
Collects total disk capacity, available capacity, used capacity, read and write count.

```python
def get_disk_info():
    """Fetch Disk information."""
    ...
    return "Disk", [
        ("Total (GB)", bytes_to_gb(disk_info.total)),
        ...
    ]
```

### 5. Network Information Collection
Collects host name, IP address, MAC address, active network interfaces, gateway, and DNS information.

```python
def get_network_info():
    """Fetch Network information."""
    ...
    return "Network", [
        ("Hostname", socket.gethostname()),
        ...
    ]
```

### 6. Advanced Network Information Collection
Collects IP address, netmask, broadcast, and MAC address of each network interface.

```python
def get_advanced_network_info():
    """Fetch advanced network information using netifaces."""
    ...
    return "Advanced Network", iface_info
```

### 7. GPU Information Collection
Collects GPU name and driver version (if GPUtil is installed).

```python
def get_gpu_info():
    """Fetch GPU information if available."""
    ...
    return "GPU", info_list
```

### 8. Graphic Card Information Collection
Collects VGA compatible controller information.

```python
def get_graphic_card_info():
    ...
    return "Graphic Card", info_list
```

### 9. Process Information Collection
Collects information on all running processes and users on the system.

```python
def get_process_info():
    """Fetch Process information."""
    ...
    return "Process", sorted(process_list)
```

### 10. Data Saving
Saves all collected system information to a YAML file.

```python
def save_to_yaml(data):
    """Save dictionary data to YAML file."""
    ...
```

## Output
The collected information is printed to the console in a neat table format, and is also saved to a `system_info.yaml` file.

Example
```
System Information:
+-------+--------------+-----------------------+----------------------------------------------------------+
| Index |    Group     |        Category       |                           Info                           |
+-------+--------------+-----------------------+----------------------------------------------------------+
|   1   |      OS      |          Name         |                          Linux                           |
|   2   |      OS      |        Version        |       #224-Ubuntu SMP Mon Jun 19 13:30:12 UTC 2023       |
|   3   |      OS      |      Architecture     |                     ('64bit', 'ELF')                     |
|   4   |      OS      |        Platform       | Linux-4.15.0-213-generic-x86_64-with-Ubuntu-18.04-bionic |
|   5   |      OS      |       Boot Time       |                   2023-09-18 11:11:51                    |
|   6   |      OS      |      Logged User      |                           son                            |
|   7   |      OS      |     Kernel Version    |                    4.15.0-213-generic                    |
|   8   |      OS      |      Distribution     |                   Ubuntu 18.04 bionic                    |
|   9   |     CPU      |         Brand         |                          x86_64                          |
|   10  |     CPU      |  Core Count (Logical) |                            4                             |
|   11  |     CPU      | Core Count (Physical) |                            4                             |
|   12  |     CPU      |   Current Frequency   |                        3600.0 MHz                        |
|   13  |     CPU      |    Context Switches   |                        3132898179                        |
|   14  |     CPU      |       Interrupts      |                        1738814431                        |
|   15  |     CPU      |      Architecture     |                          x86_64                          |
|   16  |     CPU      |     User Time (%)     |                           17.0                           |
|   17  |     CPU      |    System Time (%)    |                           0.0                            |
|   18  |     CPU      |     Idle Time (%)     |                           21.0                           |
|   19  |    Memory    |       Total (GB)      |                           7.79                           |
|   20  |    Memory    |     Available (GB)    |                           2.22                           |
|   21  |    Memory    |       Used (GB)       |                           4.85                           |
|   22  |    Memory    |      Cached (GB)      |                           1.95                           |
|   23  |    Memory    |    Swap Total (GB)    |                           2.0                            |
|   24  |    Memory    |     Swap Free (GB)    |                           0.86                           |
|   25  |    Memory    |     Swap Used (GB)    |                           1.14                           |
|   26  |     Disk     |       Total (GB)      |                          97.87                           |
|   27  |     Disk     |       Free (GB)       |                           3.95                           |
|   28  |     Disk     |       Used (GB)       |                          88.91                           |
|   29  |     Disk     |       Read Count      |                         5742877                          |
|   30  |     Disk     |      Write Count      |                         23171054                         |
|   31  |   Network    |        Hostname       |                           son                            |
|   32  |   Network    |       IP Address      |                        127.0.1.1                         |
|   33  |   Network    |      MAC Address      |                    aa:83:85:16:60:d5                     |
|   34  |   Network    |   Active Interfaces   |             lo, docker0, enp0s3, veth6c9eb12             |
|   35  |   Network    |        Gateway        |                        127.0.1.1                         |
|   36  |   Network    |          DNS          |                        127.0.1.1                         |
|   37  | Graphic Card |         Status        |                      Not Available                       |
+-------+--------------+-----------------------+----------------------------------------------------------+

Advanced Network Information:
+-----------------+------------+---------------+----------------+-------------------+
|    Interface    | IP Address |    Netmask    |   Broadcast    |    MAC Address    |
+-----------------+------------+---------------+----------------+-------------------+
|        lo       | 127.0.0.1  |   255.0.0.0   |      N/A       | 00:00:00:00:00:00 |
|      enp0s3     | 10.0.2.15  | 255.255.255.0 |   10.0.2.255   | 08:00:27:bd:9c:3e |
| br-3ede32bcf02b | 172.18.0.1 |  255.255.0.0  | 172.18.255.255 | 02:42:ca:27:eb:e0 |
|     docker0     | 172.17.0.1 |  255.255.0.0  | 172.17.255.255 | 02:42:a6:17:95:87 |
+-----------------+------------+---------------+----------------+-------------------+

Process Information:
+-----------------+--------------------------------------------------------------------------------+
|       User      |                                 Process Names                                  |
+-----------------+--------------------------------------------------------------------------------+
|      avahi      |                                  avahi-daemon                                  |
| aws-replication |                                      java                                      |
| aws-replication |                    run_linux_migration_scripts_periodically                    |
| aws-replication |                                  tail, tailer                                  |
| aws-replication |                             update_onprem_volumes                              |
|      colord     |                                     colord                                     |
|       gdm       |                                    (sd-pam)                                    |
|       gdm       |                                    Xwayland                                    |
|       gdm       |                     at-spi-bus-launcher, at-spi2-registryd                     |
|       gdm       |                                  dbus-daemon                                   |
|       gdm       |                              gdm-wayland-session                               |
|       gdm       |                       gnome-session-binary, gnome-shell                        |
|       gdm       |  gsd-a11y-settings, gsd-clipboard, gsd-color, gsd-datetime, gsd-housekeeping   |
|       gdm       |  gsd-keyboard, gsd-media-keys, gsd-mouse, gsd-power, gsd-print-notifications   |
|       gdm       |    gsd-rfkill, gsd-screensaver-proxy, gsd-sharing, gsd-smartcard, gsd-sound    |
...
|       root      |                                      ksmd                                      |
|       root      |               ksoftirqd/0, ksoftirqd/1, ksoftirqd/2, ksoftirqd/3               |
|       root      |                                     kstrp                                      |
|       root      |                                    kswapd0                                     |
|       root      |                               kthreadd, kthrotld                               |
|       root      | kworker/0:0, kworker/0:0H, kworker/0:1, kworker/0:1H, kworker/0:2, kworker/0:3 |
|       root      | kworker/1:0, kworker/1:0H, kworker/1:1, kworker/1:1H, kworker/1:2, kworker/1:3 |
|       root      | kworker/2:0, kworker/2:0H, kworker/2:1, kworker/2:1H, kworker/2:2, kworker/3:0 |
|       root      |       kworker/3:0H, kworker/3:1, kworker/3:1H, kworker/3:2, kworker/u8:0       |
|       root      |             kworker/u8:1, kworker/u8:3, kworker/u8:4, kworker/u9:0             |
|       root      |  loop0, loop1, loop10, loop11, loop12, loop13, loop14, loop15, loop16, loop17  |
|       root      | loop18, loop19, loop2, loop20, loop21, loop22, loop23, loop24, loop25, loop26  |
|       root      | loop27, loop28, loop29, loop3, loop30, loop31, loop32, loop33, loop34, loop35  |
|       root      |    loop36, loop37, loop38, loop39, loop4, loop5, loop6, loop7, loop8, loop9    |
|       root      |                                       md                                       |
|       root      |               migration/0, migration/1, migration/2, migration/3               |
|       root      |                                  mm_percpu_wq                                  |
|       root      |                                     netns                                      |
|       root      |                                networkd-dispat                                 |
|       root      |                                   oom_reaper                                   |
|       root      |                                  packagekitd                                   |
|       root      |                                    polkitd                                     |
|       root      |                       rcu_bh, rcu_sched, rcu_tasks_kthre                       |
|       root      |      scsi_eh_0, scsi_eh_1, scsi_eh_2, scsi_tmf_0, scsi_tmf_1, scsi_tmf_2       |
|       root      |                                     snapd                                      |
|       root      |                                      sshd                                      |
|       root      |                                      sudo                                      |
|       root      |            systemd, systemd-journald, systemd-logind, systemd-udevd            |
...
|       son       |       evolution-calendar-factory, evolution-calendar-factory-subprocess        |
|       son       |                           evolution-source-registry                            |
|       son       |                                 gdm-x-session                                  |
|       son       |            gnome-keyring-daemon, gnome-session-binary, gnome-shell             |
|       son       |       gnome-shell-calendar-server, gnome-software, gnome-terminal-server       |
|       son       |                        goa-daemon, goa-identity-service                        |
...
|       son       |                                    systemd                                     |
|       son       |                        update-manager, update-notifier                         |
|       son       |        xdg-desktop-portal, xdg-desktop-portal-gtk, xdg-document-portal         |
|       son       |                              xdg-permission-store                              |
|      syslog     |                                    rsyslogd                                    |
| systemd-resolve |                                systemd-resolved                                |
|     whoopsie    |                                    whoopsie                                    |
+-----------------+--------------------------------------------------------------------------------+
```