### PR TITLE
Staging for v0.2.0 release

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -71,7 +71,7 @@ jobs:
             # type=semver,pattern={{major}}.{{minor}}
             ## Tags for a push branch event
             # Tags to reflect the last commit of the active branch
-            type=edge,enable=true,branch=main
+            type=edge,enable=true
             ## Other types (currently the followings may be out of scope in this project)
             ## Tags for a push branch event
             # minimal (short sha)

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -40,7 +40,7 @@ jobs:
           go-version: ${{matrix.go-version}}
 
       - name: Build
-        run: make # cd cmd/cm-beetle && go build -v -o cm-beetle
+        run: make
 
       # - name: Test
       #   run: go test -v ./...
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Build
+      - name: Build image
         env:
           IMAGE_NAME: ${{ github.event.repository.name }}
         run: docker build . --file Dockerfile --tag $IMAGE_NAME

--- a/pkg/api/rest/model/README.md
+++ b/pkg/api/rest/model/README.md
@@ -1,18 +1,23 @@
 ## Model synchronization for on-premise
 
 ### Synchronization Date
-- Date: Mon May 27 19:28:28 KST 2024
+
+- Date: Thu Jul 4 14:42:07 KST 2024
 
 ### Repository Details
+
 - Repository: [cloud-barista/cm-honeybee](https://github.com/cloud-barista/cm-honeybee.git)
 - Branch: main
-- Latest Commit Hash: f22d87db289592463240bd886bcbf71c2bd41bd7
+- Latest Commit Hash: d7c645ce260621fd5f9bef31a82b08ef2f0e1fa7
 
 ### Usage Instructions
+
 - Update the models with the command below:
+
   ```
-  
+
   make onprem-model
   ```
+
 - This command synchronizes the models to the latest versions.
 - Do not edit these files directly as they are managed automatically.


### PR DESCRIPTION
* Update CI and CD workflows
* Synchronize on-premise model (currently the metric of source computing infra analysis), but no models have changed.
* Test with CM-Honeybee, CB-Spider, and CB-Tumblebug
* Update the execution guide separately  (see https://github.com/cloud-barista/cm-beetle/discussions/73)