### PR TITLE
Enhance the function to find an ideal VM OS image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloud-barista/cm-beetle
 go 1.21.6
 
 require (
-	github.com/cloud-barista/cb-store v0.8.0
+	github.com/cloud-barista/cb-store v0.8.2
 	github.com/cloud-barista/cb-tumblebug v0.8.12
 	github.com/cloud-barista/cm-honeybee/agent v0.0.0-20240530070023-ee1c0a77fbf7
 	github.com/docker/docker v26.1.3+incompatible
@@ -26,7 +26,7 @@ require (
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/bwmarrin/snowflake v0.3.0 // indirect
-	github.com/cloud-barista/cb-log v0.8.0 // indirect
+	github.com/cloud-barista/cb-log v0.8.2 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,12 @@ github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86c
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cloud-barista/cb-log v0.8.0 h1:ArWCs1EgpoD3ZnBgcC4cAw5ufI/JHmFKfJswlv4whgk=
 github.com/cloud-barista/cb-log v0.8.0/go.mod h1:nGgfTFMPwl1MpCO3FBjexUkNdOYA0BNJoyM9Pd0lMms=
+github.com/cloud-barista/cb-log v0.8.2 h1:hPCbLj6TW6m9UWlq002sDuGgxKFVp68w4V3k493+MxY=
+github.com/cloud-barista/cb-log v0.8.2/go.mod h1:nGgfTFMPwl1MpCO3FBjexUkNdOYA0BNJoyM9Pd0lMms=
 github.com/cloud-barista/cb-store v0.8.0 h1:0K47YEf+K3wx18D+m0XirlDbdTz229XxsTXw6WACjRA=
 github.com/cloud-barista/cb-store v0.8.0/go.mod h1:6NuA5TdeVRExd59ULXv6LEhm4EE0ODn9L820g4VqApo=
+github.com/cloud-barista/cb-store v0.8.2 h1:7excW7SX0Xw9Xxo0xO4HkndjOYonh4z6mFzNqYN3XH4=
+github.com/cloud-barista/cb-store v0.8.2/go.mod h1:GBTRuOApzMWSENFSgIPtrbWUKSwP30bn90gWE0ENUD8=
 github.com/cloud-barista/cb-tumblebug v0.8.12 h1:uc5aOI9q5XhMq7GQ9s7WyWyLoxtklcqib/gdDaSgumw=
 github.com/cloud-barista/cb-tumblebug v0.8.12/go.mod h1:yOwgw7jXqMdSSgC2g0TvgCG1WyXNw6Q7J6JGfbsqEOw=
 github.com/cloud-barista/cm-honeybee/agent v0.0.0-20240530070023-ee1c0a77fbf7 h1:4r7YI8FlWfk2H/H+fICupvzEjCP+4cCkqG5CMzvhDdo=

--- a/pkg/example/levenshtein-distance/main.go
+++ b/pkg/example/levenshtein-distance/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cloud-barista/cm-beetle/pkg/core/recommendation"
+)
+
+func main() {
+
+	compareWordSet := []struct {
+		str1 string
+		str2 string
+	}{
+		{"22.04", "22.04.1"},
+		{"22.04", "20.04"},
+		{"20.04", "18.04"},
+		{"x86_64", "amd64"},
+		{"hvm-ssd", "ssd"},
+		{"hvm-ssd", "hdd"},
+	}
+
+	for _, set := range compareWordSet {
+		fmt.Printf("Comparing '%s' with '%s':\n", set.str1, set.str2)
+		fmt.Printf(" - LevenshteinDistance, Similarity ratio: %.2f\n", recommendation.CalculateSimilarityByLevenshteinDistance(set.str1, set.str2))
+		fmt.Printf(" - SequenceMatcher, Similarity ratio: %.2f\n", recommendation.CalculateSimilarityBySequenceMatcher(set.str1, set.str2))
+		fmt.Println("--------------------------------------------------------")
+	}
+
+	keywords := "Ubuntu 22.04.4 LTS (Jammy Jellyfish) x86_64 SSD"
+	vmImages := []string{
+		"ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220609",
+		"ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20191002",
+	}
+
+	// Select VM OS image via LevenshteinDistance-based text similarity
+	delimiters1 := []string{" ", "-", "_", ",", "(", ")", "[", "]", "/"}
+	delimiters2 := delimiters1
+
+	for _, image := range vmImages {
+		fmt.Printf("Comparing keywords with VM Image:\n")
+		fmt.Printf("Keywords: '%s'\n", keywords)
+		fmt.Printf("VM Image: '%s'\n", image)
+		score := recommendation.CalculateSimilarity(keywords, delimiters1, image, delimiters2)
+		fmt.Printf(" - Similarity Score: %.2f\n", score)
+		fmt.Println("--------------------------------------------------------")
+	}
+}


### PR DESCRIPTION
* Add SequenceMatcher calculating text similarity
* Add an example to compare LevenshteinDistance and SequenceMatcher

This PR will help recommend a more ideal VM OS image.
: When a user inputs "Ubuntu 22.04.4 LTS (Jammy Jellyfish) x86_64 SSD" and requests a recommendation for a VM OS image, : among many images, "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20191002" can be recommended as an ideal image.

### The details

It has been discovered that in some cases, **LevenshteinDistance is not properly recommending VM OS images**.

For example, when comparing '22.04' with '22.04.4', '20.04', and '18.04', '22.04.4' should be the most similar one.
But, the results were as follows.
* Comparing '22.04' with '22.04.1': The similarity ratio is 0.71
* Comparing '22.04' with '20.04': The similarity ratio is **0.80**
* Comparing '20.04' with '18.04': The similarity ratio is 0.60

SequenceMatcher can resolve this issue as follows.
* Comparing '22.04' with '22.04.1': The similarity ratio is **0.83**
* Comparing '22.04' with '20.04': The similarity ratio is 0.60
* Comparing '20.04' with '18.04': The similarity ratio is 0.60

Lastly, to exclude unnecessary similarity ratio values ​​of short substrings, LeRU with a threshold of 0.5 was applied.
* This has a value of 0 in the following cases:
  - '22.04.4', '18.04' (similarity: 0.50)
  - 'lts', 'ssd' (similarity: 0.33)
  - 'jellyfish', 'hvm' (similarity: 0.17)
  - 'x86', 'amd64' (similarity: 0.25)
  - 'jellyfish', 'hvm' (similarity: 0.17)

(Extra examples)
* comparing 'x86_64' with 'amd64': LevenshteinDistance (0.33), SequenceMatcher (0.36)
* comparing 'hvm-ssd' with 'ssd': LevenshteinDistance (0.43), SequenceMatcher (0.60)
* comparing 'hvm-ssd' with 'hdd': LevenshteinDistance (0.29), SequenceMatcher (0.20)
