### PR TITLE
Makefile: Fix golangci-lint compatibility issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dependency: ## Get dependencies
 lint: dependency ## Lint the files
 	@echo "Running linter..."
 	@if [ ! -f "$(GOPATH)/bin/golangci-lint" ] && [ ! -f "$(shell go env GOROOT)/bin/golangci-lint" ]; then \
-		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1; \
 	fi
 	@golangci-lint run -E contextcheck -D unused
 	@echo "Linter finished!"


### PR DESCRIPTION
## Makefile: Fix golangci-lint compatibility issue
- `make lint` command will fail in the new environment.
- New golangci-lint requires golang v1.23. So, use an older version, which is compatible with v1.21.