### PR TITLE
Add Container Infrastructure Recommendation API

### DIFF
--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -160,7 +160,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.10.0
+    image: cloudbaristaorg/cb-spider:0.10.2
     container_name: cb-spider
     # build:
     #   context: ../cb-spider

--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.10.3
+    image: cloudbaristaorg/cb-tumblebug:0.10.6
     container_name: cb-tumblebug
     # build:
     #   context: ${COMPOSE_PROJECT_ROOT}/../cb-tumblebug

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.23.0
 // replace github.com/cloud-barista/cm-model => ../cm-model
 
 require (
-	github.com/cloud-barista/cb-tumblebug v0.10.3
+	github.com/cloud-barista/cb-tumblebug v0.10.6
 	github.com/cloud-barista/cm-model v0.0.3
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-playground/validator/v10 v10.22.0
@@ -40,9 +40,10 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.5.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -88,7 +89,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c // indirect
 	google.golang.org/grpc v1.62.1 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/gc/v3 v3.0.0-20240304020402-f0dba7c97c2b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 gitea.com/xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a h1:lSA0F4e9A2NcQSqGqTOXqu2aRi/XEQxDCBwM8yJtE6s=
@@ -6,6 +8,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/cloud-barista/cb-tumblebug v0.10.3 h1:a7toSyzDIb7/4/TSSpf1bZaU+bAjNRhwZZjLNO8WKOo=
 github.com/cloud-barista/cb-tumblebug v0.10.3/go.mod h1:fey4X6GLmN+6Wfbz5BiV/ZmuCNy7KYeem6oy55641mY=
+github.com/cloud-barista/cb-tumblebug v0.10.6 h1:EsDd+RcdxHGg7EctigrixNRFEc5RGxgBzbxspvjSbKs=
+github.com/cloud-barista/cb-tumblebug v0.10.6/go.mod h1:ypw2oY3yIktBr4SYat3qcHWCeSUfSEq9s3vhERJ1XiQ=
 github.com/cloud-barista/cm-model v0.0.3 h1:sYowqaUMw77j2Hmz8nt/pjEA6lfMkGkZ31jNDDPN0Tk=
 github.com/cloud-barista/cm-model v0.0.3/go.mod h1:gSuMhQxD813KIdSvkp8uGptYOeyDik749sYcICZjhj8=
 github.com/cloud-barista/mc-terrarium v0.0.18 h1:uDzFOIOoIb7hSXJ5ovrrx8+/hqjHeyNNMU3EDfv8If0=
@@ -58,6 +62,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -74,6 +79,8 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
+github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/jedib0t/go-pretty/v6 v6.5.6 h1:nKXVLqPfAwY7sWcYXdNZZZ2fjqDpAtj9UeWupgfUxSg=
 github.com/jedib0t/go-pretty/v6 v6.5.6/go.mod h1:5LQIxa52oJ/DlDSLv0HEkWOFMDGoWkJb9ss5KqPpJBg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -296,6 +303,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
@@ -311,6 +319,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/gc/v3 v3.0.0-20240304020402-f0dba7c97c2b h1:BnN1t+pb1cy61zbvSUV7SeI0PwosMhlAEi/vBY4qxp8=

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -24,7 +24,6 @@ import (
 	// "github.com/cloud-barista/cm-honeybee/agent/pkg/api/rest/model/onprem/infra"
 	inframodel "github.com/cloud-barista/cm-model/infra/onprem"
 
-	// "github.com/cloud-barista/cm-beetle/pkg/config"
 	"github.com/cloud-barista/cm-beetle/pkg/core/common"
 	"github.com/cloud-barista/cm-beetle/pkg/core/recommendation"
 	"github.com/labstack/echo/v4"

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -60,7 +60,7 @@ type RecommendInfraResponse struct {
 // @Description - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
 // @Description
 // @Description - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
-// @Tags [Recommendation] Multi-Cloud Infrastructure
+// @Tags [Recommendation] Infrastructure
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendInfraRequest true "Specify the your infrastructure to be migrated"

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -178,6 +178,7 @@ func RecommendContainerInfra(c echo.Context) error {
 	if region == "" {
 		region = desiredRegion
 	}
+	sourceInfra := reqt.OnpremiseInfraModel.OnpremiseInfraModel
 
 	if provider == "ncp" {
 		provider = provider + "vpc"
@@ -189,7 +190,7 @@ func RecommendContainerInfra(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, common.SimpleMsg{Message: err.Error()})
 	}
 
-	result, err := recommendation.RecommendContainer(provider, region)
+	result, err := recommendation.RecommendContainer(provider, region, sourceInfra)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to call RecommendContainer")
 		return c.JSON(http.StatusInternalServerError, common.SimpleMsg{Message: "container recommendation failed"})

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cloud-barista/cm-beetle/pkg/core/recommendation"
 	"github.com/labstack/echo/v4"
 
-	// "github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -136,16 +136,16 @@ func RecommendVMInfra(c echo.Context) error {
 
 // RecommendContainerInfra godoc
 // @ID RecommendContainerInfra
-// @Summary Recommend an appropriate container infrastructure for container migration
+// @Summary Recommend an appropriate container infrastructure for cloud migration
 // @Description Recommend an appropriate container infrastructure for container-based workloads
 // @Description
 // @Description [Note] `desiredProvider` and `desiredRegion` are required.
 // @Description - `desiredProvider` and `desiredRegion` can be set in the query parameter or the request body.
 // @Description - If both are set, the values in the request body take precedence.
-// @Tags [Recommendation] Container Infrastructure
+// @Tags [Recommendation] Infrastructure
 // @Accept  json
 // @Produce  json
-// @Param UserInfra body RecommendInfraRequest true "Specify the source container infrastructure (temporarily using VM structure)"
+// @Param UserInfra body RecommendInfraRequest true "Specify the source container infrastructure"
 // @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -222,7 +222,7 @@ func RunServer(port string) {
 
 	// Recommendation APIs
 	gRecommendation.POST("/mci", controller.RecommendVMInfra)
-	gRecommendation.POST("/container", controller.RecommendContainerInfra)
+	gRecommendation.POST("/containerInfra", controller.RecommendContainerInfra)
 
 	// Migration API group
 	gMigration := gBeetle.Group("/migration")

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -221,7 +221,8 @@ func RunServer(port string) {
 	gRecommendation.Use(middlewares.TumblebugInitChecker)
 
 	// Recommendation APIs
-	gRecommendation.POST("/mci", controller.RecommendInfra)
+	gRecommendation.POST("/mci", controller.RecommendVMInfra)
+	gRecommendation.POST("/container", controller.RecommendContainerInfra)
 
 	// Migration API group
 	gMigration := gBeetle.Group("/migration")

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -380,7 +380,6 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 			Vm:          []tbmodel.TbVmDynamicReq{}, // K8s 노드 정보를 담는 필드
 	}
 	
-	// 클라이언트 직접 생성
 	client := resty.New()
 	client.SetBaseURL(config.Tumblebug.RestUrl)
 	client.SetBasicAuth(config.Tumblebug.API.Username, config.Tumblebug.API.Password)

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -402,7 +402,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 			Limit: "5",
 	}
 	
-	// TbSpecInfo는 스펙 정보를 위한 기존 구조체
+	// TbSpecInfo is a response body that contains a list of Kubernetes node specs.
 	var specResp []tbmodel.TbSpecInfo
 	resp, err := client.R().
 			SetBody(plan).

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -425,7 +425,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 			return result, nil
 	}
 	
-	// 각 스펙에 대해 개별적으로 이미지 확인
+	// Recommend available OS images for Kubernetes node spec
 	for _, specInfo := range specResp {
 			// Step 2: 해당 스펙에 대한 이미지 가용성 확인 - k8sClusterDynamicCheckRequest API 요청 형식 수정
 			reqCheck := tbmodel.K8sClusterConnectionConfigCandidatesReq{

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -384,7 +384,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 	client.SetBaseURL(config.Tumblebug.RestUrl)
 	client.SetBasicAuth(config.Tumblebug.API.Username, config.Tumblebug.API.Password)
 	
-	// Step 1: 스펙 추천 - k8s 인프라 타입 필터 추가
+	// Step 1: Recommend spec for Kubernetes node
 	plan := tbmodel.DeploymentPlan{
 			Filter: tbmodel.FilterInfo{Policy: []tbmodel.FilterCondition{
 					{Metric: "vCPU", Condition: []tbmodel.Operation{{Operator: ">=", Operand: "2"}}},

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -427,7 +427,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 	
 	// Recommend available OS images for Kubernetes node spec
 	for _, specInfo := range specResp {
-			// Step 2: 해당 스펙에 대한 이미지 가용성 확인 - k8sClusterDynamicCheckRequest API 요청 형식 수정
+			// Step 2: Request the available OS image for the spec
 			reqCheck := tbmodel.K8sClusterConnectionConfigCandidatesReq{
 					CommonSpecs: []string{specInfo.Id},
 			}

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -448,7 +448,6 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 					continue // 이 스펙에 대한 이미지 확인 실패 시 다음 스펙으로 진행
 			}
 			
-			// 결과 처리 - 정확한 응답 구조체 사용
 			if len(checkResp.ReqCheck) == 0 {
 					log.Warn().Str("specId", specInfo.Id).Msg("no compatibility info found for spec")
 					continue

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -463,7 +463,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 							continue
 					}
 					
-					imageID := "default" // K8s의 경우 일부 CSP에서는 default 이미지 사용
+					imageID := "default" // * NOTE: Set to "default" because Some CSP's Kubernetes Service uses default image.
 					if nodeInfo.Image[0].Id != "default" {
 							imageID = nodeInfo.Image[0].Id
 					}

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -440,7 +440,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 			
 			if err != nil {
 					log.Error().Err(err).Str("specId", specInfo.Id).Msg("failed to call k8sClusterDynamicCheckRequest")
-					continue // 이 스펙에 대한 이미지 확인 실패 시 다음 스펙으로 진행
+					continue
 			}
 			
 			if resp.StatusCode() != 200 {

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -377,7 +377,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 	result.TargetInfra = tbmodel.TbMciDynamicReq{
 			Description: "Recommended Kubernetes node configuration by CM-Beetle",
 			Name:        "recommended-k8s-cluster",
-			Vm:          []tbmodel.TbVmDynamicReq{}, // K8s 노드 정보를 담는 필드
+			Vm:          []tbmodel.TbVmDynamicReq{}, // a field to contain Kubernetes node information
 	}
 	
 	client := resty.New()

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -370,123 +370,179 @@ func RecommendVM(desiredProvider string, desiredRegion string, srcInfra inframod
 }
 
 // RecommendContainer recommends appropriate K8s node specs for container workloads
-func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
-	var emptyResp RecommendedInfraInfo
-	var result RecommendedInfraInfo
-	
-	result.TargetInfra = tbmodel.TbMciDynamicReq{
-			Description: "Recommended Kubernetes node configuration by CM-Beetle",
-			Name:        "recommended-k8s-cluster",
-			Vm:          []tbmodel.TbVmDynamicReq{}, // a field to contain Kubernetes node information
-	}
-	
-	client := resty.New()
-	client.SetBaseURL(config.Tumblebug.RestUrl)
-	client.SetBasicAuth(config.Tumblebug.API.Username, config.Tumblebug.API.Password)
-	
-	// Step 1: Recommend spec for Kubernetes node
-	plan := tbmodel.DeploymentPlan{
-			Filter: tbmodel.FilterInfo{Policy: []tbmodel.FilterCondition{
-					{Metric: "vCPU", Condition: []tbmodel.Operation{{Operator: ">=", Operand: "2"}}},
-					{Metric: "memoryGiB", Condition: []tbmodel.Operation{{Operator: ">=", Operand: "4"}}},
-					{Metric: "providerName", Condition: []tbmodel.Operation{{Operand: provider}}},
-					{Metric: "regionName", Condition: []tbmodel.Operation{{Operand: region}}},
-					{Metric: "infraType", Condition: []tbmodel.Operation{{Operand: "k8s"}}},
-			}},
-			Priority: tbmodel.PriorityInfo{
-					Policy: []tbmodel.PriorityCondition{
-							{Metric: "performance", Weight: "0.5"},
-							{Metric: "cost", Weight: "0.5"},
-					},
-			},
-			Limit: "5",
-	}
-	
-	// TbSpecInfo is a response body that contains a list of Kubernetes node specs.
-	var specResp []tbmodel.TbSpecInfo
-	resp, err := client.R().
-			SetBody(plan).
-			SetResult(&specResp).
-			Post("/k8sClusterRecommendNode")
-	if err != nil {
-			log.Error().Err(err).Msg("failed to call k8sClusterRecommendNode")
-			return emptyResp, fmt.Errorf("failed to call k8sClusterRecommendNode: %w", err)
-	}
-	
-	if resp.StatusCode() != 200 {
-			log.Error().Int("status", resp.StatusCode()).Msg("k8sClusterRecommendNode returned non-200 status")
-			return emptyResp, fmt.Errorf("k8sClusterRecommendNode returned non-200 status: %d", resp.StatusCode())
-	}
-	
-	if len(specResp) == 0 {
-			log.Warn().Msg("no recommended specs found")
-			result.Status = string(NothingRecommended) 
-			result.Description = "Could not find appropriate K8s node specification."
-			return result, nil
-	}
-	
-	// Recommend available OS images for Kubernetes node spec
-	for _, specInfo := range specResp {
-			// Step 2: Request the available OS image for the spec
-			reqCheck := tbmodel.K8sClusterConnectionConfigCandidatesReq{
-					CommonSpecs: []string{specInfo.Id},
-			}
-			
-			var checkResp tbmodel.CheckK8sClusterDynamicReqInfo
-			resp, err = client.R().
-					SetBody(reqCheck).
-					SetResult(&checkResp).
-					Post("/k8sClusterDynamicCheckRequest")
-			
-			if err != nil {
-					log.Error().Err(err).Str("specId", specInfo.Id).Msg("failed to call k8sClusterDynamicCheckRequest")
-					continue
-			}
-			
-			if resp.StatusCode() != 200 {
-					log.Error().Int("status", resp.StatusCode()).Str("specId", specInfo.Id).Msg("k8sClusterDynamicCheckRequest returned non-200 status")
-					continue
-			}
-			
-			if len(checkResp.ReqCheck) == 0 {
-					log.Warn().Str("specId", specInfo.Id).Msg("no compatibility info found for spec")
-					continue
-			}
-			
-			for _, nodeInfo := range checkResp.ReqCheck {
-					commonSpec := specInfo.Id
-					
-					// 이미지 선택
-					if len(nodeInfo.Image) == 0 {
-							log.Warn().Str("spec", commonSpec).Msg("no compatible images found for spec")
-							continue
-					}
-					
-					imageID := "default" // * NOTE: Set to "default" because Some CSP's Kubernetes Service uses default image.
-					if nodeInfo.Image[0].Id != "default" {
-							imageID = nodeInfo.Image[0].Id
-					}
-					
-					// Set the recommended Kubernetes node spec and OS image to the response body
-					vm := tbmodel.TbVmDynamicReq{
-							Name:        fmt.Sprintf("k8snode-%s", strings.Split(commonSpec, "-")[len(strings.Split(commonSpec, "-"))-1]),
-							CommonSpec:  commonSpec,
-							CommonImage: imageID,
-							Description: "Recommended K8s node",
-					}
-					result.TargetInfra.Vm = append(result.TargetInfra.Vm, vm)
-			}
-	}
-	
-	if len(result.TargetInfra.Vm) > 0 {
-			result.Status = string(FullyRecommended)
-			result.Description = "K8s node configuration recommended."
-	} else {
-			result.Status = string(NothingRecommended)
-			result.Description = "Could not find appropriate K8s node configuration."
-	}
-	
-	return result, nil
+func RecommendContainer(provider, region string, srcInfra inframodel.OnpremInfra) (RecommendedInfraInfo, error) {
+    var emptyResp RecommendedInfraInfo
+    var result RecommendedInfraInfo
+    
+    result.TargetInfra = tbmodel.TbMciDynamicReq{
+            Description: "Recommended Kubernetes node configuration by CM-Beetle",
+            Name:        "recommended-k8s-cluster",
+            Vm:          []tbmodel.TbVmDynamicReq{}, // a field to contain Kubernetes node information
+    }
+    
+    client := resty.New()
+    client.SetBaseURL(config.Tumblebug.RestUrl)
+    client.SetBasicAuth(config.Tumblebug.API.Username, config.Tumblebug.API.Password)
+    
+    // Analyze container workload resource requirements from user input (srcInfra)
+    var totalCores uint32 = 0
+    var totalMemory uint32 = 0
+    
+    // Calculate resource requirements if container workloads exist
+    if len(srcInfra.Servers) > 0 {
+        // Utilize server information hosting container workloads
+        for _, server := range srcInfra.Servers {
+            totalCores += server.CPU.Cores
+            totalMemory += uint32(server.Memory.TotalSize)
+        }
+    }
+    
+    var coresMin, coresMax uint32
+    var memoryMin, memoryMax uint32
+    
+    if totalCores > 0 {
+        coresMax = totalCores << 1  // Double
+        if totalCores > 1 {
+            coresMin = totalCores >> 1  // Half
+        } else {
+            coresMin = 1  // Minimum 1
+        }
+    } else {
+        // Set default values
+        coresMin = 2
+        coresMax = 4
+    }
+    
+    if totalMemory > 0 {
+        memoryMax = totalMemory << 1  // Double
+        if totalMemory > 1 {
+            memoryMin = totalMemory >> 1  // Half
+        } else {
+            memoryMin = 1  // Minimum 1
+        }
+    } else {
+        // Set default values
+        memoryMin = 4
+        memoryMax = 8
+    }
+    
+    log.Debug().
+        Uint32("coreLowerLimit", coresMin).
+        Uint32("coreUpperLimit", coresMax).
+        Uint32("memoryLowerLimit (GiB)", memoryMin).
+        Uint32("memoryUpperLimit (GiB)", memoryMax).
+        Str("providerName", provider).
+        Str("regionName", region).
+        Msg("Container workload resource requirements")
+    
+    // Step 1: Recommend spec for Kubernetes node - using dynamic values based on user input
+    plan := tbmodel.DeploymentPlan{
+            Filter: tbmodel.FilterInfo{Policy: []tbmodel.FilterCondition{
+                    {Metric: "vCPU", Condition: []tbmodel.Operation{
+                        {Operator: ">=", Operand: fmt.Sprintf("%d", coresMin)},
+                        {Operator: "<=", Operand: fmt.Sprintf("%d", coresMax)},
+                    }},
+                    {Metric: "memoryGiB", Condition: []tbmodel.Operation{
+                        {Operator: ">=", Operand: fmt.Sprintf("%d", memoryMin)},
+                        {Operator: "<=", Operand: fmt.Sprintf("%d", memoryMax)},
+                    }},
+                    {Metric: "providerName", Condition: []tbmodel.Operation{{Operand: provider}}},
+                    {Metric: "regionName", Condition: []tbmodel.Operation{{Operand: region}}},
+                    {Metric: "infraType", Condition: []tbmodel.Operation{{Operand: "k8s"}}},
+            }},
+            Priority: tbmodel.PriorityInfo{
+                    Policy: []tbmodel.PriorityCondition{
+                            {Metric: "performance", Weight: "0.5"},
+                            {Metric: "cost", Weight: "0.5"},
+                    },
+            },
+            Limit: "5",
+    }
+    
+    // TbSpecInfo is a response body that contains a list of Kubernetes node specs.
+    var specResp []tbmodel.TbSpecInfo
+    resp, err := client.R().
+            SetBody(plan).
+            SetResult(&specResp).
+            Post("/k8sClusterRecommendNode")
+    if err != nil {
+            log.Error().Err(err).Msg("failed to call k8sClusterRecommendNode")
+            return emptyResp, fmt.Errorf("failed to call k8sClusterRecommendNode: %w", err)
+    }
+    
+    if resp.StatusCode() != 200 {
+            log.Error().Int("status", resp.StatusCode()).Msg("k8sClusterRecommendNode returned non-200 status")
+            return emptyResp, fmt.Errorf("k8sClusterRecommendNode returned non-200 status: %d", resp.StatusCode())
+    }
+    
+    if len(specResp) == 0 {
+            log.Warn().Msg("no recommended specs found")
+            result.Status = string(NothingRecommended) 
+            result.Description = "Could not find appropriate K8s node specification."
+            return result, nil
+    }
+    
+    // Recommend available OS images for Kubernetes node spec
+    for _, specInfo := range specResp {
+            // Step 2: Request the available OS image for the spec
+            reqCheck := tbmodel.K8sClusterConnectionConfigCandidatesReq{
+                    CommonSpecs: []string{specInfo.Id},
+            }
+            
+            var checkResp tbmodel.CheckK8sClusterDynamicReqInfo
+            resp, err = client.R().
+                    SetBody(reqCheck).
+                    SetResult(&checkResp).
+                    Post("/k8sClusterDynamicCheckRequest")
+            
+            if err != nil {
+                    log.Error().Err(err).Str("specId", specInfo.Id).Msg("failed to call k8sClusterDynamicCheckRequest")
+                    continue
+            }
+            
+            if resp.StatusCode() != 200 {
+                    log.Error().Int("status", resp.StatusCode()).Str("specId", specInfo.Id).Msg("k8sClusterDynamicCheckRequest returned non-200 status")
+                    continue
+            }
+            
+            if len(checkResp.ReqCheck) == 0 {
+                    log.Warn().Str("specId", specInfo.Id).Msg("no compatibility info found for spec")
+                    continue
+            }
+            
+            for _, nodeInfo := range checkResp.ReqCheck {
+                    commonSpec := specInfo.Id
+                    
+                    if len(nodeInfo.Image) == 0 {
+                            log.Warn().Str("spec", commonSpec).Msg("no compatible images found for spec")
+                            continue
+                    }
+                    
+                    imageID := "default" // * NOTE: Set to "default" because Some CSP's Kubernetes Service uses default image.
+                    if nodeInfo.Image[0].Id != "default" {
+                            imageID = nodeInfo.Image[0].Id
+                    }
+                    
+                    // Set the recommended Kubernetes node spec and OS image to the response body
+                    vm := tbmodel.TbVmDynamicReq{
+                            Name:        fmt.Sprintf("k8snode-%s", strings.Split(commonSpec, "-")[len(strings.Split(commonSpec, "-"))-1]),
+                            CommonSpec:  commonSpec,
+                            CommonImage: imageID,
+                            Description: "Recommended K8s node",
+                    }
+                    result.TargetInfra.Vm = append(result.TargetInfra.Vm, vm)
+            }
+    }
+    
+    if len(result.TargetInfra.Vm) > 0 {
+            result.Status = string(FullyRecommended)
+            result.Description = "K8s node configuration recommended."
+    } else {
+            result.Status = string(NothingRecommended)
+            result.Description = "Could not find appropriate K8s node configuration."
+    }
+    
+    return result, nil
 }
 
 // Function to check overall status for the entire list of VMs

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -468,7 +468,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 							imageID = nodeInfo.Image[0].Id
 					}
 					
-					// K8s 노드 정보 구성
+					// Set the recommended Kubernetes node spec and OS image to the response body
 					vm := tbmodel.TbVmDynamicReq{
 							Name:        fmt.Sprintf("k8snode-%s", strings.Split(commonSpec, "-")[len(strings.Split(commonSpec, "-"))-1]),
 							CommonSpec:  commonSpec,

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -479,7 +479,6 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 			}
 	}
 	
-	// 상태 및 설명 정리
 	if len(result.TargetInfra.Vm) > 0 {
 			result.Status = string(FullyRecommended)
 			result.Description = "K8s node configuration recommended."

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -429,7 +429,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 	for _, specInfo := range specResp {
 			// Step 2: 해당 스펙에 대한 이미지 가용성 확인 - k8sClusterDynamicCheckRequest API 요청 형식 수정
 			reqCheck := tbmodel.K8sClusterConnectionConfigCandidatesReq{
-					CommonSpecs: []string{specInfo.Id}, // 배열로 전달
+					CommonSpecs: []string{specInfo.Id},
 			}
 			
 			var checkResp tbmodel.CheckK8sClusterDynamicReqInfo

--- a/pkg/core/recommendation/recommendation.go
+++ b/pkg/core/recommendation/recommendation.go
@@ -445,7 +445,7 @@ func RecommendContainer(provider, region string) (RecommendedInfraInfo, error) {
 			
 			if resp.StatusCode() != 200 {
 					log.Error().Int("status", resp.StatusCode()).Str("specId", specInfo.Id).Msg("k8sClusterDynamicCheckRequest returned non-200 status")
-					continue // 이 스펙에 대한 이미지 확인 실패 시 다음 스펙으로 진행
+					continue
 			}
 			
 			if len(checkResp.ReqCheck) == 0 {


### PR DESCRIPTION
1. Implemented new functions to call Tumblebug's K8s node recommendation API:
- RecommendContainer
- RecommendContainerInfra

2. Added new API endpoint for container infrastructure recommendations in pkg/api/rest/server.go

3. Renamed existing functions for clarity:
- Recommend → RecommendVM
- RecommendInfra → RecommendVMInfra

4. Modified docker-compose.yaml to use Tumblebug version 0.10.6 instead of 0.10.3 to resolve K8s cluster creation issues