### PR TITLE
Infrastructure Migration API bug fix(issue #120)

### DIFF
--- a/pkg/core/migration/migration.go
+++ b/pkg/core/migration/migration.go
@@ -99,11 +99,20 @@ const DefaultSystemLabel string = "Managed by CM-Beetle"
 func CreateVMInfra(nsId string, infraModel *mci.TbMciDynamicReq) (mci.TbMciInfo, error) {
 
 	client := resty.New()
-	client.SetBasicAuth("default", "default")
+	// client.SetBasicAuth("default", "default")
+	// apiUser := viper.GetString("beetle.api.username")
+	// apiPass := viper.GetString("beetle.api.password")
+	// apiUser := viper.GetString("beetle.tumblebug.api.username")
+	// apiPass := viper.GetString("beetle.tumblebug.api.password")
+	apiUser := os.Getenv("BEETLE_API_USERNAME")
+	apiPass := os.Getenv("BEETLE_API_PASSWORD")
+	client.SetBasicAuth(apiUser, apiPass)
+
 	method := "POST"
 
 	// CB-Tumblebug API endpoint
-	cbTumblebugApiEndpoint := "http://localhost:1323/tumblebug"
+	//cbTumblebugApiEndpoint := "http://localhost:1323/tumblebug"
+	cbTumblebugApiEndpoint := common.TumblebugRestUrl
 	url := cbTumblebugApiEndpoint + fmt.Sprintf("/ns/%s/mciDynamic", nsId)
 	// url := fmt.Sprintf("%s/ns/{nsId}/mciDynamic%s", cbTumblebugApiEndpoint, idDetails.IdInSp)
 

--- a/pkg/core/migration/migration.go
+++ b/pkg/core/migration/migration.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloud-barista/cm-beetle/pkg/core/common"
 	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 //"log"

--- a/pkg/core/migration/migration.go
+++ b/pkg/core/migration/migration.go
@@ -99,13 +99,8 @@ const DefaultSystemLabel string = "Managed by CM-Beetle"
 func CreateVMInfra(nsId string, infraModel *mci.TbMciDynamicReq) (mci.TbMciInfo, error) {
 
 	client := resty.New()
-	// client.SetBasicAuth("default", "default")
-	// apiUser := viper.GetString("beetle.api.username")
-	// apiPass := viper.GetString("beetle.api.password")
-	// apiUser := viper.GetString("beetle.tumblebug.api.username")
-	// apiPass := viper.GetString("beetle.tumblebug.api.password")
-	apiUser := os.Getenv("BEETLE_API_USERNAME")
-	apiPass := os.Getenv("BEETLE_API_PASSWORD")
+	apiUser := viper.GetString("beetle.tumblebug.api.username")
+	apiPass := viper.GetString("beetle.tumblebug.api.password")
 	client.SetBasicAuth(apiUser, apiPass)
 
 	method := "POST"


### PR DESCRIPTION
Modified tumblebug's api endpoint to get it from a common variable.

The API authentication method is taken from an environment variable, but may need to be modified later.
apiUser := os.Getenv(“BEETLE_API_USERNAME”)
apiPass := os.Getenv(“BEETLE_API_PASSWORD”)