### PR TITLE
feat: improve security group rule generation

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -393,7 +393,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -473,7 +473,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -537,6 +537,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -544,6 +545,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "mig-sg-01",
                         "description": "Security Group ID",
                         "name": "sgId",
                         "in": "path",
@@ -587,7 +589,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -595,8 +597,9 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "mig-sg-01",
                         "description": "Security Group ID",
-                        "name": "securityGroupId",
+                        "name": "sgId",
                         "in": "path",
                         "required": true
                     }
@@ -640,7 +643,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -720,7 +723,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -784,6 +787,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -791,6 +795,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "mig-sshkey-01",
                         "description": "SSH Key ID",
                         "name": "sshKeyId",
                         "in": "path",
@@ -834,7 +839,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -842,6 +847,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "mig-sshkey-01",
                         "description": "SSH Key ID",
                         "name": "sshKeyId",
                         "in": "path",
@@ -887,6 +893,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -945,6 +952,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -999,6 +1007,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -1006,6 +1015,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "mig-vnet-01",
                         "description": "Virtual Network ID",
                         "name": "vNetId",
                         "in": "path",
@@ -1049,6 +1059,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -1056,6 +1067,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "mig-vnet-01",
                         "description": "Virtual Network ID",
                         "name": "vNetId",
                         "in": "path",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -387,7 +387,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -467,7 +467,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -531,6 +531,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -538,6 +539,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "mig-sg-01",
                         "description": "Security Group ID",
                         "name": "sgId",
                         "in": "path",
@@ -581,7 +583,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -589,8 +591,9 @@
                     },
                     {
                         "type": "string",
+                        "default": "mig-sg-01",
                         "description": "Security Group ID",
-                        "name": "securityGroupId",
+                        "name": "sgId",
                         "in": "path",
                         "required": true
                     }
@@ -634,7 +637,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -714,7 +717,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -778,6 +781,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -785,6 +789,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "mig-sshkey-01",
                         "description": "SSH Key ID",
                         "name": "sshKeyId",
                         "in": "path",
@@ -828,7 +833,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -836,6 +841,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "mig-sshkey-01",
                         "description": "SSH Key ID",
                         "name": "sshKeyId",
                         "in": "path",
@@ -881,6 +887,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -939,6 +946,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -993,6 +1001,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -1000,6 +1009,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "mig-vnet-01",
                         "description": "Virtual Network ID",
                         "name": "vNetId",
                         "in": "path",
@@ -1043,6 +1053,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "mig01",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -1050,6 +1061,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "mig-vnet-01",
                         "description": "Virtual Network ID",
                         "name": "vNetId",
                         "in": "path",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2434,7 +2434,7 @@ paths:
       description: Get the list of all migrated security groups in the namespace
       operationId: ListMigratedSecurityGroups
       parameters:
-      - default: default
+      - default: mig01
         description: Namespace ID
         in: path
         name: nsId
@@ -2485,7 +2485,7 @@ paths:
       description: Create a new migrated security group in the namespace
       operationId: CreateMigratedSecurityGroup
       parameters:
-      - default: default
+      - default: mig01
         description: Namespace ID
         in: path
         name: nsId
@@ -2529,15 +2529,16 @@ paths:
       description: Delete a specific migrated security group in the namespace
       operationId: DeleteMigratedSecurityGroup
       parameters:
-      - default: default
+      - default: mig01
         description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: Security Group ID
+      - default: mig-sg-01
+        description: Security Group ID
         in: path
-        name: securityGroupId
+        name: sgId
         required: true
         type: string
       produces:
@@ -2564,12 +2565,14 @@ paths:
       description: Get details of a specific migrated security group in the namespace
       operationId: GetMigratedSecurityGroup
       parameters:
-      - description: Namespace ID
+      - default: mig01
+        description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: Security Group ID
+      - default: mig-sg-01
+        description: Security Group ID
         in: path
         name: sgId
         required: true
@@ -2599,7 +2602,7 @@ paths:
       description: Get the list of all migrated SSH keys in the namespace
       operationId: ListMigratedSSHKeys
       parameters:
-      - default: default
+      - default: mig01
         description: Namespace ID
         in: path
         name: nsId
@@ -2650,7 +2653,7 @@ paths:
       description: Create a new migrated SSH key in the namespace
       operationId: CreateMigratedSSHKey
       parameters:
-      - default: default
+      - default: mig01
         description: Namespace ID
         in: path
         name: nsId
@@ -2694,13 +2697,14 @@ paths:
       description: Delete a specific migrated SSH key in the namespace
       operationId: DeleteMigratedSSHKey
       parameters:
-      - default: default
+      - default: mig01
         description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: SSH Key ID
+      - default: mig-sshkey-01
+        description: SSH Key ID
         in: path
         name: sshKeyId
         required: true
@@ -2729,12 +2733,14 @@ paths:
       description: Get details of a specific migrated SSH key in the namespace
       operationId: GetMigratedSSHKey
       parameters:
-      - description: Namespace ID
+      - default: mig01
+        description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: SSH Key ID
+      - default: mig-sshkey-01
+        description: SSH Key ID
         in: path
         name: sshKeyId
         required: true
@@ -2764,7 +2770,8 @@ paths:
       description: Get the list of all migrated virtual networks in the namespace
       operationId: ListMigratedVNets
       parameters:
-      - description: Namespace ID
+      - default: mig01
+        description: Namespace ID
         in: path
         name: nsId
         required: true
@@ -2800,7 +2807,8 @@ paths:
       description: Create a new migrated virtual network in the namespace
       operationId: CreateVNet
       parameters:
-      - description: Namespace ID
+      - default: mig01
+        description: Namespace ID
         in: path
         name: nsId
         required: true
@@ -2836,12 +2844,14 @@ paths:
       description: Delete a specific migrated virtual network in the namespace
       operationId: DeleteMigratedVNet
       parameters:
-      - description: Namespace ID
+      - default: mig01
+        description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: Virtual Network ID
+      - default: mig-vnet-01
+        description: Virtual Network ID
         in: path
         name: vNetId
         required: true
@@ -2874,12 +2884,14 @@ paths:
       description: Get details of a specific virtual network in the namespace
       operationId: GetMigratedVNet
       parameters:
-      - description: Namespace ID
+      - default: mig01
+        description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: Virtual Network ID
+      - default: mig-vnet-01
+        description: Virtual Network ID
         in: path
         name: vNetId
         required: true

--- a/pkg/api/rest/controller/migration-resource.go
+++ b/pkg/api/rest/controller/migration-resource.go
@@ -97,7 +97,7 @@ func createTumblebugProxyHandler(sourcePattern string, targetPattern string) ech
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
 // @Success 200 {object} JSONResult{[DEFAULT]=tbresource.RestGetAllVNetResponse,[ID]=tbmodel.IdList} "Different return structures by the given option param"
 // @Failure 404 {object} tbmodel.SimpleMsg
 // @Failure 500 {object} tbmodel.SimpleMsg
@@ -119,8 +119,8 @@ func ListMigratedVNets(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID"
-// @Param vNetId path string true "Virtual Network ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
+// @Param vNetId path string true "Virtual Network ID" default(mig-vnet-01)
 // @Success 200 {object} tbmodel.TbVNetInfo
 // @Failure 404 {object} tbmodel.SimpleMsg
 // @Failure 500 {object} tbmodel.SimpleMsg
@@ -142,7 +142,7 @@ func GetMigratedVNet(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
 // @Param vNetReq body tbmodel.TbVNetReq true "Virtual Network creation request"
 // @Success 200 {object} tbmodel.TbVNetInfo
 // @Failure 400 {object} tbmodel.SimpleMsg
@@ -165,8 +165,8 @@ func CreateVNet(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID"
-// @Param vNetId path string true "Virtual Network ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
+// @Param vNetId path string true "Virtual Network ID" default(mig-vnet-01)
 // @Param action query string false "Action" Enums(withsubnets,refine,force)
 // @Success 200 {object} tbmodel.SimpleMsg
 // @Failure 404 {object} tbmodel.SimpleMsg
@@ -189,7 +189,7 @@ func DeleteMigratedVNet(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(mig01)
 // @Param option query string false "Option" Enums(id)
 // @Param filterKey query string false "Field key for filtering (ex: systemLabel)"
 // @Param filterVal query string false "Field value for filtering (ex: Registered from CSP resource)"
@@ -214,8 +214,8 @@ func ListMigratedSSHKeys(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID"
-// @Param sshKeyId path string true "SSH Key ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
+// @Param sshKeyId path string true "SSH Key ID" default(mig-sshkey-01)
 // @Success 200 {object} tbmodel.TbSshKeyInfo
 // @Failure 404 {object} tbmodel.SimpleMsg
 // @Failure 500 {object} tbmodel.SimpleMsg
@@ -237,7 +237,7 @@ func GetMigratedSSHKey(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(mig01)
 // @Param option query string false "Option: [required params for register] connectionName, name, cspKeyId" Enums(register)
 // @Param sshKeyReq body tbmodel.TbSshKeyReq true "Details for an SSH key object"
 // @Success 200 {object} tbmodel.TbSshKeyInfo
@@ -261,8 +261,8 @@ func CreateMigratedSSHKey(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param sshKeyId path string true "SSH Key ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
+// @Param sshKeyId path string true "SSH Key ID" default(mig-sshkey-01)
 // @Success 200 {object} tbmodel.SimpleMsg
 // @Failure 404 {object} tbmodel.SimpleMsg
 // @Failure 500 {object} tbmodel.SimpleMsg
@@ -285,7 +285,7 @@ func DeleteMigratedSSHKey(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(mig01)
 // @Param option query string false "Option" Enums(id)
 // @Param filterKey query string false "Field key for filtering (ex: systemLabel)"
 // @Param filterVal query string false "Field value for filtering (ex: Registered from CSP resource)"
@@ -310,8 +310,8 @@ func ListMigratedSecurityGroups(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID"
-// @Param sgId path string true "Security Group ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
+// @Param sgId path string true "Security Group ID" default(mig-sg-01)
 // @Success 200 {object} tbmodel.TbSecurityGroupInfo
 // @Failure 404 {object} tbmodel.SimpleMsg
 // @Failure 500 {object} tbmodel.SimpleMsg
@@ -333,7 +333,7 @@ func GetMigratedSecurityGroup(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(mig01)
 // @Param option query string false "Option: [required params for register] connectionName, name, vNetId, cspResourceId" Enums(register)
 // @Param securityGroupReq body tbmodel.TbSecurityGroupReq true "Details for an securityGroup object"
 // @Success 200 {object} tbmodel.TbSecurityGroupInfo
@@ -357,8 +357,8 @@ func CreateMigratedSecurityGroup(c echo.Context) error {
 // @Tags [Migration] Resources for VM infrastructure
 // @Accept json
 // @Produce json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param securityGroupId path string true "Security Group ID"
+// @Param nsId path string true "Namespace ID" default(mig01)
+// @Param sgId path string true "Security Group ID" default(mig-sg-01)
 // @Success 200 {object} tbmodel.SimpleMsg
 // @Failure 404 {object} tbmodel.SimpleMsg
 // @Failure 500 {object} tbmodel.SimpleMsg

--- a/pkg/client/tumblebug/mci.go
+++ b/pkg/client/tumblebug/mci.go
@@ -166,6 +166,11 @@ func (c *TumblebugClient) ReadMciIDs(nsId string) (tbmodel.IdList, error) {
 	method := "GET"
 	url := fmt.Sprintf("%s/ns/%s/mci", c.restUrl, nsId)
 
+	option := "id" // Use 'ids' option to retrieve only IDs
+	if option != "" {
+		url += fmt.Sprintf("?option=%s", option)
+	}
+
 	reqBody := common.NoBody
 	resBody := tbmodel.IdList{}
 


### PR DESCRIPTION
- Add IPv6 rule detection and filtering to skip unsupported IPv6 firewall rules
- Implement CB-Spider specification compliance for protocol port handling:
  * ALL protocol: use port -1 instead of port ranges
  * ICMP protocol: use port -1 (no port concept for ICMP)
  * TCP/UDP protocols: maintain 1-65535 port range for wildcards
- Skip default inbound/outbound ALL traffic rules to prevent conflicts with existing rules by cloud providers CB-Spider, or CB-Tumblebug