### PR TITLE
Support query param for desired provider and region

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -296,7 +296,7 @@ const docTemplate = `{
         },
         "/recommendation/mci": {
             "post": {
-                "description": "Recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration",
+                "description": "Recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
                 "consumes": [
                     "application/json"
                 ],
@@ -317,6 +317,26 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/controller.RecommendInfraRequest"
                         }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredProvider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
                     },
                     {
                         "type": "string",
@@ -852,8 +872,6 @@ const docTemplate = `{
         "controller.RecommendInfraRequest": {
             "type": "object",
             "required": [
-                "desiredProvider",
-                "desiredRegion",
                 "onpremiseInfraModel"
             ],
             "properties": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -290,7 +290,7 @@
         },
         "/recommendation/mci": {
             "post": {
-                "description": "Recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration",
+                "description": "Recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
                 "consumes": [
                     "application/json"
                 ],
@@ -311,6 +311,26 @@
                         "schema": {
                             "$ref": "#/definitions/controller.RecommendInfraRequest"
                         }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredProvider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
                     },
                     {
                         "type": "string",
@@ -846,8 +866,6 @@
         "controller.RecommendInfraRequest": {
             "type": "object",
             "required": [
-                "desiredProvider",
-                "desiredRegion",
                 "onpremiseInfraModel"
             ],
             "properties": {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -136,8 +136,6 @@ definitions:
       onpremiseInfraModel:
         $ref: '#/definitions/onprem.OnPremInfra'
     required:
-    - desiredProvider
-    - desiredRegion
     - onpremiseInfraModel
     type: object
   controller.RecommendInfraResponse:
@@ -696,8 +694,13 @@ paths:
     post:
       consumes:
       - application/json
-      description: Recommend an appropriate multi-cloud infrastructure (MCI) for cloud
-        migration
+      description: |-
+        Recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration
+
+        [Note] `desiredProvider` and `desiredRegion` are required.
+        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
+
+        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
       operationId: RecommendInfra
       parameters:
       - description: Specify the your infrastructure to be migrated
@@ -706,6 +709,21 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/controller.RecommendInfraRequest'
+      - default: aws
+        description: Provider (e.g., aws, azure, gcp)
+        enum:
+        - aws
+        - azure
+        - gcp
+        - ncp
+        in: query
+        name: desiredProvider
+        type: string
+      - default: ap-northeast-2
+        description: Region (e.g., ap-northeast-2)
+        in: query
+        name: desiredRegion
+        type: string
       - description: 'Custom request ID (NOTE: It will be used as a trace ID.)'
         in: header
         name: X-Request-Id

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -15,6 +15,7 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	// cloudmodel "github.com/cloud-barista/cm-beetle/pkg/api/rest/model/cloud/infra"
@@ -39,8 +40,8 @@ import (
 // }
 
 type RecommendInfraRequest struct {
-	DesiredProvider     string             `json:"desiredProvider" validate:"required" example:"aws"`
-	DesiredRegion       string             `json:"desiredRegion" validate:"required" example:"ap-northeast-2"`
+	DesiredProvider     string             `json:"desiredProvider" example:"aws"`
+	DesiredRegion       string             `json:"desiredRegion" example:"ap-northeast-2"`
 	OnpremiseInfraModel onprem.OnPremInfra `json:"onpremiseInfraModel" validate:"required"`
 }
 
@@ -52,16 +53,26 @@ type RecommendInfraResponse struct {
 // @ID RecommendInfra
 // @Summary Recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration
 // @Description Recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration
+// @Description
+// @Description [Note] `desiredProvider` and `desiredRegion` are required.
+// @Description - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
+// @Description
+// @Description - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
 // @Tags [Recommendation] Infrastructure
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendInfraRequest true "Specify the your infrastructure to be migrated"
+// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Success 200 {object} RecommendInfraResponse "The result of recommended infrastructure"
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /recommendation/mci [post]
 func RecommendInfra(c echo.Context) error {
+
+	desiredProvider := c.QueryParam("desiredProvider")
+	desiredRegion := c.QueryParam("desiredRegion")
 
 	// [Input]
 	reqt := &RecommendInfraRequest{}
@@ -73,8 +84,25 @@ func RecommendInfra(c echo.Context) error {
 
 	log.Trace().Msgf("reqt: %v\n", reqt)
 
+	if reqt.DesiredProvider == "" && desiredProvider == "" {
+		err := fmt.Errorf("invalid request: 'desiredProvider' is required")
+		resp := common.SimpleMsg{Message: err.Error()}
+		return c.JSON(http.StatusBadRequest, resp)
+	}
+	if reqt.DesiredRegion == "" && desiredRegion == "" {
+		err := fmt.Errorf("invalid request: 'desiredRegion' is required")
+		resp := common.SimpleMsg{Message: err.Error()}
+		return c.JSON(http.StatusBadRequest, resp)
+	}
+
 	provider := reqt.DesiredProvider
+	if provider == "" {
+		provider = desiredProvider
+	}
 	region := reqt.DesiredRegion
+	if region == "" {
+		region = desiredRegion
+	}
 	sourceInfra := reqt.OnpremiseInfraModel
 
 	ok, err := recommendation.IsValidProviderAndRegion(provider, region)


### PR DESCRIPTION
* If `desiredProvider` and `desiredRegion` are set on the request body, the values in the query parameter will be ignored.

(Note)
This is temporarily supported for integration between subsystems.
It will be updated later.

(Example)
![image](https://github.com/user-attachments/assets/4ca743e8-c091-4088-ab80-8cc8b5524f59)
![image](https://github.com/user-attachments/assets/33854630-cf09-44b1-b609-cecfb0a61ff5)
