### PR TITLE
Add how to install swag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ cd ${HOME}/cm-beetle/pkg
 make swag
 ```
 
+If you got an error because of missing `swag`, install `swag`:
+```bash
+go install github.com/swaggo/swag/cmd/swag@latest
+```
+
 #### Run CM-Beetle binary
 
 ```bash


### PR DESCRIPTION
swag 실행 파일이 없는 경우 에러가 발생하기 때문에 간단한 설치 방법을 추가합니다.
혹시 특정 버전을 명시해야 하는 경우 알려주시면 반영하도록 하겠습니다.