### PR TITLE
Specify `golangci-lint` version supporting Go 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dependency: ## Get dependencies
 lint: dependency ## Lint the files
 	@echo "Running linter..."
 	@if [ ! -f "$(GOPATH)/bin/golangci-lint" ] && [ ! -f "$(shell go env GOROOT)/bin/golangci-lint" ]; then \
-		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2; \
 	fi
 	@golangci-lint run -E contextcheck -D unused
 	@echo "Linter finished!"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dependency: ## Get dependencies
 lint: dependency ## Lint the files
 	@echo "Running linter..."
 	@if [ ! -f "$(GOPATH)/bin/golangci-lint" ] && [ ! -f "$(shell go env GOROOT)/bin/golangci-lint" ]; then \
-		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1; \
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
 	fi
 	@golangci-lint run -E contextcheck -D unused
 	@echo "Linter finished!"


### PR DESCRIPTION
Reverts cloud-barista/cm-beetle#110

We can now revert this change to use the new linter after https://github.com/cloud-barista/cm-beetle/commit/03d77e7545b94dc4e9b85cb302d7bba9ca20d2b5.