### PR TITLE
Bugfix and update API handling

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -11,8 +11,7 @@ const docTemplate = `{
         "title": "{{.Title}}",
         "contact": {
             "name": "API Support",
-            "url": "http://cloud-barista.github.io",
-            "email": "contact-to-cloud-barista@googlegroups.com"
+            "url": "https://github.com/cloud-barista/cm-beetle/issues/new/choose"
         },
         "license": {
             "name": "Apache 2.0",
@@ -36,6 +35,7 @@ const docTemplate = `{
                     "[Admin] System management"
                 ],
                 "summary": "Check HTTP version of incoming request",
+                "operationId": "CheckHTTPVersion",
                 "parameters": [
                     {
                         "type": "string",
@@ -258,6 +258,7 @@ const docTemplate = `{
                     "[Admin] System management"
                 ],
                 "summary": "Check Beetle is ready",
+                "operationId": "GetReadyz",
                 "parameters": [
                     {
                         "type": "string",
@@ -635,6 +636,7 @@ const docTemplate = `{
                     "[Test] Utility"
                 ],
                 "summary": "Test tracing to Tumblebug",
+                "operationId": "TestTracing",
                 "parameters": [
                     {
                         "type": "string",
@@ -1234,7 +1236,7 @@ const docTemplate = `{
         }
     },
     "externalDocs": {
-        "description": "▶▶▶ CB-Tumblebug REST API",
+        "description": "▶▶▶ CB-Tumblebug REST API (access via Beetle's reverse proxy)",
         "url": "http://localhost:8056/tumblebug/api/index.html"
     }
 }`
@@ -1242,7 +1244,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "latest",
-	Host:             "",
+	Host:             "localhost:8056",
 	BasePath:         "/beetle",
 	Schemes:          []string{},
 	Title:            "CM-Beetle REST API",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -5,8 +5,7 @@
         "title": "CM-Beetle REST API",
         "contact": {
             "name": "API Support",
-            "url": "http://cloud-barista.github.io",
-            "email": "contact-to-cloud-barista@googlegroups.com"
+            "url": "https://github.com/cloud-barista/cm-beetle/issues/new/choose"
         },
         "license": {
             "name": "Apache 2.0",
@@ -14,6 +13,7 @@
         },
         "version": "latest"
     },
+    "host": "localhost:8056",
     "basePath": "/beetle",
     "paths": {
         "/httpVersion": {
@@ -29,6 +29,7 @@
                     "[Admin] System management"
                 ],
                 "summary": "Check HTTP version of incoming request",
+                "operationId": "CheckHTTPVersion",
                 "parameters": [
                     {
                         "type": "string",
@@ -251,6 +252,7 @@
                     "[Admin] System management"
                 ],
                 "summary": "Check Beetle is ready",
+                "operationId": "GetReadyz",
                 "parameters": [
                     {
                         "type": "string",
@@ -628,6 +630,7 @@
                     "[Test] Utility"
                 ],
                 "summary": "Test tracing to Tumblebug",
+                "operationId": "TestTracing",
                 "parameters": [
                     {
                         "type": "string",
@@ -1227,7 +1230,7 @@
         }
     },
     "externalDocs": {
-        "description": "▶▶▶ CB-Tumblebug REST API",
+        "description": "▶▶▶ CB-Tumblebug REST API (access via Beetle's reverse proxy)",
         "url": "http://localhost:8056/tumblebug/api/index.html"
     }
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -420,13 +420,13 @@ definitions:
         $ref: '#/definitions/onprem.DiskProperty'
     type: object
 externalDocs:
-  description: ▶▶▶ CB-Tumblebug REST API
+  description: ▶▶▶ CB-Tumblebug REST API (access via Beetle's reverse proxy)
   url: http://localhost:8056/tumblebug/api/index.html
+host: localhost:8056
 info:
   contact:
-    email: contact-to-cloud-barista@googlegroups.com
     name: API Support
-    url: http://cloud-barista.github.io
+    url: https://github.com/cloud-barista/cm-beetle/issues/new/choose
   description: CM-Beetle REST API
   license:
     name: Apache 2.0
@@ -440,6 +440,7 @@ paths:
       - application/json
       description: Checks and logs the HTTP version of the incoming request to the
         server console.
+      operationId: CheckHTTPVersion
       parameters:
       - description: 'Custom request ID (NOTE: It will be used as a trace ID.)'
         in: header
@@ -592,6 +593,7 @@ paths:
       consumes:
       - application/json
       description: Check Beetle is ready
+      operationId: GetReadyz
       parameters:
       - description: 'Custom request ID (NOTE: It will be used as a trace ID.)'
         in: header
@@ -850,6 +852,7 @@ paths:
       consumes:
       - application/json
       description: Test tracing to Tumblebug
+      operationId: TestTracing
       parameters:
       - description: 'Custom request ID (NOTE: It will be used as a trace ID.)'
         in: header

--- a/cmd/cm-beetle/main.go
+++ b/cmd/cm-beetle/main.go
@@ -127,19 +127,20 @@ func checkReadiness(url string) (bool, error) {
 // @title CM-Beetle REST API
 // @version latest
 // @description CM-Beetle REST API
+// // @termsOfService none
 
 // @contact.name API Support
-// @contact.url http://cloud-barista.github.io
-// @contact.email contact-to-cloud-barista@googlegroups.com
+// @contact.url https://github.com/cloud-barista/cm-beetle/issues/new/choose
 
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 
+// @host localhost:8056
 // @BasePath /beetle
 
 // @securityDefinitions.basic BasicAuth
 
-// @externalDocs.description  ▶▶▶ CB-Tumblebug REST API
+// @externalDocs.description ▶▶▶ CB-Tumblebug REST API (access via Beetle's reverse proxy)
 // @externalDocs.url http://localhost:8056/tumblebug/api/index.html
 
 func main() {

--- a/go.work.sum
+++ b/go.work.sum
@@ -519,11 +519,14 @@ github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 github.com/zcalusic/sysinfo v1.0.2/go.mod h1:kluzTYflRWo6/tXVMJPdEjShsbPpsFRyy+p1mBQPC30=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
+go.etcd.io/etcd/api/v3 v3.5.12 h1:W4sw5ZoU2Juc9gBWuLk5U6fHfNVyY1WC5g9uiXZio/c=
 go.etcd.io/etcd/api/v3 v3.5.12/go.mod h1:Ot+o0SWSyT6uHhA56al1oCED0JImsRiU9Dc26+C2a+4=
+go.etcd.io/etcd/client/pkg/v3 v3.5.12 h1:EYDL6pWwyOsylrQyLp2w+HkQ46ATiOvoEdMarindU2A=
 go.etcd.io/etcd/client/pkg/v3 v3.5.12/go.mod h1:seTzl2d9APP8R5Y2hFL3NVlD6qC/dOT+3kvrqPyTas4=
 go.etcd.io/etcd/client/v2 v2.305.7/go.mod h1:GQGT5Z3TBuAQGvgPfhR7VPySu/SudxmEkRq9BgzFU6s=
 go.etcd.io/etcd/client/v2 v2.305.10/go.mod h1:m3CKZi69HzilhVqtPDcjhSGp+kA1OmbNn0qamH80xjA=
 go.etcd.io/etcd/client/v2 v2.305.12/go.mod h1:aQ/yhsxMu+Oht1FOupSr60oBvcS9cKXHrzBpDsPTf9E=
+go.etcd.io/etcd/client/v3 v3.5.12 h1:v5lCPXn1pf1Uu3M4laUE2hp/geOTc5uPcYYsNe1lDxg=
 go.etcd.io/etcd/client/v3 v3.5.12/go.mod h1:tSbBCakoWmmddL+BKVAJHa9km+O/E+bumDe9mSbPiqw=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0/go.mod h1:Mjt1i1INqiaoZOMGR1RIUJN+i3ChKoFRqzrRQhlkbs0=
@@ -582,8 +585,11 @@ google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 h1:9+tzLLstTlPTRyJTh+ah5wIMsBW5c4tQwGTN3thOW9Y=
 google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9/go.mod h1:mqHbVIp48Muh7Ywss/AD6I5kNVKZMmAa/QEW58Gxp2s=
+google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 h1:rIo7ocm2roD9DcFIX67Ym8icoGCKSARAiPljFhh5suQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2/go.mod h1:O1cOfN1Cy6QEYr7VxtjOyP5AdAuR0aJ/MYZaaof623Y=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c h1:lfpJ/2rWPa/kJgxyyXM8PrNnfCzcmxJ265mADgwmvLI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/grpc v1.62.1 h1:B4n+nfKzOICUXMgyrNd19h/I9oH0L1pizfk1d4zSgTk=
 google.golang.org/grpc v1.62.1/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJaiq+QE=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/pkg/api/rest/common/utility.go
+++ b/pkg/api/rest/common/utility.go
@@ -74,8 +74,8 @@ type SimpleMessage struct {
 	common.SimpleMsg
 }
 
-// RestGetReadyz func check if CM-Beetle server is ready or not.
-// RestGetReadyz godoc
+// GetReadyz godoc
+// @ID GetReadyz
 // @Summary Check Beetle is ready
 // @Description Check Beetle is ready
 // @Tags [Admin] System management
@@ -85,7 +85,7 @@ type SimpleMessage struct {
 // @Success 200 {object} SimpleMessage
 // @Failure 503 {object} SimpleMessage
 // @Router /readyz [get]
-func RestGetReadyz(c echo.Context) error {
+func GetReadyz(c echo.Context) error {
 
 	ctx := c.Request().Context()                    // Get context
 	log.Ctx(ctx).Info().Msg("RestGetReadyz called") // Log ctx to trace
@@ -99,7 +99,8 @@ func RestGetReadyz(c echo.Context) error {
 	return c.JSON(http.StatusOK, &message)
 }
 
-// RestCheckHTTPVersion godoc
+// CheckHTTPVersion godoc
+// @ID CheckHTTPVersion
 // @Summary Check HTTP version of incoming request
 // @Description Checks and logs the HTTP version of the incoming request to the server console.
 // @Tags [Admin] System management
@@ -110,7 +111,7 @@ func RestGetReadyz(c echo.Context) error {
 // @Failure 404 {object} SimpleMessage
 // @Failure 500 {object} SimpleMessage
 // @Router /httpVersion [get]
-func RestCheckHTTPVersion(c echo.Context) error {
+func CheckHTTPVersion(c echo.Context) error {
 	// Access the *http.Request object from the echo.Context
 	req := c.Request()
 
@@ -121,7 +122,8 @@ func RestCheckHTTPVersion(c echo.Context) error {
 	return c.JSON(http.StatusOK, &okMessage)
 }
 
-// RestGetTestTracingToTumblebug godoc
+// TestTracing godoc
+// @ID TestTracing
 // @Summary Test tracing to Tumblebug
 // @Description Test tracing to Tumblebug
 // @Tags [Test] Utility
@@ -131,7 +133,7 @@ func RestCheckHTTPVersion(c echo.Context) error {
 // @Success 200 {object} SimpleMessage
 // @Failure 503 {object} SimpleMessage
 // @Router /test/tracing [get]
-func RestGetTestTracing(c echo.Context) error {
+func TestTracing(c echo.Context) error {
 
 	ctx := c.Request().Context()                    // Get context
 	log.Ctx(ctx).Info().Msg("RestGetReadyz called") // Log ctx to trace

--- a/pkg/api/rest/middlewares/tumblebug-init-checker.go
+++ b/pkg/api/rest/middlewares/tumblebug-init-checker.go
@@ -1,0 +1,62 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cloud-barista/cm-beetle/pkg/config"
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
+	"github.com/go-resty/resty/v2"
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
+
+	tbResource "github.com/cloud-barista/cb-tumblebug/src/api/rest/server/resource"
+)
+
+var isTbInitalized bool = false
+
+// TumblebugInitChecker
+func TumblebugInitChecker(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+
+		if !isTbInitalized {
+			// Initialize resty client with basic auth
+			client := resty.New()
+			apiUser := config.Tumblebug.API.Username
+			apiPass := config.Tumblebug.API.Password
+			client.SetBasicAuth(apiUser, apiPass)
+
+			// set tumblebug rest url
+			epTumblebug := config.Tumblebug.RestUrl
+
+			// Search and set a target VM spec
+			method := "GET"
+			nsId := "system"
+			url := fmt.Sprintf("%s/ns/%s/resources/image", epTumblebug, nsId)
+
+			tbReqt := common.NoBody
+			tbResp := tbResource.RestGetAllImageResponse{}
+
+			err := common.ExecuteHttpRequest(
+				client,
+				method,
+				url,
+				nil,
+				common.SetUseBody(tbReqt),
+				&tbReqt,
+				&tbResp,
+				common.VeryShortDuration,
+			)
+
+			if err != nil {
+				log.Warn().Err(err).Msg("Tumblebug needs to be initialized.")
+				res := common.SimpleMsg{Message: "Tumblebug needs to be initialized. See https://github.com/cloud-barista/cb-tumblebug?tab=readme-ov-file#3-initialize-cb-tumblebug-to-configure-multi-cloud-info"}
+				return c.JSON(http.StatusServiceUnavailable, res)
+			}
+
+			isTbInitalized = true
+		}
+
+		return next(c)
+	}
+}

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -202,11 +202,11 @@ func RunServer(port string) {
 	gBeetle.GET("/api/*", echoSwagger.WrapHandler)
 
 	// System management APIs
-	gBeetle.GET("/readyz", rest_common.RestGetReadyz)
-	gBeetle.GET("/httpVersion", rest_common.RestCheckHTTPVersion)
+	gBeetle.GET("/readyz", rest_common.GetReadyz)
+	gBeetle.GET("/httpVersion", rest_common.CheckHTTPVersion)
 
 	// Test utility APIs
-	gBeetle.GET("/test/tracing", rest_common.RestGetTestTracing)
+	gBeetle.GET("/test/tracing", rest_common.TestTracing)
 
 	// Namespace API group
 	// gNamespace := gBeetle.Group("/ns")

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -217,6 +217,10 @@ func RunServer(port string) {
 
 	// Recommendation API group
 	gRecommendation := gBeetle.Group("/recommendation")
+	// Custom middleware to check if the Tumblebug is initialized
+	gRecommendation.Use(middlewares.TumblebugInitChecker)
+
+	// Recommendation APIs
 	gRecommendation.POST("/mci", controller.RecommendInfra)
 
 	// Migration API group


### PR DESCRIPTION
* Add a middleware to check if Tumblebug is initialized (temporarily)
* Bugfix `@ID` missing in API annotations

About the middleware

**Before Tumblebug is initialized**

Logs:
```
cb-tumblebug       | 11:42AM ERR src/api/rest/server/middlewares/zerologger.go:72 > request error error="code=404, message=Not valid namespace" URI=/tumblebug/ns/system/resources/image bytes_in= bytes_out=34 client_ip=172.25.0.5 id=1726746145103384911 latency_human="861.3µs" method=GET status=404
cm-beetle          | 11:42AM WRN pkg/api/rest/middlewares/tumblebug-init-checker.go:52 > Tumblebug needs to be initialized. error="[Error from: http://cb-tumblebug:1323/tumblebug/ns/system/resources/image] Status code: 404 Not Found, Message: {\"message\":\"Not valid namespace\"}\n"
cm-beetle          | 11:42AM INF pkg/api/rest/middlewares/zerologger.go:56 > request URI=/beetle/recommendation/mci bytes_in=1199 bytes_out=174 id=1726746145101904211 latency_human=3.1424ms method=POST remote_ip=172.25.0.1 status=503
```

Response:
```json
{
  "message": "Tumblebug needs to be initialized. See https://github.com/cloud-barista/cb-tumblebug?tab=readme-ov-file#3-initialize-cb-tumblebug-to-configure-multi-cloud-info"
}
```

**After Tumblebug is initialized**

Logs:
```
cb-tumblebug       | 11:52AM DBG src/core/resource/common.go:471 > [Get] image list
cb-tumblebug       | 11:52AM DBG src/core/resource/common.go:473 > /ns/system/resources/image
cb-tumblebug       | 11:52AM INF src/api/rest/server/middlewares/zerologger.go:57 > request URI=/tumblebug/ns/system/resources/image bytes_in= bytes_out=13 client_ip=172.25.0.5 id=1726746740108686987 latency_human=1.6298ms method=GET status=200
cm-beetle          | 11:52AM DBG pkg/core/recommendation/recommendation.go:162 > Source computing infrastructure info coreLowerLimit=9 coreUpperLimit=36 memoryLowerLimit (GiB)=1 memoryUpperLimit (GiB)=0 osNameWithVersion="ubuntu 22.04.3 lts (jammy jellyfish)" providerName=aws regionName=ap-northeast-2

...

cm-beetle          | 11:52AM DBG pkg/core/recommendation/recommendation.go:285 > the recommended infra info: {Status: Description: TargetInfra:{Name: InstallMonAgent:no Label:rehosted-mci SystemLabel: Description:A cloud infra recommended by CM-Beetle Vm:[{Name:rehosted-string SubGroupSize: Label:rehosted-vm Description:a recommended virtual machine CommonSpec:aws+ap-northeast-2+i3.8xlarge CommonImage:aws+ap-northeast-2+ubuntu22.04 RootDiskType: RootDiskSize: VmUserPassword: ConnectionName:}]}}
cm-beetle          | 11:52AM INF pkg/api/rest/middlewares/zerologger.go:56 > request URI=/beetle/recommendation/mci bytes_in=1199 bytes_out=423 id=1726746740107439587 latency_human=60.748ms method=POST remote_ip=172.25.0.1 status=200
```

Response:
```json
{
  "status": "ok",
  "description": "Target infra is recommended.",
  "targetInfra": {
    "name": "mmci01",
    "installMonAgent": "no",
    "label": "rehosted-mci",
    "systemLabel": "",
    "description": "A cloud infra recommended by CM-Beetle",
    "vm": [
      {
        "name": "rehosted-string",
        "subGroupSize": "",
        "label": "rehosted-vm",
        "description": "a recommended virtual machine",
        "commonSpec": "aws+ap-northeast-2+i3.8xlarge",
        "commonImage": "aws+ap-northeast-2+ubuntu22.04"
      }
    ]
  }
}
```

Close #126 
Also, related to #119