### PR TITLE
feat: recommend VM specs using vCPU:memory ratio and prime numbers

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1168,6 +1168,7 @@ const docTemplate = `{
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1247,6 +1248,7 @@ const docTemplate = `{
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1320,6 +1322,7 @@ const docTemplate = `{
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1393,6 +1396,7 @@ const docTemplate = `{
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1466,6 +1470,7 @@ const docTemplate = `{
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1539,6 +1544,7 @@ const docTemplate = `{
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1612,6 +1618,7 @@ const docTemplate = `{
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1162,6 +1162,7 @@
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1241,6 +1242,7 @@
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1314,6 +1316,7 @@
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1387,6 +1390,7 @@
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1460,6 +1464,7 @@
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1533,6 +1538,7 @@
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",
@@ -1606,6 +1612,7 @@
                             "aws",
                             "azure",
                             "gcp",
+                            "alibaba",
                             "ncp"
                         ],
                         "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2963,6 +2963,7 @@ paths:
         - aws
         - azure
         - gcp
+        - alibaba
         - ncp
         in: query
         name: desiredProvider
@@ -3024,6 +3025,7 @@ paths:
         - aws
         - azure
         - gcp
+        - alibaba
         - ncp
         in: query
         name: desiredCsp
@@ -3081,6 +3083,7 @@ paths:
         - aws
         - azure
         - gcp
+        - alibaba
         - ncp
         in: query
         name: desiredCsp
@@ -3138,6 +3141,7 @@ paths:
         - aws
         - azure
         - gcp
+        - alibaba
         - ncp
         in: query
         name: desiredProvider
@@ -3194,6 +3198,7 @@ paths:
         - aws
         - azure
         - gcp
+        - alibaba
         - ncp
         in: query
         name: desiredProvider
@@ -3250,6 +3255,7 @@ paths:
         - aws
         - azure
         - gcp
+        - alibaba
         - ncp
         in: query
         name: desiredProvider
@@ -3306,6 +3312,7 @@ paths:
         - aws
         - azure
         - gcp
+        - alibaba
         - ncp
         in: query
         name: desiredProvider

--- a/pkg/api/rest/controller/recommendation-resource.go
+++ b/pkg/api/rest/controller/recommendation-resource.go
@@ -48,7 +48,7 @@ type RecommendVNetResponse struct {
 // @Accept json
 // @Produce	json
 // @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
-// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Success 200 {object} RecommendVNetResponse "The result of recommended vNet"
@@ -142,7 +142,7 @@ type RecommendSecurityGroupResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
-// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Success 200 {object} RecommendSecurityGroupResponse "The result of recommended security groups"
@@ -207,7 +207,7 @@ type RecommendVmSpecResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
-// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param machineID query string false "Machine ID (e.g., TBD, xxxxxx)"
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
@@ -374,7 +374,7 @@ type RecommendVmOsImageResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
-// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Success 200 {object} RecommendVmOsImageResponse "The result of recommended VM OS images"

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -58,7 +58,7 @@ type RecommendVmInfraWithDefaultsResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendVmInfraWithDefaultsRequest true "Specify the your infrastructure to be migrated"
-// @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Success 200 {object} RecommendVmInfraWithDefaultsResponse "The result of recommended infrastructure"
@@ -151,7 +151,7 @@ type RecommendVmInfraResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
-// @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Success 200 {object} RecommendVmInfraResponse "The result of recommended infrastructure"
@@ -247,7 +247,7 @@ type RecommendInfraResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param UserInfra body RecommendInfraRequest true "Specify the source container infrastructure"
-// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,ncp) default(aws)
+// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Success 200 {object} RecommendInfraResponse "The result of recommended container infrastructure"


### PR DESCRIPTION
Enhanced VM spec search range calculation by analyzing vCPU:memory ratio and using prime number boundaries for optimal range determination.

- Applied ratio constraints (1:2 to 1:8) for General Purpose instances
- Applied ratio constraints (up to 1:8) for Compute Intensive Purpose instances
- Applied ratio constraints (from 1:2) for Memory Intensive Purpose instances
- Used findPreviousPrimeNumberOrOne() and findNextPrimeNumber() for boundary calculation

This complements existing workload-specific range calculations:
- Compute Intensive (≤3.0 ratio): wide memory search range
- Memory Intensive (≥7.0 ratio): wide vCPU search range
- General Purpose (3.0-7.0 ratio): balanced search ranges