### PR TITLE
fix(aws-compat): mitigate strict AWS spec-image compatibility checks

### DIFF
--- a/cmd/test-cli/testdata/recommendation-request.json
+++ b/cmd/test-cli/testdata/recommendation-request.json
@@ -11,6 +11,11 @@
             "ip": "192.168.110.254",
             "interfaceName": "br-ex",
             "machineId": "00a9f3d4-74b6-e811-906e-000ffee02d5c"
+          },
+          {
+            "ip": "192.168.110.254",
+            "interfaceName": "br-ex",
+            "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c"
           }
         ]
       },
@@ -31,9 +36,9 @@
         },
         "memory": {
           "type": "DDR4",
-          "totalSize": 8,
-          "available": 3,
-          "used": 5
+          "totalSize": 64,
+          "available": 30,
+          "used": 34
         },
         "rootDisk": {
           "label": "unknown",
@@ -1052,573 +1057,799 @@
             "protocol": "udp",
             "direction": "inbound",
             "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.5 LTS",
+          "version": "22.04.5 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "cm-web",
+        "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 2,
+          "cores": 18,
+          "threads": 36,
+          "maxSpeed": 3.7,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 32,
+          "available": 14,
+          "used": 18
+        },
+        "rootDisk": {
+          "label": "unknown",
+          "type": "HDD",
+          "totalSize": 1312,
+          "available": 1222,
+          "used": 23
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp24s0f0",
+            "macAddress": "b4:96:91:53:01:58",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "name": "enp24s0f1",
+            "macAddress": "b4:96:91:53:01:59",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "icmp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f0",
+            "macAddress": "b4:96:91:55:23:8c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "67",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "68",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno1np0",
+            "macAddress": "a4:bf:01:5a:b1:1b",
+            "ipv4CidrBlocks": [
+              "172.29.0.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "224.0.0.251/32",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f0",
+            "macAddress": "b4:96:91:53:01:6c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "239.255.255.250/32",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f1",
+            "macAddress": "b4:96:91:53:01:6d",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno2np1",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11c/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f1",
+            "macAddress": "b4:96:91:55:23:8e",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f0",
+            "macAddress": "b4:96:91:55:1e:04",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8086",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f1",
+            "macAddress": "b4:96:91:55:1e:06",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8888",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "ovs-system",
+            "macAddress": "6e:a8:ca:69:96:82",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9201",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-ex",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv4CidrBlocks": [
+              "192.168.110.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "2001::1000/64",
+              "fe80::7824:d2ff:fe2c:7330/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9202",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "genev_sys_6081",
+            "macAddress": "fa:e3:ea:20:21:0c",
+            "ipv6CidrBlocks": [
+              "fe80::2caf:1eff:fe7f:f78f/64"
+            ],
+            "mtu": 65000,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9203",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-int",
+            "macAddress": "ea:d0:e7:43:23:41",
+            "mtu": 1442
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9204",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap334a688a-76",
+            "macAddress": "fe:16:3e:52:10:6e",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe52:106e/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9206",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd4e69ee0-72",
+            "macAddress": "fe:16:3e:2c:59:7a",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2c:597a/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap50ee370b-a7",
+            "macAddress": "fe:16:3e:71:22:43",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe71:2243/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape46b2f03-d0",
+            "macAddress": "fe:16:3e:e2:ea:0f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fee2:ea0f/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap78b1ab69-36",
+            "macAddress": "fe:16:3e:14:65:fb",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe14:65fb/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape545ab95-ab",
+            "macAddress": "fe:16:3e:73:24:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe73:2490/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9001",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapadd1bc06-e8",
+            "macAddress": "fe:16:3e:26:ea:51",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe26:ea51/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "18080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd7ff0608-f0",
+            "macAddress": "fe:16:3e:2b:75:d6",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2b:75d6/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "13000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap26b9063f-c8",
+            "macAddress": "fe:16:3e:6c:c9:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe6c:c990/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9101",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap0d667e3a-e2",
+            "macAddress": "fe:16:3e:9f:7a:65",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe9f:7a65/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1df68fb5-f9",
+            "macAddress": "fe:16:3e:13:66:6f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe13:666f/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9106",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap3b66c516-59",
+            "macAddress": "fe:16:3e:77:e4:da",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe77:e4da/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9105",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap6f653485-7f",
+            "macAddress": "fe:16:3e:7d:85:5b",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe7d:855b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1479d90f-c0",
+            "macAddress": "02:b9:31:31:0d:fe",
+            "ipv6CidrBlocks": [
+              "fe80::b9:31ff:fe31:dfe/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9102",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap87daf3f9-0f",
+            "macAddress": "fe:16:3e:cb:97:79",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fecb:9779/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9103",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "172.29.0.0/24",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9104",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "192.168.110.0/24",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "5672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "1883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "4369",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15675",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "25672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "16567",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "destination": "fe80::/64",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "547",
-            "dstCIDR": "fe80::/10",
-            "dstPorts": "546",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::fb/128",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::f/128",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::1000/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::b9:31ff:fe31:dfe/128",
+            "interface": "tap1479d90f-c0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::2caf:1eff:fe7f:f78f/128",
+            "interface": "genev_sys_6081",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::7824:d2ff:fe2c:7330/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "deny"
+            "destination": "fe80::a6bf:1ff:fe5a:b11b/128",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::a6bf:1ff:fe5a:b11c/128",
+            "interface": "eno2np1",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe13:666f/128",
+            "interface": "tap1df68fb5-f9",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe14:65fb/128",
+            "interface": "tap78b1ab69-36",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe26:ea51/128",
+            "interface": "tapadd1bc06-e8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2b:75d6/128",
+            "interface": "tapd7ff0608-f0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2c:597a/128",
+            "interface": "tapd4e69ee0-72",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe52:106e/128",
+            "interface": "tap334a688a-76",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe6c:c990/128",
+            "interface": "tap26b9063f-c8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe71:2243/128",
+            "interface": "tap50ee370b-a7",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe73:2490/128",
+            "interface": "tape545ab95-ab",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe77:e4da/128",
+            "interface": "tap3b66c516-59",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe7d:855b/128",
+            "interface": "tap6f653485-7f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe9f:7a65/128",
+            "interface": "tap0d667e3a-e2",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fecb:9779/128",
+            "interface": "tap87daf3f9-0f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fee2:ea0f/128",
+            "interface": "tape46b2f03-d0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           }
         ],
         "os": {

--- a/cmd/test-cli/testresult/beetle-test-results-alibaba.md
+++ b/cmd/test-cli/testresult/beetle-test-results-alibaba.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: v0.4.0 (76a9a3e)
+- CM-Beetle: v0.4.0 (81e984e)
 - cm-model: v0.0.11
 - CB-Tumblebug: v0.11.3
 - CB-Spider: v0.11.1
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: August 19, 2025
-- Test Time: 15:19:38 KST
-- Test Execution: 2025-08-19 15:19:38 KST
+- Test Date: August 20, 2025
+- Test Time: 22:09:18 KST
+- Test Execution: 2025-08-20 22:09:18 KST
 
 ### Scenario
 
@@ -39,18 +39,18 @@
 
 | Test | Endpoint | Status | Duration | Details |
 |------|----------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 236ms | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 43.876s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 136ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 91ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 134ms | Pass |
-| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 45.885s | Pass |
+| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 390ms | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 2m29.15s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 111ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 73ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 110ms | Pass |
+| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 40.277s | Pass |
 
 **Overall Result**: 6/6 tests passed ✅
 
-**Total Duration**: 2m0.589386277s
+**Total Duration**: 3m40.306533038s
 
-*Test executed on August 19, 2025 at 15:19:38 KST (2025-08-19 15:19:38 KST) using CM-Beetle automated test CLI*
+*Test executed on August 20, 2025 at 22:09:18 KST (2025-08-20 22:09:18 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -86,6 +86,11 @@
             "ip": "192.168.110.254",
             "interfaceName": "br-ex",
             "machineId": "00a9f3d4-74b6-e811-906e-000ffee02d5c"
+          },
+          {
+            "ip": "192.168.110.254",
+            "interfaceName": "br-ex",
+            "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c"
           }
         ]
       },
@@ -106,9 +111,9 @@
         },
         "memory": {
           "type": "DDR4",
-          "totalSize": 8,
-          "available": 3,
-          "used": 5
+          "totalSize": 255,
+          "available": 146,
+          "used": 109
         },
         "rootDisk": {
           "label": "unknown",
@@ -1127,573 +1132,799 @@
             "protocol": "udp",
             "direction": "inbound",
             "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.5 LTS",
+          "version": "22.04.5 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "cm-web",
+        "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 2,
+          "cores": 18,
+          "threads": 36,
+          "maxSpeed": 3.7,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 255,
+          "available": 89,
+          "used": 166
+        },
+        "rootDisk": {
+          "label": "unknown",
+          "type": "HDD",
+          "totalSize": 1312,
+          "available": 1222,
+          "used": 23
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp24s0f0",
+            "macAddress": "b4:96:91:53:01:58",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "name": "enp24s0f1",
+            "macAddress": "b4:96:91:53:01:59",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "icmp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f0",
+            "macAddress": "b4:96:91:55:23:8c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "67",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "68",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno1np0",
+            "macAddress": "a4:bf:01:5a:b1:1b",
+            "ipv4CidrBlocks": [
+              "172.29.0.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "224.0.0.251/32",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f0",
+            "macAddress": "b4:96:91:53:01:6c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "239.255.255.250/32",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f1",
+            "macAddress": "b4:96:91:53:01:6d",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno2np1",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11c/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f1",
+            "macAddress": "b4:96:91:55:23:8e",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f0",
+            "macAddress": "b4:96:91:55:1e:04",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8086",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f1",
+            "macAddress": "b4:96:91:55:1e:06",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8888",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "ovs-system",
+            "macAddress": "6e:a8:ca:69:96:82",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9201",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-ex",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv4CidrBlocks": [
+              "192.168.110.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "2001::1000/64",
+              "fe80::7824:d2ff:fe2c:7330/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9202",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "genev_sys_6081",
+            "macAddress": "fa:e3:ea:20:21:0c",
+            "ipv6CidrBlocks": [
+              "fe80::2caf:1eff:fe7f:f78f/64"
+            ],
+            "mtu": 65000,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9203",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-int",
+            "macAddress": "ea:d0:e7:43:23:41",
+            "mtu": 1442
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9204",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap334a688a-76",
+            "macAddress": "fe:16:3e:52:10:6e",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe52:106e/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9206",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd4e69ee0-72",
+            "macAddress": "fe:16:3e:2c:59:7a",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2c:597a/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap50ee370b-a7",
+            "macAddress": "fe:16:3e:71:22:43",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe71:2243/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape46b2f03-d0",
+            "macAddress": "fe:16:3e:e2:ea:0f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fee2:ea0f/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap78b1ab69-36",
+            "macAddress": "fe:16:3e:14:65:fb",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe14:65fb/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape545ab95-ab",
+            "macAddress": "fe:16:3e:73:24:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe73:2490/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9001",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapadd1bc06-e8",
+            "macAddress": "fe:16:3e:26:ea:51",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe26:ea51/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "18080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd7ff0608-f0",
+            "macAddress": "fe:16:3e:2b:75:d6",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2b:75d6/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "13000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap26b9063f-c8",
+            "macAddress": "fe:16:3e:6c:c9:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe6c:c990/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9101",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap0d667e3a-e2",
+            "macAddress": "fe:16:3e:9f:7a:65",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe9f:7a65/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1df68fb5-f9",
+            "macAddress": "fe:16:3e:13:66:6f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe13:666f/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9106",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap3b66c516-59",
+            "macAddress": "fe:16:3e:77:e4:da",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe77:e4da/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9105",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap6f653485-7f",
+            "macAddress": "fe:16:3e:7d:85:5b",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe7d:855b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1479d90f-c0",
+            "macAddress": "02:b9:31:31:0d:fe",
+            "ipv6CidrBlocks": [
+              "fe80::b9:31ff:fe31:dfe/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9102",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap87daf3f9-0f",
+            "macAddress": "fe:16:3e:cb:97:79",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fecb:9779/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9103",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "172.29.0.0/24",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9104",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "192.168.110.0/24",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "5672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "1883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "4369",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15675",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "25672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "16567",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "destination": "fe80::/64",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "547",
-            "dstCIDR": "fe80::/10",
-            "dstPorts": "546",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::fb/128",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::f/128",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::1000/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::b9:31ff:fe31:dfe/128",
+            "interface": "tap1479d90f-c0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::2caf:1eff:fe7f:f78f/128",
+            "interface": "genev_sys_6081",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::7824:d2ff:fe2c:7330/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "deny"
+            "destination": "fe80::a6bf:1ff:fe5a:b11b/128",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::a6bf:1ff:fe5a:b11c/128",
+            "interface": "eno2np1",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe13:666f/128",
+            "interface": "tap1df68fb5-f9",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe14:65fb/128",
+            "interface": "tap78b1ab69-36",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe26:ea51/128",
+            "interface": "tapadd1bc06-e8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2b:75d6/128",
+            "interface": "tapd7ff0608-f0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2c:597a/128",
+            "interface": "tapd4e69ee0-72",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe52:106e/128",
+            "interface": "tap334a688a-76",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe6c:c990/128",
+            "interface": "tap26b9063f-c8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe71:2243/128",
+            "interface": "tap50ee370b-a7",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe73:2490/128",
+            "interface": "tape545ab95-ab",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe77:e4da/128",
+            "interface": "tap3b66c516-59",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe7d:855b/128",
+            "interface": "tap6f653485-7f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe9f:7a65/128",
+            "interface": "tap0d667e3a-e2",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fecb:9779/128",
+            "interface": "tap87daf3f9-0f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fee2:ea0f/128",
+            "interface": "tape46b2f03-d0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           }
         ],
         "os": {
@@ -1740,12 +1971,28 @@
         "label": null,
         "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
         "connectionName": "alibaba-ap-northeast-2",
-        "specId": "ecs.e-c1m4.large",
+        "specId": "ecs.r6.8xlarge",
         "imageId": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
         "vNetId": "mig-vnet-01",
         "subnetId": "mig-subnet-01",
         "securityGroupIds": [
           "mig-sg-01"
+        ],
+        "sshKeyId": "mig-sshkey-01",
+        "dataDiskIds": null
+      },
+      {
+        "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "subGroupSize": "",
+        "label": null,
+        "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "connectionName": "alibaba-ap-northeast-2",
+        "specId": "ecs.r6.8xlarge",
+        "imageId": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
+        "vNetId": "mig-vnet-01",
+        "subnetId": "mig-subnet-01",
+        "securityGroupIds": [
+          "mig-sg-02"
         ],
         "sshKeyId": "mig-sshkey-01",
         "dataDiskIds": null
@@ -1783,19 +2030,19 @@
   },
   "targetVmSpecList": [
     {
-      "id": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
-      "cspSpecName": "ecs.e-c1m4.large",
-      "name": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
+      "id": "alibaba+ap-northeast-2+ecs.r6.8xlarge",
+      "cspSpecName": "ecs.r6.8xlarge",
+      "name": "alibaba+ap-northeast-2+ecs.r6.8xlarge",
       "namespace": "system",
       "connectionName": "alibaba-ap-northeast-2",
       "providerName": "alibaba",
       "regionName": "ap-northeast-2",
       "infraType": "vm",
       "architecture": "x86_64",
-      "vCPU": 2,
-      "memoryGiB": 8,
+      "vCPU": 32,
+      "memoryGiB": 256,
       "diskSizeGB": -1,
-      "costPerHour": 0.0791,
+      "costPerHour": 1.71649,
       "orderInFilteredResult": 1,
       "evaluationScore01": -1,
       "evaluationScore02": -1,
@@ -1805,7 +2052,7 @@
       "evaluationScore06": -1,
       "evaluationScore07": -1,
       "evaluationScore08": -1,
-      "evaluationScore09": 1.0000001,
+      "evaluationScore09": 1,
       "evaluationScore10": -1,
       "rootDiskType": "",
       "rootDiskSize": "-1",
@@ -1813,11 +2060,11 @@
       "details": [
         {
           "key": "MemorySize",
-          "value": "8.00"
+          "value": "256.00"
         },
         {
           "key": "InstancePpsRx",
-          "value": "200000"
+          "value": "2000000"
         },
         {
           "key": "EriQuantity",
@@ -1825,15 +2072,15 @@
         },
         {
           "key": "EniPrivateIpAddressQuantity",
-          "value": "2"
+          "value": "20"
         },
         {
           "key": "CpuCoreCount",
-          "value": "2"
+          "value": "32"
         },
         {
           "key": "EniTotalQuantity",
-          "value": "2"
+          "value": "40"
         },
         {
           "key": "NetworkEncryptionSupport",
@@ -1853,11 +2100,11 @@
         },
         {
           "key": "InstanceTypeId",
-          "value": "ecs.e-c1m4.large"
+          "value": "ecs.r6.8xlarge"
         },
         {
           "key": "InstanceBandwidthRx",
-          "value": "409600"
+          "value": "10240000"
         },
         {
           "key": "QueuePairNumber",
@@ -1865,11 +2112,11 @@
         },
         {
           "key": "EniQuantity",
-          "value": "2"
+          "value": "8"
         },
         {
           "key": "InstanceTypeFamily",
-          "value": "ecs.e"
+          "value": "ecs.r6"
         },
         {
           "key": "InitialCredit",
@@ -1877,11 +2124,11 @@
         },
         {
           "key": "InstancePpsTx",
-          "value": "200000"
+          "value": "2000000"
         },
         {
           "key": "InstanceFamilyLevel",
-          "value": "EntryLevel"
+          "value": "EnterpriseLevel"
         },
         {
           "key": "LocalStorageAmount",
@@ -1889,7 +2136,7 @@
         },
         {
           "key": "TotalEniQueueQuantity",
-          "value": "2"
+          "value": "128"
         },
         {
           "key": "CpuArchitecture",
@@ -1897,15 +2144,15 @@
         },
         {
           "key": "SecondaryEniQueueNumber",
-          "value": "1"
+          "value": "16"
         },
         {
           "key": "InstanceBandwidthTx",
-          "value": "409600"
+          "value": "10240000"
         },
         {
           "key": "MaximumQueueNumberPerEni",
-          "value": "0"
+          "value": "32"
         },
         {
           "key": "DiskQuantity",
@@ -1913,7 +2160,7 @@
         },
         {
           "key": "PrimaryEniQueueNumber",
-          "value": "1"
+          "value": "16"
         },
         {
           "key": "Memory",
@@ -1921,7 +2168,7 @@
         },
         {
           "key": "CpuTurboFrequency",
-          "value": "0.00"
+          "value": "3.20"
         },
         {
           "key": "BaselineCredit",
@@ -1929,7 +2176,7 @@
         },
         {
           "key": "EniTrunkSupported",
-          "value": "false"
+          "value": "true"
         },
         {
           "key": "GPUAmount",
@@ -1945,7 +2192,7 @@
         },
         {
           "key": "InstanceCategory",
-          "value": "Shared"
+          "value": "Memory-optimized"
         },
         {
           "key": "EniIpv6AddressQuantity",
@@ -1961,7 +2208,7 @@
         },
         {
           "key": "PhysicalProcessorModel",
-          "value": "Intel(R) Xeon(R) Platinum"
+          "value": "Intel Xeon (Cascade Lake) Platinum 8269CY"
         },
         {
           "key": "SupportedBootModes",
@@ -1973,7 +2220,7 @@
         },
         {
           "key": "CpuOptions",
-          "value": "{Core:1,HyperThreadingAdjustable:true,CoreCount:0,CoreFactor:1,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+          "value": "{Core:16,HyperThreadingAdjustable:false,CoreCount:0,CoreFactor:2,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:[ContinuousCoreToHTMapping,DiscreteCoreToHTMapping]}}"
         },
         {
           "key": "NetworkCards",
@@ -2020,7 +2267,7 @@
       "id": "alibaba+ubuntu_22_04_x64_20g_alibase_20250722.vhd",
       "name": "alibaba+ubuntu_22_04_x64_20g_alibase_20250722.vhd",
       "connectionName": "alibaba-ap-northeast-1",
-      "fetchedTime": "2025.08.18 10:52:58 Mon",
+      "fetchedTime": "2025.08.19 12:20:31 Tue",
       "osType": "Ubuntu 22.04",
       "osArchitecture": "x86_64",
       "osPlatform": "Linux/UNIX",
@@ -2169,257 +2416,20 @@
           "Protocol": "udp",
           "Direction": "inbound",
           "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "",
-          "Protocol": "icmp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "68",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "5353",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1900",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
+        }
+      ],
+      "cspResourceId": ""
+    },
+    {
+      "name": "mig-sg-02",
+      "connectionName": "alibaba-ap-northeast-2",
+      "vNetId": "mig-vnet-01",
+      "description": "Recommended security group for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "firewallRules": [
         {
           "Ports": "22",
           "Protocol": "tcp",
           "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "80",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "8086",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8888",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9201",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9202",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9203",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9204",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9206",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9001",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "18080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "13000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9101",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9106",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9105",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9102",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9103",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9104",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "5672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "4369",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15675",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "25672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "16567",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "outbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "outbound",
           "CIDR": "0.0.0.0/0"
         }
       ],
@@ -2454,13 +2464,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i1f3cdjuna1t4r4s10",
+  "uid": "d2isi48eak5cr9n8jak0",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2481,7 +2491,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i1f3cdjuna1t4r4s10"
+    "sys.uid": "d2isi48eak5cr9n8jak0"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2489,12 +2499,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i1f3cdjuna1t4r4s20",
-      "cspResourceName": "d2i1f3cdjuna1t4r4s20",
-      "cspResourceId": "i-mj70pwbh0kgud1490tbq",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isi48eak5cr9n8jam0",
+      "cspResourceName": "d2isi48eak5cr9n8jam0",
+      "cspResourceId": "i-mj70tz47n16tbhhc32wp",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "South Korea (Seoul)",
         "latitude": 37.36,
@@ -2506,30 +2516,30 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 06:20:25",
+      "createdTime": "2025-08-20 13:10:19",
       "label": {
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2025-08-19 06:20:25",
-        "sys.cspResourceId": "i-mj70pwbh0kgud1490tbq",
-        "sys.cspResourceName": "d2i1f3cdjuna1t4r4s20",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 13:10:19",
+        "sys.cspResourceId": "i-mj70tz47n16tbhhc32wp",
+        "sys.cspResourceName": "d2isi48eak5cr9n8jam0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i1f3cdjuna1t4r4s20"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isi48eak5cr9n8jam0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "ap-northeast-2",
         "Zone": "ap-northeast-2a"
       },
-      "publicIP": "8.220.214.219",
+      "publicIP": "8.213.135.208",
       "sshPort": "22",
       "publicDNS": "",
-      "privateIP": "192.168.110.234",
+      "privateIP": "192.168.110.80",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": "40",
@@ -2563,23 +2573,23 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "ecs.e-c1m4.large",
-      "cspSpecName": "ecs.e-c1m4.large",
+      "specId": "ecs.r6.8xlarge",
+      "cspSpecName": "ecs.r6.8xlarge",
       "imageId": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "vpc-mj732c61jpttpajkf153r",
+      "cspVNetId": "vpc-mj7vkfd9s3bnm8ogljdj4",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "vsw-mj7nu57symn2wmfselol8",
-      "networkInterface": "eni-mj70pwbh0kgud14ai61y",
+      "cspSubnetId": "vsw-mj7o5otesxobk45dfsv1d",
+      "networkInterface": "eni-mj70tz47n16tbhh6yqvu",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i1f2cdjuna1t4r4s00",
+      "cspSshKeyId": "d2isi2oeak5cr9n8jaig",
       "vmUserName": "cb-user",
-      "vmUserPassword": "!cu$dAf1i32d1j",
+      "vmUserPassword": "keA1i!i24$8sad",
       "addtionalDetails": [
         {
           "key": "ImageId",
@@ -2587,7 +2597,7 @@
         },
         {
           "key": "InstanceType",
-          "value": "ecs.e-c1m4.large"
+          "value": "ecs.r6.8xlarge"
         },
         {
           "key": "DeviceAvailable",
@@ -2611,7 +2621,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "d2i1f3cdjuna1t4r4s20"
+          "value": "d2isi48eak5cr9n8jam0"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -2631,7 +2641,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2025-08-19T06:20Z"
+          "value": "2025-08-20T13:09Z"
         },
         {
           "key": "ZoneId",
@@ -2639,7 +2649,7 @@
         },
         {
           "key": "InternetMaxBandwidthIn",
-          "value": "400"
+          "value": "10000"
         },
         {
           "key": "InternetChargeType",
@@ -2647,7 +2657,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj70pwbh0kgud1490tbqZ"
+          "value": "iZmj70tz47n16tbhhc32wpZ"
         },
         {
           "key": "Status",
@@ -2659,7 +2669,7 @@
         },
         {
           "key": "Cpu",
-          "value": "2"
+          "value": "32"
         },
         {
           "key": "SpotPriceLimit",
@@ -2679,7 +2689,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "63434865-547c-4ebc-a07b-2c685d4db22d"
+          "value": "a8b15d59-dbe4-48ba-8cbd-b57974f1cf12"
         },
         {
           "key": "RegionId",
@@ -2695,11 +2705,11 @@
         },
         {
           "key": "InstanceTypeFamily",
-          "value": "ecs.e"
+          "value": "ecs.r6"
         },
         {
           "key": "InstanceId",
-          "value": "i-mj70pwbh0kgud1490tbq"
+          "value": "i-mj70tz47n16tbhhc32wp"
         },
         {
           "key": "Recyclable",
@@ -2715,15 +2725,15 @@
         },
         {
           "key": "Memory",
-          "value": "8192"
+          "value": "262144"
         },
         {
           "key": "CreationTime",
-          "value": "2025-08-19T06:20Z"
+          "value": "2025-08-20T13:09Z"
         },
         {
           "key": "KeyPairName",
-          "value": "d2i1f2cdjuna1t4r4s00"
+          "value": "d2isi2oeak5cr9n8jaig"
         },
         {
           "key": "LocalStorageCapacity",
@@ -2747,7 +2757,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7c7jv71yc9hgpbapks]}"
+          "value": "{SecurityGroupId:[sg-mj703mxyyq8qhxlrxy1i]}"
         },
         {
           "key": "InnerIpAddress",
@@ -2755,7 +2765,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[8.220.214.219]}"
+          "value": "{IpAddress:[8.213.135.208]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -2771,7 +2781,7 @@
         },
         {
           "key": "CpuOptions",
-          "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:1,CoreFactor:0,Numa:ON,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+          "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:16,CoreFactor:0,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
         },
         {
           "key": "HibernationOptions",
@@ -2803,7 +2813,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7nu57symn2wmfselol8,VpcId:vpc-mj732c61jpttpajkf153r,NatIpAddress:,PrivateIpAddress:{IpAddress:[192.168.110.234]}}"
+          "value": "{VSwitchId:vsw-mj7o5otesxobk45dfsv1d,VpcId:vpc-mj7vkfd9s3bnm8ogljdj4,NatIpAddress:,PrivateIpAddress:{IpAddress:[192.168.110.80]}}"
         },
         {
           "key": "Tags",
@@ -2811,7 +2821,339 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:01:8d:a5,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70pwbh0kgud14ai61y,PrimaryIpAddress:192.168.110.234,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:192.168.110.234,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:02:1f:40,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70tz47n16tbhh6yqvu,PrimaryIpAddress:192.168.110.80,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:192.168.110.80,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+        },
+        {
+          "key": "OperationLocks",
+          "value": "{LockReason:[]}"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2isi48eak5cr9n8jal0",
+      "cspResourceName": "d2isi48eak5cr9n8jal0",
+      "cspResourceId": "i-mj7627lkja1bm4rojr1u",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.36,
+        "longitude": 126.78
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:11:48",
+      "label": {
+        "sys.connectionName": "alibaba-ap-northeast-2",
+        "sys.createdTime": "2025-08-20 13:11:48",
+        "sys.cspResourceId": "i-mj7627lkja1bm4rojr1u",
+        "sys.cspResourceName": "d2isi48eak5cr9n8jal0",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isi48eak5cr9n8jal0"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "ap-northeast-2",
+        "Zone": "ap-northeast-2a"
+      },
+      "publicIP": "8.220.214.219",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.79",
+      "privateDNS": "",
+      "rootDiskType": "cloud_essd",
+      "rootDiskSize": "40",
+      "rootDiskName": "",
+      "connectionName": "alibaba-ap-northeast-2",
+      "connectionConfig": {
+        "configName": "alibaba-ap-northeast-2",
+        "providerName": "alibaba",
+        "driverName": "alibaba-driver-v1.0.so",
+        "credentialName": "alibaba",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "alibaba-ap-northeast-2",
+        "regionZoneInfo": {
+          "assignedRegion": "ap-northeast-2",
+          "assignedZone": "ap-northeast-2a"
+        },
+        "regionDetail": {
+          "regionId": "ap-northeast-2",
+          "regionName": "ap-northeast-2",
+          "description": "South Korea (Seoul)",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "zones": [
+            "ap-northeast-2a",
+            "ap-northeast-2b"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "ecs.r6.8xlarge",
+      "cspSpecName": "ecs.r6.8xlarge",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
+      "cspImageName": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "vpc-mj7vkfd9s3bnm8ogljdj4",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "vsw-mj7o5otesxobk45dfsv1d",
+      "networkInterface": "eni-mj7627lkja1bm4rwh3d1",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isi2oeak5cr9n8jaig",
+      "vmUserName": "cb-user",
+      "vmUserPassword": "keA1i!i24$8sad",
+      "addtionalDetails": [
+        {
+          "key": "ImageId",
+          "value": "ubuntu_22_04_x64_20G_alibase_20250722.vhd"
+        },
+        {
+          "key": "InstanceType",
+          "value": "ecs.r6.8xlarge"
+        },
+        {
+          "key": "DeviceAvailable",
+          "value": "true"
+        },
+        {
+          "key": "InstanceNetworkType",
+          "value": "vpc"
+        },
+        {
+          "key": "LocalStorageAmount",
+          "value": "0"
+        },
+        {
+          "key": "IsSpot",
+          "value": "false"
+        },
+        {
+          "key": "InstanceChargeType",
+          "value": "PostPaid"
+        },
+        {
+          "key": "InstanceName",
+          "value": "d2isi48eak5cr9n8jal0"
+        },
+        {
+          "key": "DeploymentSetGroupNo",
+          "value": "0"
+        },
+        {
+          "key": "GPUAmount",
+          "value": "0"
+        },
+        {
+          "key": "Connected",
+          "value": "false"
+        },
+        {
+          "key": "InvocationCount",
+          "value": "0"
+        },
+        {
+          "key": "StartTime",
+          "value": "2025-08-20T13:09Z"
+        },
+        {
+          "key": "ZoneId",
+          "value": "ap-northeast-2a"
+        },
+        {
+          "key": "InternetMaxBandwidthIn",
+          "value": "10000"
+        },
+        {
+          "key": "InternetChargeType",
+          "value": "PayByBandwidth"
+        },
+        {
+          "key": "HostName",
+          "value": "iZmj7627lkja1bm4rojr1uZ"
+        },
+        {
+          "key": "Status",
+          "value": "Running"
+        },
+        {
+          "key": "CPU",
+          "value": "0"
+        },
+        {
+          "key": "Cpu",
+          "value": "32"
+        },
+        {
+          "key": "SpotPriceLimit",
+          "value": "0.00"
+        },
+        {
+          "key": "OSName",
+          "value": "Ubuntu  22.04 64位"
+        },
+        {
+          "key": "InstanceOwnerId",
+          "value": "0"
+        },
+        {
+          "key": "OSNameEn",
+          "value": "Ubuntu  22.04 64 bit"
+        },
+        {
+          "key": "SerialNumber",
+          "value": "c4de2650-e657-4b39-8eae-c1ddb5bdc07e"
+        },
+        {
+          "key": "RegionId",
+          "value": "ap-northeast-2"
+        },
+        {
+          "key": "IoOptimized",
+          "value": "true"
+        },
+        {
+          "key": "InternetMaxBandwidthOut",
+          "value": "5"
+        },
+        {
+          "key": "InstanceTypeFamily",
+          "value": "ecs.r6"
+        },
+        {
+          "key": "InstanceId",
+          "value": "i-mj7627lkja1bm4rojr1u"
+        },
+        {
+          "key": "Recyclable",
+          "value": "false"
+        },
+        {
+          "key": "ExpiredTime",
+          "value": "2099-12-31T15:59Z"
+        },
+        {
+          "key": "OSType",
+          "value": "linux"
+        },
+        {
+          "key": "Memory",
+          "value": "262144"
+        },
+        {
+          "key": "CreationTime",
+          "value": "2025-08-20T13:09Z"
+        },
+        {
+          "key": "KeyPairName",
+          "value": "d2isi2oeak5cr9n8jaig"
+        },
+        {
+          "key": "LocalStorageCapacity",
+          "value": "0"
+        },
+        {
+          "key": "StoppedMode",
+          "value": "Not-applicable"
+        },
+        {
+          "key": "SpotStrategy",
+          "value": "NoSpot"
+        },
+        {
+          "key": "SpotDuration",
+          "value": "0"
+        },
+        {
+          "key": "DeletionProtection",
+          "value": "false"
+        },
+        {
+          "key": "SecurityGroupIds",
+          "value": "{SecurityGroupId:[sg-mj7627lkja1bm4rw0m6i]}"
+        },
+        {
+          "key": "InnerIpAddress",
+          "value": "{IpAddress:[]}"
+        },
+        {
+          "key": "PublicIpAddress",
+          "value": "{IpAddress:[8.220.214.219]}"
+        },
+        {
+          "key": "RdmaIpAddress",
+          "value": "{IpAddress:null}"
+        },
+        {
+          "key": "DedicatedHostAttribute",
+          "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+        },
+        {
+          "key": "EcsCapacityReservationAttr",
+          "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+        },
+        {
+          "key": "CpuOptions",
+          "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:16,CoreFactor:0,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+        },
+        {
+          "key": "HibernationOptions",
+          "value": "{Configured:false}"
+        },
+        {
+          "key": "DedicatedInstanceAttribute",
+          "value": "{Affinity:,Tenancy:}"
+        },
+        {
+          "key": "PrivateDnsNameOptions",
+          "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+        },
+        {
+          "key": "AdditionalInfo",
+          "value": "{EnableHighDensityMode:false}"
+        },
+        {
+          "key": "ImageOptions",
+          "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+        },
+        {
+          "key": "EipAddress",
+          "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+        },
+        {
+          "key": "MetadataOptions",
+          "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+        },
+        {
+          "key": "VpcAttributes",
+          "value": "{VSwitchId:vsw-mj7o5otesxobk45dfsv1d,VpcId:vpc-mj7vkfd9s3bnm8ogljdj4,NatIpAddress:,PrivateIpAddress:{IpAddress:[192.168.110.79]}}"
+        },
+        {
+          "key": "Tags",
+          "value": "{Tag:null}"
+        },
+        {
+          "key": "NetworkInterfaces",
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:02:1f:3f,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7627lkja1bm4rwh3d1,PrimaryIpAddress:192.168.110.79,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:192.168.110.79,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -2855,13 +3197,13 @@
     {
       "resourceType": "mci",
       "id": "mmci01",
-      "uid": "d2i1f3cdjuna1t4r4s10",
+      "uid": "d2isi48eak5cr9n8jak0",
       "name": "mmci01",
-      "status": "Running:1 (R:1/1)",
+      "status": "Running:2 (R:2/2)",
       "statusCount": {
-        "countTotal": 1,
+        "countTotal": 2,
         "countCreating": 0,
-        "countRunning": 1,
+        "countRunning": 2,
         "countFailed": 0,
         "countSuspended": 0,
         "countRebooting": 0,
@@ -2882,8 +3224,80 @@
       "vm": [
         {
           "resourceType": "mci",
+          "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+          "uid": "d2isi48eak5cr9n8jak0",
+          "name": "mmci01",
+          "subGroupId": "",
+          "location": {
+            "display": "",
+            "latitude": 0,
+            "longitude": 0
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "a recommended multi-cloud infrastructure",
+          "region": {
+            "Region": "",
+            "Zone": ""
+          },
+          "publicIP": "",
+          "sshPort": "",
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": "",
+          "rootDiskName": "",
+          "connectionName": "",
+          "connectionConfig": {
+            "configName": "",
+            "providerName": "",
+            "driverName": "",
+            "credentialName": "",
+            "credentialHolder": "",
+            "regionZoneInfoName": "",
+            "regionZoneInfo": {
+              "assignedRegion": "",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "",
+              "regionName": "",
+              "description": "",
+              "location": {
+                "display": "",
+                "latitude": 0,
+                "longitude": 0
+              },
+              "zones": null
+            },
+            "regionRepresentative": false,
+            "verified": false
+          },
+          "specId": "",
+          "cspSpecName": "",
+          "imageId": "",
+          "cspImageName": "",
+          "vNetId": "",
+          "cspVNetId": "",
+          "subnetId": "",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": null,
+          "dataDiskIds": null,
+          "sshKeyId": "",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "mci",
           "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-          "uid": "d2i1f3cdjuna1t4r4s10",
+          "uid": "d2isi48eak5cr9n8jak0",
           "name": "mmci01",
           "subGroupId": "",
           "location": {
@@ -3015,13 +3429,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i1f3cdjuna1t4r4s10",
+  "uid": "d2isi48eak5cr9n8jak0",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -3042,7 +3456,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i1f3cdjuna1t4r4s10"
+    "sys.uid": "d2isi48eak5cr9n8jak0"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -3050,12 +3464,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i1f3cdjuna1t4r4s20",
-      "cspResourceName": "d2i1f3cdjuna1t4r4s20",
-      "cspResourceId": "i-mj70pwbh0kgud1490tbq",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isi48eak5cr9n8jam0",
+      "cspResourceName": "d2isi48eak5cr9n8jam0",
+      "cspResourceId": "i-mj70tz47n16tbhhc32wp",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "South Korea (Seoul)",
         "latitude": 37.36,
@@ -3067,30 +3481,30 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 06:20:25",
+      "createdTime": "2025-08-20 13:10:19",
       "label": {
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2025-08-19 06:20:25",
-        "sys.cspResourceId": "i-mj70pwbh0kgud1490tbq",
-        "sys.cspResourceName": "d2i1f3cdjuna1t4r4s20",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 13:10:19",
+        "sys.cspResourceId": "i-mj70tz47n16tbhhc32wp",
+        "sys.cspResourceName": "d2isi48eak5cr9n8jam0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i1f3cdjuna1t4r4s20"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isi48eak5cr9n8jam0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "ap-northeast-2",
         "Zone": "ap-northeast-2a"
       },
-      "publicIP": "8.220.214.219",
+      "publicIP": "8.213.135.208",
       "sshPort": "22",
       "publicDNS": "",
-      "privateIP": "192.168.110.234",
+      "privateIP": "192.168.110.80",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": "40",
@@ -3124,23 +3538,23 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "ecs.e-c1m4.large",
-      "cspSpecName": "ecs.e-c1m4.large",
+      "specId": "ecs.r6.8xlarge",
+      "cspSpecName": "ecs.r6.8xlarge",
       "imageId": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "vpc-mj732c61jpttpajkf153r",
+      "cspVNetId": "vpc-mj7vkfd9s3bnm8ogljdj4",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "vsw-mj7nu57symn2wmfselol8",
-      "networkInterface": "eni-mj70pwbh0kgud14ai61y",
+      "cspSubnetId": "vsw-mj7o5otesxobk45dfsv1d",
+      "networkInterface": "eni-mj70tz47n16tbhh6yqvu",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i1f2cdjuna1t4r4s00",
+      "cspSshKeyId": "d2isi2oeak5cr9n8jaig",
       "vmUserName": "cb-user",
-      "vmUserPassword": "!cu$dAf1i32d1j",
+      "vmUserPassword": "keA1i!i24$8sad",
       "addtionalDetails": [
         {
           "key": "ImageId",
@@ -3148,7 +3562,7 @@
         },
         {
           "key": "InstanceType",
-          "value": "ecs.e-c1m4.large"
+          "value": "ecs.r6.8xlarge"
         },
         {
           "key": "DeviceAvailable",
@@ -3172,7 +3586,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "d2i1f3cdjuna1t4r4s20"
+          "value": "d2isi48eak5cr9n8jam0"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -3192,7 +3606,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2025-08-19T06:20Z"
+          "value": "2025-08-20T13:09Z"
         },
         {
           "key": "ZoneId",
@@ -3200,7 +3614,7 @@
         },
         {
           "key": "InternetMaxBandwidthIn",
-          "value": "400"
+          "value": "10000"
         },
         {
           "key": "InternetChargeType",
@@ -3208,7 +3622,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj70pwbh0kgud1490tbqZ"
+          "value": "iZmj70tz47n16tbhhc32wpZ"
         },
         {
           "key": "Status",
@@ -3220,7 +3634,7 @@
         },
         {
           "key": "Cpu",
-          "value": "2"
+          "value": "32"
         },
         {
           "key": "SpotPriceLimit",
@@ -3240,7 +3654,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "63434865-547c-4ebc-a07b-2c685d4db22d"
+          "value": "a8b15d59-dbe4-48ba-8cbd-b57974f1cf12"
         },
         {
           "key": "RegionId",
@@ -3256,11 +3670,11 @@
         },
         {
           "key": "InstanceTypeFamily",
-          "value": "ecs.e"
+          "value": "ecs.r6"
         },
         {
           "key": "InstanceId",
-          "value": "i-mj70pwbh0kgud1490tbq"
+          "value": "i-mj70tz47n16tbhhc32wp"
         },
         {
           "key": "Recyclable",
@@ -3276,15 +3690,15 @@
         },
         {
           "key": "Memory",
-          "value": "8192"
+          "value": "262144"
         },
         {
           "key": "CreationTime",
-          "value": "2025-08-19T06:20Z"
+          "value": "2025-08-20T13:09Z"
         },
         {
           "key": "KeyPairName",
-          "value": "d2i1f2cdjuna1t4r4s00"
+          "value": "d2isi2oeak5cr9n8jaig"
         },
         {
           "key": "LocalStorageCapacity",
@@ -3308,7 +3722,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7c7jv71yc9hgpbapks]}"
+          "value": "{SecurityGroupId:[sg-mj703mxyyq8qhxlrxy1i]}"
         },
         {
           "key": "InnerIpAddress",
@@ -3316,7 +3730,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[8.220.214.219]}"
+          "value": "{IpAddress:[8.213.135.208]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -3332,7 +3746,7 @@
         },
         {
           "key": "CpuOptions",
-          "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:1,CoreFactor:0,Numa:ON,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+          "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:16,CoreFactor:0,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
         },
         {
           "key": "HibernationOptions",
@@ -3364,7 +3778,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7nu57symn2wmfselol8,VpcId:vpc-mj732c61jpttpajkf153r,NatIpAddress:,PrivateIpAddress:{IpAddress:[192.168.110.234]}}"
+          "value": "{VSwitchId:vsw-mj7o5otesxobk45dfsv1d,VpcId:vpc-mj7vkfd9s3bnm8ogljdj4,NatIpAddress:,PrivateIpAddress:{IpAddress:[192.168.110.80]}}"
         },
         {
           "key": "Tags",
@@ -3372,7 +3786,339 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:01:8d:a5,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70pwbh0kgud14ai61y,PrimaryIpAddress:192.168.110.234,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:192.168.110.234,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:02:1f:40,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70tz47n16tbhh6yqvu,PrimaryIpAddress:192.168.110.80,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:192.168.110.80,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+        },
+        {
+          "key": "OperationLocks",
+          "value": "{LockReason:[]}"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2isi48eak5cr9n8jal0",
+      "cspResourceName": "d2isi48eak5cr9n8jal0",
+      "cspResourceId": "i-mj7627lkja1bm4rojr1u",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.36,
+        "longitude": 126.78
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:11:48",
+      "label": {
+        "sys.connectionName": "alibaba-ap-northeast-2",
+        "sys.createdTime": "2025-08-20 13:11:48",
+        "sys.cspResourceId": "i-mj7627lkja1bm4rojr1u",
+        "sys.cspResourceName": "d2isi48eak5cr9n8jal0",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isi48eak5cr9n8jal0"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "ap-northeast-2",
+        "Zone": "ap-northeast-2a"
+      },
+      "publicIP": "8.220.214.219",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.79",
+      "privateDNS": "",
+      "rootDiskType": "cloud_essd",
+      "rootDiskSize": "40",
+      "rootDiskName": "",
+      "connectionName": "alibaba-ap-northeast-2",
+      "connectionConfig": {
+        "configName": "alibaba-ap-northeast-2",
+        "providerName": "alibaba",
+        "driverName": "alibaba-driver-v1.0.so",
+        "credentialName": "alibaba",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "alibaba-ap-northeast-2",
+        "regionZoneInfo": {
+          "assignedRegion": "ap-northeast-2",
+          "assignedZone": "ap-northeast-2a"
+        },
+        "regionDetail": {
+          "regionId": "ap-northeast-2",
+          "regionName": "ap-northeast-2",
+          "description": "South Korea (Seoul)",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "zones": [
+            "ap-northeast-2a",
+            "ap-northeast-2b"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "ecs.r6.8xlarge",
+      "cspSpecName": "ecs.r6.8xlarge",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
+      "cspImageName": "ubuntu_22_04_x64_20G_alibase_20250722.vhd",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "vpc-mj7vkfd9s3bnm8ogljdj4",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "vsw-mj7o5otesxobk45dfsv1d",
+      "networkInterface": "eni-mj7627lkja1bm4rwh3d1",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isi2oeak5cr9n8jaig",
+      "vmUserName": "cb-user",
+      "vmUserPassword": "keA1i!i24$8sad",
+      "addtionalDetails": [
+        {
+          "key": "ImageId",
+          "value": "ubuntu_22_04_x64_20G_alibase_20250722.vhd"
+        },
+        {
+          "key": "InstanceType",
+          "value": "ecs.r6.8xlarge"
+        },
+        {
+          "key": "DeviceAvailable",
+          "value": "true"
+        },
+        {
+          "key": "InstanceNetworkType",
+          "value": "vpc"
+        },
+        {
+          "key": "LocalStorageAmount",
+          "value": "0"
+        },
+        {
+          "key": "IsSpot",
+          "value": "false"
+        },
+        {
+          "key": "InstanceChargeType",
+          "value": "PostPaid"
+        },
+        {
+          "key": "InstanceName",
+          "value": "d2isi48eak5cr9n8jal0"
+        },
+        {
+          "key": "DeploymentSetGroupNo",
+          "value": "0"
+        },
+        {
+          "key": "GPUAmount",
+          "value": "0"
+        },
+        {
+          "key": "Connected",
+          "value": "false"
+        },
+        {
+          "key": "InvocationCount",
+          "value": "0"
+        },
+        {
+          "key": "StartTime",
+          "value": "2025-08-20T13:09Z"
+        },
+        {
+          "key": "ZoneId",
+          "value": "ap-northeast-2a"
+        },
+        {
+          "key": "InternetMaxBandwidthIn",
+          "value": "10000"
+        },
+        {
+          "key": "InternetChargeType",
+          "value": "PayByBandwidth"
+        },
+        {
+          "key": "HostName",
+          "value": "iZmj7627lkja1bm4rojr1uZ"
+        },
+        {
+          "key": "Status",
+          "value": "Running"
+        },
+        {
+          "key": "CPU",
+          "value": "0"
+        },
+        {
+          "key": "Cpu",
+          "value": "32"
+        },
+        {
+          "key": "SpotPriceLimit",
+          "value": "0.00"
+        },
+        {
+          "key": "OSName",
+          "value": "Ubuntu  22.04 64位"
+        },
+        {
+          "key": "InstanceOwnerId",
+          "value": "0"
+        },
+        {
+          "key": "OSNameEn",
+          "value": "Ubuntu  22.04 64 bit"
+        },
+        {
+          "key": "SerialNumber",
+          "value": "c4de2650-e657-4b39-8eae-c1ddb5bdc07e"
+        },
+        {
+          "key": "RegionId",
+          "value": "ap-northeast-2"
+        },
+        {
+          "key": "IoOptimized",
+          "value": "true"
+        },
+        {
+          "key": "InternetMaxBandwidthOut",
+          "value": "5"
+        },
+        {
+          "key": "InstanceTypeFamily",
+          "value": "ecs.r6"
+        },
+        {
+          "key": "InstanceId",
+          "value": "i-mj7627lkja1bm4rojr1u"
+        },
+        {
+          "key": "Recyclable",
+          "value": "false"
+        },
+        {
+          "key": "ExpiredTime",
+          "value": "2099-12-31T15:59Z"
+        },
+        {
+          "key": "OSType",
+          "value": "linux"
+        },
+        {
+          "key": "Memory",
+          "value": "262144"
+        },
+        {
+          "key": "CreationTime",
+          "value": "2025-08-20T13:09Z"
+        },
+        {
+          "key": "KeyPairName",
+          "value": "d2isi2oeak5cr9n8jaig"
+        },
+        {
+          "key": "LocalStorageCapacity",
+          "value": "0"
+        },
+        {
+          "key": "StoppedMode",
+          "value": "Not-applicable"
+        },
+        {
+          "key": "SpotStrategy",
+          "value": "NoSpot"
+        },
+        {
+          "key": "SpotDuration",
+          "value": "0"
+        },
+        {
+          "key": "DeletionProtection",
+          "value": "false"
+        },
+        {
+          "key": "SecurityGroupIds",
+          "value": "{SecurityGroupId:[sg-mj7627lkja1bm4rw0m6i]}"
+        },
+        {
+          "key": "InnerIpAddress",
+          "value": "{IpAddress:[]}"
+        },
+        {
+          "key": "PublicIpAddress",
+          "value": "{IpAddress:[8.220.214.219]}"
+        },
+        {
+          "key": "RdmaIpAddress",
+          "value": "{IpAddress:null}"
+        },
+        {
+          "key": "DedicatedHostAttribute",
+          "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+        },
+        {
+          "key": "EcsCapacityReservationAttr",
+          "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+        },
+        {
+          "key": "CpuOptions",
+          "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:16,CoreFactor:0,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+        },
+        {
+          "key": "HibernationOptions",
+          "value": "{Configured:false}"
+        },
+        {
+          "key": "DedicatedInstanceAttribute",
+          "value": "{Affinity:,Tenancy:}"
+        },
+        {
+          "key": "PrivateDnsNameOptions",
+          "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+        },
+        {
+          "key": "AdditionalInfo",
+          "value": "{EnableHighDensityMode:false}"
+        },
+        {
+          "key": "ImageOptions",
+          "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+        },
+        {
+          "key": "EipAddress",
+          "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+        },
+        {
+          "key": "MetadataOptions",
+          "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+        },
+        {
+          "key": "VpcAttributes",
+          "value": "{VSwitchId:vsw-mj7o5otesxobk45dfsv1d,VpcId:vpc-mj7vkfd9s3bnm8ogljdj4,NatIpAddress:,PrivateIpAddress:{IpAddress:[192.168.110.79]}}"
+        },
+        {
+          "key": "Tags",
+          "value": "{Tag:null}"
+        },
+        {
+          "key": "NetworkInterfaces",
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:02:1f:3f,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7627lkja1bm4rwh3d1,PrimaryIpAddress:192.168.110.79,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:192.168.110.79,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",

--- a/cmd/test-cli/testresult/beetle-test-results-aws.md
+++ b/cmd/test-cli/testresult/beetle-test-results-aws.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: v0.4.0 (76a9a3e)
+- CM-Beetle: v0.4.0 (b20b7be)
 - cm-model: v0.0.11
 - CB-Tumblebug: v0.11.3
 - CB-Spider: v0.11.1
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: August 19, 2025
-- Test Time: 14:50:38 KST
-- Test Execution: 2025-08-19 14:50:38 KST
+- Test Date: August 20, 2025
+- Test Time: 21:56:03 KST
+- Test Execution: 2025-08-20 21:56:03 KST
 
 ### Scenario
 
@@ -39,18 +39,18 @@
 
 | Test | Endpoint | Status | Duration | Details |
 |------|----------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 1.003s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 52.609s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 165ms | Pass |
+| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 1.37s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 2m55.915s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 198ms | Pass |
 | 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 65ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 169ms | Pass |
-| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 58.194s | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 176ms | Pass |
+| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 1m44.076s | Pass |
 
 **Overall Result**: 6/6 tests passed ✅
 
-**Total Duration**: 2m22.43552985s
+**Total Duration**: 5m12.005415179s
 
-*Test executed on August 19, 2025 at 14:50:38 KST (2025-08-19 14:50:38 KST) using CM-Beetle automated test CLI*
+*Test executed on August 20, 2025 at 21:56:03 KST (2025-08-20 21:56:03 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -86,6 +86,11 @@
             "ip": "192.168.110.254",
             "interfaceName": "br-ex",
             "machineId": "00a9f3d4-74b6-e811-906e-000ffee02d5c"
+          },
+          {
+            "ip": "192.168.110.254",
+            "interfaceName": "br-ex",
+            "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c"
           }
         ]
       },
@@ -106,9 +111,9 @@
         },
         "memory": {
           "type": "DDR4",
-          "totalSize": 8,
-          "available": 3,
-          "used": 5
+          "totalSize": 255,
+          "available": 146,
+          "used": 109
         },
         "rootDisk": {
           "label": "unknown",
@@ -1127,573 +1132,799 @@
             "protocol": "udp",
             "direction": "inbound",
             "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.5 LTS",
+          "version": "22.04.5 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "cm-web",
+        "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 2,
+          "cores": 18,
+          "threads": 36,
+          "maxSpeed": 3.7,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 255,
+          "available": 89,
+          "used": 166
+        },
+        "rootDisk": {
+          "label": "unknown",
+          "type": "HDD",
+          "totalSize": 1312,
+          "available": 1222,
+          "used": 23
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp24s0f0",
+            "macAddress": "b4:96:91:53:01:58",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "name": "enp24s0f1",
+            "macAddress": "b4:96:91:53:01:59",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "icmp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f0",
+            "macAddress": "b4:96:91:55:23:8c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "67",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "68",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno1np0",
+            "macAddress": "a4:bf:01:5a:b1:1b",
+            "ipv4CidrBlocks": [
+              "172.29.0.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "224.0.0.251/32",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f0",
+            "macAddress": "b4:96:91:53:01:6c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "239.255.255.250/32",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f1",
+            "macAddress": "b4:96:91:53:01:6d",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno2np1",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11c/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f1",
+            "macAddress": "b4:96:91:55:23:8e",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f0",
+            "macAddress": "b4:96:91:55:1e:04",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8086",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f1",
+            "macAddress": "b4:96:91:55:1e:06",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8888",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "ovs-system",
+            "macAddress": "6e:a8:ca:69:96:82",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9201",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-ex",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv4CidrBlocks": [
+              "192.168.110.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "2001::1000/64",
+              "fe80::7824:d2ff:fe2c:7330/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9202",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "genev_sys_6081",
+            "macAddress": "fa:e3:ea:20:21:0c",
+            "ipv6CidrBlocks": [
+              "fe80::2caf:1eff:fe7f:f78f/64"
+            ],
+            "mtu": 65000,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9203",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-int",
+            "macAddress": "ea:d0:e7:43:23:41",
+            "mtu": 1442
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9204",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap334a688a-76",
+            "macAddress": "fe:16:3e:52:10:6e",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe52:106e/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9206",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd4e69ee0-72",
+            "macAddress": "fe:16:3e:2c:59:7a",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2c:597a/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap50ee370b-a7",
+            "macAddress": "fe:16:3e:71:22:43",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe71:2243/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape46b2f03-d0",
+            "macAddress": "fe:16:3e:e2:ea:0f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fee2:ea0f/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap78b1ab69-36",
+            "macAddress": "fe:16:3e:14:65:fb",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe14:65fb/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape545ab95-ab",
+            "macAddress": "fe:16:3e:73:24:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe73:2490/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9001",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapadd1bc06-e8",
+            "macAddress": "fe:16:3e:26:ea:51",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe26:ea51/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "18080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd7ff0608-f0",
+            "macAddress": "fe:16:3e:2b:75:d6",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2b:75d6/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "13000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap26b9063f-c8",
+            "macAddress": "fe:16:3e:6c:c9:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe6c:c990/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9101",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap0d667e3a-e2",
+            "macAddress": "fe:16:3e:9f:7a:65",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe9f:7a65/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1df68fb5-f9",
+            "macAddress": "fe:16:3e:13:66:6f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe13:666f/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9106",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap3b66c516-59",
+            "macAddress": "fe:16:3e:77:e4:da",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe77:e4da/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9105",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap6f653485-7f",
+            "macAddress": "fe:16:3e:7d:85:5b",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe7d:855b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1479d90f-c0",
+            "macAddress": "02:b9:31:31:0d:fe",
+            "ipv6CidrBlocks": [
+              "fe80::b9:31ff:fe31:dfe/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9102",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap87daf3f9-0f",
+            "macAddress": "fe:16:3e:cb:97:79",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fecb:9779/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9103",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "172.29.0.0/24",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9104",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "192.168.110.0/24",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "5672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "1883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "4369",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15675",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "25672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "16567",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "destination": "fe80::/64",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "547",
-            "dstCIDR": "fe80::/10",
-            "dstPorts": "546",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::fb/128",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::f/128",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::1000/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::b9:31ff:fe31:dfe/128",
+            "interface": "tap1479d90f-c0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::2caf:1eff:fe7f:f78f/128",
+            "interface": "genev_sys_6081",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::7824:d2ff:fe2c:7330/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "deny"
+            "destination": "fe80::a6bf:1ff:fe5a:b11b/128",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::a6bf:1ff:fe5a:b11c/128",
+            "interface": "eno2np1",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe13:666f/128",
+            "interface": "tap1df68fb5-f9",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe14:65fb/128",
+            "interface": "tap78b1ab69-36",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe26:ea51/128",
+            "interface": "tapadd1bc06-e8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2b:75d6/128",
+            "interface": "tapd7ff0608-f0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2c:597a/128",
+            "interface": "tapd4e69ee0-72",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe52:106e/128",
+            "interface": "tap334a688a-76",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe6c:c990/128",
+            "interface": "tap26b9063f-c8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe71:2243/128",
+            "interface": "tap50ee370b-a7",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe73:2490/128",
+            "interface": "tape545ab95-ab",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe77:e4da/128",
+            "interface": "tap3b66c516-59",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe7d:855b/128",
+            "interface": "tap6f653485-7f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe9f:7a65/128",
+            "interface": "tap0d667e3a-e2",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fecb:9779/128",
+            "interface": "tap87daf3f9-0f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fee2:ea0f/128",
+            "interface": "tape46b2f03-d0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           }
         ],
         "os": {
@@ -1740,12 +1971,28 @@
         "label": null,
         "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
         "connectionName": "aws-ap-northeast-2",
-        "specId": "t2.large",
-        "imageId": "ami-0c20ca7e412876c67",
+        "specId": "r5a.8xlarge",
+        "imageId": "ami-0bf861cd35755d804",
         "vNetId": "mig-vnet-01",
         "subnetId": "mig-subnet-01",
         "securityGroupIds": [
           "mig-sg-01"
+        ],
+        "sshKeyId": "mig-sshkey-01",
+        "dataDiskIds": null
+      },
+      {
+        "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "subGroupSize": "",
+        "label": null,
+        "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "connectionName": "aws-ap-northeast-2",
+        "specId": "r5a.8xlarge",
+        "imageId": "ami-0bf861cd35755d804",
+        "vNetId": "mig-vnet-01",
+        "subnetId": "mig-subnet-01",
+        "securityGroupIds": [
+          "mig-sg-02"
         ],
         "sshKeyId": "mig-sshkey-01",
         "dataDiskIds": null
@@ -1783,20 +2030,20 @@
   },
   "targetVmSpecList": [
     {
-      "id": "aws+ap-northeast-2+t2.large",
-      "cspSpecName": "t2.large",
-      "name": "aws+ap-northeast-2+t2.large",
+      "id": "aws+ap-northeast-2+r5a.8xlarge",
+      "cspSpecName": "r5a.8xlarge",
+      "name": "aws+ap-northeast-2+r5a.8xlarge",
       "namespace": "system",
       "connectionName": "aws-ap-northeast-2",
       "providerName": "aws",
       "regionName": "ap-northeast-2",
       "infraType": "vm",
       "architecture": "x86_64",
-      "vCPU": 2,
-      "memoryGiB": 8,
+      "vCPU": 32,
+      "memoryGiB": 256,
       "diskSizeGB": -1,
-      "costPerHour": 0.1152,
-      "orderInFilteredResult": 4,
+      "costPerHour": 2.176,
+      "orderInFilteredResult": 1,
       "evaluationScore01": -1,
       "evaluationScore02": -1,
       "evaluationScore03": -1,
@@ -1805,7 +2052,7 @@
       "evaluationScore06": -1,
       "evaluationScore07": -1,
       "evaluationScore08": -1,
-      "evaluationScore09": 0.8847381,
+      "evaluationScore09": 1,
       "evaluationScore10": -1,
       "rootDiskType": "",
       "rootDiskSize": "-1",
@@ -1821,7 +2068,7 @@
         },
         {
           "key": "BurstablePerformanceSupported",
-          "value": "true"
+          "value": "false"
         },
         {
           "key": "CurrentGeneration",
@@ -1833,7 +2080,7 @@
         },
         {
           "key": "EbsInfo",
-          "value": "{EbsOptimizedInfo:null,EbsOptimizedSupport:unsupported,EncryptionSupport:supported,NvmeSupport:unsupported}"
+          "value": "{EbsOptimizedInfo:{BaselineBandwidthInMbps:4750,BaselineIops:20000,BaselineThroughputInMBps:593.75,MaximumBandwidthInMbps:4750,MaximumIops:20000,MaximumThroughputInMBps:593.75},EbsOptimizedSupport:default,EncryptionSupport:supported,NvmeSupport:required}"
         },
         {
           "key": "FreeTierEligible",
@@ -1841,11 +2088,11 @@
         },
         {
           "key": "HibernationSupported",
-          "value": "true"
+          "value": "false"
         },
         {
           "key": "Hypervisor",
-          "value": "xen"
+          "value": "nitro"
         },
         {
           "key": "InstanceStorageSupported",
@@ -1853,27 +2100,27 @@
         },
         {
           "key": "InstanceType",
-          "value": "t2.large"
+          "value": "r5a.8xlarge"
         },
         {
           "key": "MemoryInfo",
-          "value": "{SizeInMiB:8192}"
+          "value": "{SizeInMiB:262144}"
         },
         {
           "key": "NetworkInfo",
-          "value": "{DefaultNetworkCardIndex:0,EfaInfo:null,EfaSupported:false,EnaSupport:unsupported,Ipv4AddressesPerInterface:12,Ipv6AddressesPerInterface:12,Ipv6Supported:true,MaximumNetworkCards:1,MaximumNetworkInterfaces:3,NetworkCards:[{MaximumNetworkInterfaces:3,NetworkCardIndex:0,NetworkPerformance:Low to Moderate}],NetworkPerformance:Low to Moderate}"
+          "value": "{DefaultNetworkCardIndex:0,EfaInfo:null,EfaSupported:false,EnaSupport:required,Ipv4AddressesPerInterface:30,Ipv6AddressesPerInterface:30,Ipv6Supported:true,MaximumNetworkCards:1,MaximumNetworkInterfaces:8,NetworkCards:[{MaximumNetworkInterfaces:8,NetworkCardIndex:0,NetworkPerformance:Up to 10 Gigabit}],NetworkPerformance:Up to 10 Gigabit}"
         },
         {
           "key": "PlacementGroupInfo",
-          "value": "{SupportedStrategies:[partition,spread]}"
+          "value": "{SupportedStrategies:[cluster,partition,spread]}"
         },
         {
           "key": "ProcessorInfo",
-          "value": "{SupportedArchitectures:[x86_64],SustainedClockSpeedInGhz:2.3}"
+          "value": "{SupportedArchitectures:[x86_64],SustainedClockSpeedInGhz:2.5}"
         },
         {
           "key": "SupportedBootModes",
-          "value": "legacy-bios"
+          "value": "legacy-bios; uefi"
         },
         {
           "key": "SupportedRootDeviceTypes",
@@ -1889,7 +2136,7 @@
         },
         {
           "key": "VCpuInfo",
-          "value": "{DefaultCores:2,DefaultThreadsPerCore:1,DefaultVCpus:2,ValidCores:null,ValidThreadsPerCore:null}"
+          "value": "{DefaultCores:16,DefaultThreadsPerCore:2,DefaultVCpus:32,ValidCores:[4,6,8,10,12,14,16],ValidThreadsPerCore:[1,2]}"
         }
       ]
     }
@@ -1898,19 +2145,19 @@
     {
       "namespace": "system",
       "providerName": "aws",
-      "cspImageName": "ami-0c20ca7e412876c67",
+      "cspImageName": "ami-0bf861cd35755d804",
       "regionList": [
         "ap-northeast-2"
       ],
-      "id": "aws+ami-0c20ca7e412876c67",
-      "name": "aws+ami-0c20ca7e412876c67",
+      "id": "aws+ami-0bf861cd35755d804",
+      "name": "aws+ami-0bf861cd35755d804",
       "connectionName": "aws-ap-northeast-2",
-      "fetchedTime": "2025.08.18 10:53:45 Mon",
-      "creationDate": "2025-08-03T18:43:13.000Z",
+      "fetchedTime": "2025.08.19 12:21:18 Tue",
+      "creationDate": "2025-08-03T18:40:37.000Z",
       "osType": "Ubuntu 22.04",
       "osArchitecture": "x86_64",
       "osPlatform": "Linux/UNIX",
-      "osDistribution": "ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64-minimal-20250803",
+      "osDistribution": "ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20250803",
       "osDiskType": "ebs",
       "osDiskSizeGB": -1,
       "imageStatus": "Available",
@@ -1929,15 +2176,15 @@
         },
         {
           "key": "CreationDate",
-          "value": "2025-08-03T18:43:13.000Z"
+          "value": "2025-08-03T18:40:37.000Z"
         },
         {
           "key": "DeprecationTime",
-          "value": "2027-08-03T18:43:13.000Z"
+          "value": "2027-08-03T18:40:37.000Z"
         },
         {
           "key": "Description",
-          "value": "Canonical, Ubuntu Minimal, 22.04, amd64 jammy image"
+          "value": "Canonical, Ubuntu Minimal, 22.04, UNSUPPORTED daily amd64 jammy image"
         },
         {
           "key": "EnaSupport",
@@ -1949,11 +2196,11 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-0c20ca7e412876c67"
+          "value": "ami-0bf861cd35755d804"
         },
         {
           "key": "ImageLocation",
-          "value": "amazon/ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64-minimal-20250803"
+          "value": "amazon/ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20250803"
         },
         {
           "key": "ImageOwnerAlias",
@@ -1965,7 +2212,7 @@
         },
         {
           "key": "Name",
-          "value": "ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64-minimal-20250803"
+          "value": "ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20250803"
         },
         {
           "key": "OwnerId",
@@ -2004,7 +2251,7 @@
           "value": "hvm"
         }
       ],
-      "description": "Canonical, Ubuntu Minimal, 22.04, amd64 jammy image"
+      "description": "Canonical, Ubuntu Minimal, 22.04, UNSUPPORTED daily amd64 jammy image"
     }
   ],
   "targetSecurityGroupList": [
@@ -2031,257 +2278,20 @@
           "Protocol": "udp",
           "Direction": "inbound",
           "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "",
-          "Protocol": "icmp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "68",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "5353",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1900",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
+        }
+      ],
+      "cspResourceId": ""
+    },
+    {
+      "name": "mig-sg-02",
+      "connectionName": "aws-ap-northeast-2",
+      "vNetId": "mig-vnet-01",
+      "description": "Recommended security group for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "firewallRules": [
         {
           "Ports": "22",
           "Protocol": "tcp",
           "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "80",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "8086",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8888",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9201",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9202",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9203",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9204",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9206",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9001",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "18080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "13000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9101",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9106",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9105",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9102",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9103",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9104",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "5672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "4369",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15675",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "25672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "16567",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "outbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "outbound",
           "CIDR": "0.0.0.0/0"
         }
       ],
@@ -2316,13 +2326,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i11gsdjuna1t4r4rh0",
+  "uid": "d2isbuoeak5cr9n8ja80",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2343,7 +2353,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i11gsdjuna1t4r4rh0"
+    "sys.uid": "d2isbuoeak5cr9n8ja80"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2351,12 +2361,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i11gsdjuna1t4r4ri0",
-      "cspResourceName": "d2i11gsdjuna1t4r4ri0",
-      "cspResourceId": "i-077bdd869e30bdb45",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isbuoeak5cr9n8jaa0",
+      "cspResourceName": "d2isbuoeak5cr9n8jaa0",
+      "cspResourceId": "i-056e91747cc733d87",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "South Korea (Seoul)",
         "latitude": 37.36,
@@ -2368,31 +2378,31 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 05:51:34",
+      "createdTime": "2025-08-20 12:57:04",
       "label": {
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2025-08-19 05:51:34",
-        "sys.cspResourceId": "i-077bdd869e30bdb45",
-        "sys.cspResourceName": "d2i11gsdjuna1t4r4ri0",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 12:57:04",
+        "sys.cspResourceId": "i-056e91747cc733d87",
+        "sys.cspResourceName": "d2isbuoeak5cr9n8jaa0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i11gsdjuna1t4r4ri0"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isbuoeak5cr9n8jaa0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "ap-northeast-2",
         "Zone": "ap-northeast-2a"
       },
-      "publicIP": "43.201.45.108",
+      "publicIP": "54.180.140.157",
       "sshPort": "22",
       "publicDNS": "",
-      "privateIP": "192.168.110.168",
-      "privateDNS": "ip-192-168-110-168.ap-northeast-2.compute.internal",
+      "privateIP": "192.168.110.135",
+      "privateDNS": "ip-192-168-110-135.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": "8",
       "rootDiskName": "",
@@ -2427,21 +2437,21 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "t2.large",
-      "cspSpecName": "t2.large",
-      "imageId": "ami-0c20ca7e412876c67",
-      "cspImageName": "ami-0c20ca7e412876c67",
+      "specId": "r5a.8xlarge",
+      "cspSpecName": "r5a.8xlarge",
+      "imageId": "ami-0bf861cd35755d804",
+      "cspImageName": "ami-0bf861cd35755d804",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "vpc-0dae9afaf7e47473c",
+      "cspVNetId": "vpc-0ec2535adc71f1295",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "subnet-0245f2d500d4de745",
-      "networkInterface": "eni-attach-03b95dcbe244695ac",
+      "cspSubnetId": "subnet-088801d463fae4cd6",
+      "networkInterface": "eni-attach-09721a89c0d3eb97f",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i11fcdjuna1t4r4rg0",
+      "cspSshKeyId": "d2isbt0eak5cr9n8ja6g",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
@@ -2454,7 +2464,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2025-08-19T05:51:04Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0bfdd1128da8162a3}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2025-08-20T12:56:47Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-099c132962e4ee7fb}}"
         },
         {
           "key": "BootMode",
@@ -2466,11 +2476,11 @@
         },
         {
           "key": "ClientToken",
-          "value": "CBDC9DDB-FB24-4A1F-BF78-F1243ECAEB5F"
+          "value": "B8A1DCDC-1513-4A52-B3E7-974913FE97BC"
         },
         {
           "key": "CpuOptions",
-          "value": "{CoreCount:2,ThreadsPerCore:1}"
+          "value": "{CoreCount:16,ThreadsPerCore:2}"
         },
         {
           "key": "EbsOptimized",
@@ -2494,23 +2504,23 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-0c20ca7e412876c67"
+          "value": "ami-0bf861cd35755d804"
         },
         {
           "key": "InstanceId",
-          "value": "i-077bdd869e30bdb45"
+          "value": "i-056e91747cc733d87"
         },
         {
           "key": "InstanceType",
-          "value": "t2.large"
+          "value": "r5a.8xlarge"
         },
         {
           "key": "KeyName",
-          "value": "d2i11fcdjuna1t4r4rg0"
+          "value": "d2isbt0eak5cr9n8ja6g"
         },
         {
           "key": "LaunchTime",
-          "value": "2025-08-19T05:51:04Z"
+          "value": "2025-08-20T12:56:46Z"
         },
         {
           "key": "MetadataOptions",
@@ -2522,7 +2532,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.45.108},Attachment:{AttachTime:2025-08-19T05:51:04Z,AttachmentId:eni-attach-03b95dcbe244695ac,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-06fbbbfbc834f66ec,GroupName:d2i11g4djuna1t4r4rgg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:ac:a9:53:d0:77,NetworkInterfaceId:eni-0d629209bd4e74f80,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:192.168.110.168,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.45.108},Primary:true,PrivateDnsName:null,PrivateIpAddress:192.168.110.168}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0245f2d500d4de745,VpcId:vpc-0dae9afaf7e47473c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.140.157},Attachment:{AttachTime:2025-08-20T12:56:46Z,AttachmentId:eni-attach-09721a89c0d3eb97f,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-00e7bad0b8c70e957,GroupName:d2isbu0eak5cr9n8ja7g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f3:30:8a:09:ad,NetworkInterfaceId:eni-026a74881876fecc9,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:192.168.110.135,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.140.157},Primary:true,PrivateDnsName:null,PrivateIpAddress:192.168.110.135}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-088801d463fae4cd6,VpcId:vpc-0ec2535adc71f1295}"
         },
         {
           "key": "Placement",
@@ -2530,15 +2540,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-192-168-110-168.ap-northeast-2.compute.internal"
+          "value": "ip-192-168-110-135.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "192.168.110.168"
+          "value": "192.168.110.135"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.201.45.108"
+          "value": "54.180.140.157"
         },
         {
           "key": "RootDeviceName",
@@ -2550,7 +2560,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-06fbbbfbc834f66ec,GroupName:d2i11g4djuna1t4r4rgg}"
+          "value": "{GroupId:sg-00e7bad0b8c70e957,GroupName:d2isbu0eak5cr9n8ja7g}"
         },
         {
           "key": "SourceDestCheck",
@@ -2562,11 +2572,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0245f2d500d4de745"
+          "value": "subnet-088801d463fae4cd6"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:d2i11gsdjuna1t4r4ri0}"
+          "value": "{Key:Name,Value:d2isbuoeak5cr9n8jaa0}"
         },
         {
           "key": "VirtualizationType",
@@ -2574,7 +2584,236 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0dae9afaf7e47473c"
+          "value": "vpc-0ec2535adc71f1295"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2isbuoeak5cr9n8ja90",
+      "cspResourceName": "d2isbuoeak5cr9n8ja90",
+      "cspResourceId": "i-086f91ce28dfc1787",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.36,
+        "longitude": 126.78
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 12:58:59",
+      "label": {
+        "sys.connectionName": "aws-ap-northeast-2",
+        "sys.createdTime": "2025-08-20 12:58:59",
+        "sys.cspResourceId": "i-086f91ce28dfc1787",
+        "sys.cspResourceName": "d2isbuoeak5cr9n8ja90",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isbuoeak5cr9n8ja90"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "ap-northeast-2",
+        "Zone": "ap-northeast-2a"
+      },
+      "publicIP": "3.36.88.162",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.215",
+      "privateDNS": "ip-192-168-110-215.ap-northeast-2.compute.internal",
+      "rootDiskType": "gp2",
+      "rootDiskSize": "8",
+      "rootDiskName": "",
+      "connectionName": "aws-ap-northeast-2",
+      "connectionConfig": {
+        "configName": "aws-ap-northeast-2",
+        "providerName": "aws",
+        "driverName": "aws-driver-v1.0.so",
+        "credentialName": "aws",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "aws-ap-northeast-2",
+        "regionZoneInfo": {
+          "assignedRegion": "ap-northeast-2",
+          "assignedZone": "ap-northeast-2a"
+        },
+        "regionDetail": {
+          "regionId": "ap-northeast-2",
+          "regionName": "ap-northeast-2",
+          "description": "Asia Pacific (Seoul)",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "zones": [
+            "ap-northeast-2a",
+            "ap-northeast-2b",
+            "ap-northeast-2c",
+            "ap-northeast-2d"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "r5a.8xlarge",
+      "cspSpecName": "r5a.8xlarge",
+      "imageId": "ami-0bf861cd35755d804",
+      "cspImageName": "ami-0bf861cd35755d804",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "vpc-0ec2535adc71f1295",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "subnet-088801d463fae4cd6",
+      "networkInterface": "eni-attach-059cd6831f9f6a9e5",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isbt0eak5cr9n8ja6g",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "AmiLaunchIndex",
+          "value": "0"
+        },
+        {
+          "key": "Architecture",
+          "value": "x86_64"
+        },
+        {
+          "key": "BlockDeviceMappings",
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2025-08-20T12:56:46Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-03321f2afeacee767}}"
+        },
+        {
+          "key": "BootMode",
+          "value": "uefi-preferred"
+        },
+        {
+          "key": "CapacityReservationSpecification",
+          "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+        },
+        {
+          "key": "ClientToken",
+          "value": "D672C7E3-B1E5-41C4-8D50-BC5A83965EB1"
+        },
+        {
+          "key": "CpuOptions",
+          "value": "{CoreCount:16,ThreadsPerCore:2}"
+        },
+        {
+          "key": "EbsOptimized",
+          "value": "false"
+        },
+        {
+          "key": "EnaSupport",
+          "value": "true"
+        },
+        {
+          "key": "EnclaveOptions",
+          "value": "{Enabled:false}"
+        },
+        {
+          "key": "HibernationOptions",
+          "value": "{Configured:false}"
+        },
+        {
+          "key": "Hypervisor",
+          "value": "xen"
+        },
+        {
+          "key": "ImageId",
+          "value": "ami-0bf861cd35755d804"
+        },
+        {
+          "key": "InstanceId",
+          "value": "i-086f91ce28dfc1787"
+        },
+        {
+          "key": "InstanceType",
+          "value": "r5a.8xlarge"
+        },
+        {
+          "key": "KeyName",
+          "value": "d2isbt0eak5cr9n8ja6g"
+        },
+        {
+          "key": "LaunchTime",
+          "value": "2025-08-20T12:56:45Z"
+        },
+        {
+          "key": "MetadataOptions",
+          "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+        },
+        {
+          "key": "Monitoring",
+          "value": "{State:disabled}"
+        },
+        {
+          "key": "NetworkInterfaces",
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.88.162},Attachment:{AttachTime:2025-08-20T12:56:45Z,AttachmentId:eni-attach-059cd6831f9f6a9e5,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0957267befef3a8a9,GroupName:d2isbtgeak5cr9n8ja70}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:87:f0:fc:76:11,NetworkInterfaceId:eni-0362468597a8f91ca,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:192.168.110.215,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.88.162},Primary:true,PrivateDnsName:null,PrivateIpAddress:192.168.110.215}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-088801d463fae4cd6,VpcId:vpc-0ec2535adc71f1295}"
+        },
+        {
+          "key": "Placement",
+          "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+        },
+        {
+          "key": "PrivateDnsName",
+          "value": "ip-192-168-110-215.ap-northeast-2.compute.internal"
+        },
+        {
+          "key": "PrivateIpAddress",
+          "value": "192.168.110.215"
+        },
+        {
+          "key": "PublicIpAddress",
+          "value": "3.36.88.162"
+        },
+        {
+          "key": "RootDeviceName",
+          "value": "/dev/sda1"
+        },
+        {
+          "key": "RootDeviceType",
+          "value": "ebs"
+        },
+        {
+          "key": "SecurityGroups",
+          "value": "{GroupId:sg-0957267befef3a8a9,GroupName:d2isbtgeak5cr9n8ja70}"
+        },
+        {
+          "key": "SourceDestCheck",
+          "value": "true"
+        },
+        {
+          "key": "State",
+          "value": "{Code:16,Name:running}"
+        },
+        {
+          "key": "SubnetId",
+          "value": "subnet-088801d463fae4cd6"
+        },
+        {
+          "key": "Tags",
+          "value": "{Key:Name,Value:d2isbuoeak5cr9n8ja90}"
+        },
+        {
+          "key": "VirtualizationType",
+          "value": "hvm"
+        },
+        {
+          "key": "VpcId",
+          "value": "vpc-0ec2535adc71f1295"
         }
       ]
     }
@@ -2614,13 +2853,13 @@
     {
       "resourceType": "mci",
       "id": "mmci01",
-      "uid": "d2i11gsdjuna1t4r4rh0",
+      "uid": "d2isbuoeak5cr9n8ja80",
       "name": "mmci01",
-      "status": "Running:1 (R:1/1)",
+      "status": "Running:2 (R:2/2)",
       "statusCount": {
-        "countTotal": 1,
+        "countTotal": 2,
         "countCreating": 0,
-        "countRunning": 1,
+        "countRunning": 2,
         "countFailed": 0,
         "countSuspended": 0,
         "countRebooting": 0,
@@ -2641,8 +2880,80 @@
       "vm": [
         {
           "resourceType": "mci",
+          "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+          "uid": "d2isbuoeak5cr9n8ja80",
+          "name": "mmci01",
+          "subGroupId": "",
+          "location": {
+            "display": "",
+            "latitude": 0,
+            "longitude": 0
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "a recommended multi-cloud infrastructure",
+          "region": {
+            "Region": "",
+            "Zone": ""
+          },
+          "publicIP": "",
+          "sshPort": "",
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": "",
+          "rootDiskName": "",
+          "connectionName": "",
+          "connectionConfig": {
+            "configName": "",
+            "providerName": "",
+            "driverName": "",
+            "credentialName": "",
+            "credentialHolder": "",
+            "regionZoneInfoName": "",
+            "regionZoneInfo": {
+              "assignedRegion": "",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "",
+              "regionName": "",
+              "description": "",
+              "location": {
+                "display": "",
+                "latitude": 0,
+                "longitude": 0
+              },
+              "zones": null
+            },
+            "regionRepresentative": false,
+            "verified": false
+          },
+          "specId": "",
+          "cspSpecName": "",
+          "imageId": "",
+          "cspImageName": "",
+          "vNetId": "",
+          "cspVNetId": "",
+          "subnetId": "",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": null,
+          "dataDiskIds": null,
+          "sshKeyId": "",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "mci",
           "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-          "uid": "d2i11gsdjuna1t4r4rh0",
+          "uid": "d2isbuoeak5cr9n8ja80",
           "name": "mmci01",
           "subGroupId": "",
           "location": {
@@ -2774,13 +3085,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i11gsdjuna1t4r4rh0",
+  "uid": "d2isbuoeak5cr9n8ja80",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2801,7 +3112,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i11gsdjuna1t4r4rh0"
+    "sys.uid": "d2isbuoeak5cr9n8ja80"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2809,12 +3120,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i11gsdjuna1t4r4ri0",
-      "cspResourceName": "d2i11gsdjuna1t4r4ri0",
-      "cspResourceId": "i-077bdd869e30bdb45",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isbuoeak5cr9n8jaa0",
+      "cspResourceName": "d2isbuoeak5cr9n8jaa0",
+      "cspResourceId": "i-056e91747cc733d87",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "South Korea (Seoul)",
         "latitude": 37.36,
@@ -2826,31 +3137,31 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 05:51:34",
+      "createdTime": "2025-08-20 12:57:04",
       "label": {
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2025-08-19 05:51:34",
-        "sys.cspResourceId": "i-077bdd869e30bdb45",
-        "sys.cspResourceName": "d2i11gsdjuna1t4r4ri0",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 12:57:04",
+        "sys.cspResourceId": "i-056e91747cc733d87",
+        "sys.cspResourceName": "d2isbuoeak5cr9n8jaa0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i11gsdjuna1t4r4ri0"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isbuoeak5cr9n8jaa0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "ap-northeast-2",
         "Zone": "ap-northeast-2a"
       },
-      "publicIP": "43.201.45.108",
+      "publicIP": "54.180.140.157",
       "sshPort": "22",
       "publicDNS": "",
-      "privateIP": "192.168.110.168",
-      "privateDNS": "ip-192-168-110-168.ap-northeast-2.compute.internal",
+      "privateIP": "192.168.110.135",
+      "privateDNS": "ip-192-168-110-135.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": "8",
       "rootDiskName": "",
@@ -2885,21 +3196,21 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "t2.large",
-      "cspSpecName": "t2.large",
-      "imageId": "ami-0c20ca7e412876c67",
-      "cspImageName": "ami-0c20ca7e412876c67",
+      "specId": "r5a.8xlarge",
+      "cspSpecName": "r5a.8xlarge",
+      "imageId": "ami-0bf861cd35755d804",
+      "cspImageName": "ami-0bf861cd35755d804",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "vpc-0dae9afaf7e47473c",
+      "cspVNetId": "vpc-0ec2535adc71f1295",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "subnet-0245f2d500d4de745",
-      "networkInterface": "eni-attach-03b95dcbe244695ac",
+      "cspSubnetId": "subnet-088801d463fae4cd6",
+      "networkInterface": "eni-attach-09721a89c0d3eb97f",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i11fcdjuna1t4r4rg0",
+      "cspSshKeyId": "d2isbt0eak5cr9n8ja6g",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
@@ -2912,7 +3223,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2025-08-19T05:51:04Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0bfdd1128da8162a3}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2025-08-20T12:56:47Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-099c132962e4ee7fb}}"
         },
         {
           "key": "BootMode",
@@ -2924,11 +3235,11 @@
         },
         {
           "key": "ClientToken",
-          "value": "CBDC9DDB-FB24-4A1F-BF78-F1243ECAEB5F"
+          "value": "B8A1DCDC-1513-4A52-B3E7-974913FE97BC"
         },
         {
           "key": "CpuOptions",
-          "value": "{CoreCount:2,ThreadsPerCore:1}"
+          "value": "{CoreCount:16,ThreadsPerCore:2}"
         },
         {
           "key": "EbsOptimized",
@@ -2952,23 +3263,23 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-0c20ca7e412876c67"
+          "value": "ami-0bf861cd35755d804"
         },
         {
           "key": "InstanceId",
-          "value": "i-077bdd869e30bdb45"
+          "value": "i-056e91747cc733d87"
         },
         {
           "key": "InstanceType",
-          "value": "t2.large"
+          "value": "r5a.8xlarge"
         },
         {
           "key": "KeyName",
-          "value": "d2i11fcdjuna1t4r4rg0"
+          "value": "d2isbt0eak5cr9n8ja6g"
         },
         {
           "key": "LaunchTime",
-          "value": "2025-08-19T05:51:04Z"
+          "value": "2025-08-20T12:56:46Z"
         },
         {
           "key": "MetadataOptions",
@@ -2980,7 +3291,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.45.108},Attachment:{AttachTime:2025-08-19T05:51:04Z,AttachmentId:eni-attach-03b95dcbe244695ac,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-06fbbbfbc834f66ec,GroupName:d2i11g4djuna1t4r4rgg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:ac:a9:53:d0:77,NetworkInterfaceId:eni-0d629209bd4e74f80,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:192.168.110.168,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.45.108},Primary:true,PrivateDnsName:null,PrivateIpAddress:192.168.110.168}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0245f2d500d4de745,VpcId:vpc-0dae9afaf7e47473c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.140.157},Attachment:{AttachTime:2025-08-20T12:56:46Z,AttachmentId:eni-attach-09721a89c0d3eb97f,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-00e7bad0b8c70e957,GroupName:d2isbu0eak5cr9n8ja7g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f3:30:8a:09:ad,NetworkInterfaceId:eni-026a74881876fecc9,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:192.168.110.135,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.140.157},Primary:true,PrivateDnsName:null,PrivateIpAddress:192.168.110.135}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-088801d463fae4cd6,VpcId:vpc-0ec2535adc71f1295}"
         },
         {
           "key": "Placement",
@@ -2988,15 +3299,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-192-168-110-168.ap-northeast-2.compute.internal"
+          "value": "ip-192-168-110-135.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "192.168.110.168"
+          "value": "192.168.110.135"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.201.45.108"
+          "value": "54.180.140.157"
         },
         {
           "key": "RootDeviceName",
@@ -3008,7 +3319,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-06fbbbfbc834f66ec,GroupName:d2i11g4djuna1t4r4rgg}"
+          "value": "{GroupId:sg-00e7bad0b8c70e957,GroupName:d2isbu0eak5cr9n8ja7g}"
         },
         {
           "key": "SourceDestCheck",
@@ -3020,11 +3331,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0245f2d500d4de745"
+          "value": "subnet-088801d463fae4cd6"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:d2i11gsdjuna1t4r4ri0}"
+          "value": "{Key:Name,Value:d2isbuoeak5cr9n8jaa0}"
         },
         {
           "key": "VirtualizationType",
@@ -3032,7 +3343,236 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0dae9afaf7e47473c"
+          "value": "vpc-0ec2535adc71f1295"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2isbuoeak5cr9n8ja90",
+      "cspResourceName": "d2isbuoeak5cr9n8ja90",
+      "cspResourceId": "i-086f91ce28dfc1787",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.36,
+        "longitude": 126.78
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 12:58:59",
+      "label": {
+        "sys.connectionName": "aws-ap-northeast-2",
+        "sys.createdTime": "2025-08-20 12:58:59",
+        "sys.cspResourceId": "i-086f91ce28dfc1787",
+        "sys.cspResourceName": "d2isbuoeak5cr9n8ja90",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isbuoeak5cr9n8ja90"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "ap-northeast-2",
+        "Zone": "ap-northeast-2a"
+      },
+      "publicIP": "3.36.88.162",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.215",
+      "privateDNS": "ip-192-168-110-215.ap-northeast-2.compute.internal",
+      "rootDiskType": "gp2",
+      "rootDiskSize": "8",
+      "rootDiskName": "",
+      "connectionName": "aws-ap-northeast-2",
+      "connectionConfig": {
+        "configName": "aws-ap-northeast-2",
+        "providerName": "aws",
+        "driverName": "aws-driver-v1.0.so",
+        "credentialName": "aws",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "aws-ap-northeast-2",
+        "regionZoneInfo": {
+          "assignedRegion": "ap-northeast-2",
+          "assignedZone": "ap-northeast-2a"
+        },
+        "regionDetail": {
+          "regionId": "ap-northeast-2",
+          "regionName": "ap-northeast-2",
+          "description": "Asia Pacific (Seoul)",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "zones": [
+            "ap-northeast-2a",
+            "ap-northeast-2b",
+            "ap-northeast-2c",
+            "ap-northeast-2d"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "r5a.8xlarge",
+      "cspSpecName": "r5a.8xlarge",
+      "imageId": "ami-0bf861cd35755d804",
+      "cspImageName": "ami-0bf861cd35755d804",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "vpc-0ec2535adc71f1295",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "subnet-088801d463fae4cd6",
+      "networkInterface": "eni-attach-059cd6831f9f6a9e5",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isbt0eak5cr9n8ja6g",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "AmiLaunchIndex",
+          "value": "0"
+        },
+        {
+          "key": "Architecture",
+          "value": "x86_64"
+        },
+        {
+          "key": "BlockDeviceMappings",
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2025-08-20T12:56:46Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-03321f2afeacee767}}"
+        },
+        {
+          "key": "BootMode",
+          "value": "uefi-preferred"
+        },
+        {
+          "key": "CapacityReservationSpecification",
+          "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+        },
+        {
+          "key": "ClientToken",
+          "value": "D672C7E3-B1E5-41C4-8D50-BC5A83965EB1"
+        },
+        {
+          "key": "CpuOptions",
+          "value": "{CoreCount:16,ThreadsPerCore:2}"
+        },
+        {
+          "key": "EbsOptimized",
+          "value": "false"
+        },
+        {
+          "key": "EnaSupport",
+          "value": "true"
+        },
+        {
+          "key": "EnclaveOptions",
+          "value": "{Enabled:false}"
+        },
+        {
+          "key": "HibernationOptions",
+          "value": "{Configured:false}"
+        },
+        {
+          "key": "Hypervisor",
+          "value": "xen"
+        },
+        {
+          "key": "ImageId",
+          "value": "ami-0bf861cd35755d804"
+        },
+        {
+          "key": "InstanceId",
+          "value": "i-086f91ce28dfc1787"
+        },
+        {
+          "key": "InstanceType",
+          "value": "r5a.8xlarge"
+        },
+        {
+          "key": "KeyName",
+          "value": "d2isbt0eak5cr9n8ja6g"
+        },
+        {
+          "key": "LaunchTime",
+          "value": "2025-08-20T12:56:45Z"
+        },
+        {
+          "key": "MetadataOptions",
+          "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+        },
+        {
+          "key": "Monitoring",
+          "value": "{State:disabled}"
+        },
+        {
+          "key": "NetworkInterfaces",
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.88.162},Attachment:{AttachTime:2025-08-20T12:56:45Z,AttachmentId:eni-attach-059cd6831f9f6a9e5,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0957267befef3a8a9,GroupName:d2isbtgeak5cr9n8ja70}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:87:f0:fc:76:11,NetworkInterfaceId:eni-0362468597a8f91ca,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:192.168.110.215,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.88.162},Primary:true,PrivateDnsName:null,PrivateIpAddress:192.168.110.215}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-088801d463fae4cd6,VpcId:vpc-0ec2535adc71f1295}"
+        },
+        {
+          "key": "Placement",
+          "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+        },
+        {
+          "key": "PrivateDnsName",
+          "value": "ip-192-168-110-215.ap-northeast-2.compute.internal"
+        },
+        {
+          "key": "PrivateIpAddress",
+          "value": "192.168.110.215"
+        },
+        {
+          "key": "PublicIpAddress",
+          "value": "3.36.88.162"
+        },
+        {
+          "key": "RootDeviceName",
+          "value": "/dev/sda1"
+        },
+        {
+          "key": "RootDeviceType",
+          "value": "ebs"
+        },
+        {
+          "key": "SecurityGroups",
+          "value": "{GroupId:sg-0957267befef3a8a9,GroupName:d2isbtgeak5cr9n8ja70}"
+        },
+        {
+          "key": "SourceDestCheck",
+          "value": "true"
+        },
+        {
+          "key": "State",
+          "value": "{Code:16,Name:running}"
+        },
+        {
+          "key": "SubnetId",
+          "value": "subnet-088801d463fae4cd6"
+        },
+        {
+          "key": "Tags",
+          "value": "{Key:Name,Value:d2isbuoeak5cr9n8ja90}"
+        },
+        {
+          "key": "VirtualizationType",
+          "value": "hvm"
+        },
+        {
+          "key": "VpcId",
+          "value": "vpc-0ec2535adc71f1295"
         }
       ]
     }

--- a/cmd/test-cli/testresult/beetle-test-results-azure.md
+++ b/cmd/test-cli/testresult/beetle-test-results-azure.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: v0.4.0 (76a9a3e)
+- CM-Beetle: v0.4.0 (81e984e)
 - cm-model: v0.0.11
 - CB-Tumblebug: v0.11.3
 - CB-Spider: v0.11.1
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: August 19, 2025
-- Test Time: 14:52:58 KST
-- Test Execution: 2025-08-19 14:52:58 KST
+- Test Date: August 20, 2025
+- Test Time: 22:28:35 KST
+- Test Execution: 2025-08-20 22:28:35 KST
 
 ### Scenario
 
@@ -39,18 +39,18 @@
 
 | Test | Endpoint | Status | Duration | Details |
 |------|----------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 257ms | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 2m30.309s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 2.391s | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 64ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 2.377s | Pass |
-| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 2m0.031s | Pass |
+| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 349ms | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 5m42.069s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 2.748s | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 58ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 2.637s | Pass |
+| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 2m13.054s | Pass |
 
 **Overall Result**: 6/6 tests passed ✅
 
-**Total Duration**: 5m5.675230405s
+**Total Duration**: 8m31.115350176s
 
-*Test executed on August 19, 2025 at 14:52:58 KST (2025-08-19 14:52:58 KST) using CM-Beetle automated test CLI*
+*Test executed on August 20, 2025 at 22:28:35 KST (2025-08-20 22:28:35 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -86,6 +86,11 @@
             "ip": "192.168.110.254",
             "interfaceName": "br-ex",
             "machineId": "00a9f3d4-74b6-e811-906e-000ffee02d5c"
+          },
+          {
+            "ip": "192.168.110.254",
+            "interfaceName": "br-ex",
+            "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c"
           }
         ]
       },
@@ -106,9 +111,9 @@
         },
         "memory": {
           "type": "DDR4",
-          "totalSize": 8,
-          "available": 3,
-          "used": 5
+          "totalSize": 64,
+          "available": 30,
+          "used": 34
         },
         "rootDisk": {
           "label": "unknown",
@@ -1127,573 +1132,799 @@
             "protocol": "udp",
             "direction": "inbound",
             "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.5 LTS",
+          "version": "22.04.5 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "cm-web",
+        "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 2,
+          "cores": 18,
+          "threads": 36,
+          "maxSpeed": 3.7,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 32,
+          "available": 14,
+          "used": 18
+        },
+        "rootDisk": {
+          "label": "unknown",
+          "type": "HDD",
+          "totalSize": 1312,
+          "available": 1222,
+          "used": 23
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp24s0f0",
+            "macAddress": "b4:96:91:53:01:58",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "name": "enp24s0f1",
+            "macAddress": "b4:96:91:53:01:59",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "icmp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f0",
+            "macAddress": "b4:96:91:55:23:8c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "67",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "68",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno1np0",
+            "macAddress": "a4:bf:01:5a:b1:1b",
+            "ipv4CidrBlocks": [
+              "172.29.0.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "224.0.0.251/32",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f0",
+            "macAddress": "b4:96:91:53:01:6c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "239.255.255.250/32",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f1",
+            "macAddress": "b4:96:91:53:01:6d",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno2np1",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11c/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f1",
+            "macAddress": "b4:96:91:55:23:8e",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f0",
+            "macAddress": "b4:96:91:55:1e:04",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8086",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f1",
+            "macAddress": "b4:96:91:55:1e:06",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8888",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "ovs-system",
+            "macAddress": "6e:a8:ca:69:96:82",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9201",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-ex",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv4CidrBlocks": [
+              "192.168.110.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "2001::1000/64",
+              "fe80::7824:d2ff:fe2c:7330/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9202",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "genev_sys_6081",
+            "macAddress": "fa:e3:ea:20:21:0c",
+            "ipv6CidrBlocks": [
+              "fe80::2caf:1eff:fe7f:f78f/64"
+            ],
+            "mtu": 65000,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9203",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-int",
+            "macAddress": "ea:d0:e7:43:23:41",
+            "mtu": 1442
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9204",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap334a688a-76",
+            "macAddress": "fe:16:3e:52:10:6e",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe52:106e/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9206",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd4e69ee0-72",
+            "macAddress": "fe:16:3e:2c:59:7a",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2c:597a/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap50ee370b-a7",
+            "macAddress": "fe:16:3e:71:22:43",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe71:2243/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape46b2f03-d0",
+            "macAddress": "fe:16:3e:e2:ea:0f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fee2:ea0f/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap78b1ab69-36",
+            "macAddress": "fe:16:3e:14:65:fb",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe14:65fb/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape545ab95-ab",
+            "macAddress": "fe:16:3e:73:24:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe73:2490/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9001",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapadd1bc06-e8",
+            "macAddress": "fe:16:3e:26:ea:51",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe26:ea51/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "18080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd7ff0608-f0",
+            "macAddress": "fe:16:3e:2b:75:d6",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2b:75d6/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "13000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap26b9063f-c8",
+            "macAddress": "fe:16:3e:6c:c9:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe6c:c990/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9101",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap0d667e3a-e2",
+            "macAddress": "fe:16:3e:9f:7a:65",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe9f:7a65/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1df68fb5-f9",
+            "macAddress": "fe:16:3e:13:66:6f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe13:666f/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9106",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap3b66c516-59",
+            "macAddress": "fe:16:3e:77:e4:da",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe77:e4da/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9105",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap6f653485-7f",
+            "macAddress": "fe:16:3e:7d:85:5b",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe7d:855b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1479d90f-c0",
+            "macAddress": "02:b9:31:31:0d:fe",
+            "ipv6CidrBlocks": [
+              "fe80::b9:31ff:fe31:dfe/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9102",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap87daf3f9-0f",
+            "macAddress": "fe:16:3e:cb:97:79",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fecb:9779/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9103",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "172.29.0.0/24",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9104",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "192.168.110.0/24",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "5672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "1883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "4369",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15675",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "25672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "16567",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "destination": "fe80::/64",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "547",
-            "dstCIDR": "fe80::/10",
-            "dstPorts": "546",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::fb/128",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::f/128",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::1000/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::b9:31ff:fe31:dfe/128",
+            "interface": "tap1479d90f-c0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::2caf:1eff:fe7f:f78f/128",
+            "interface": "genev_sys_6081",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::7824:d2ff:fe2c:7330/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "deny"
+            "destination": "fe80::a6bf:1ff:fe5a:b11b/128",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::a6bf:1ff:fe5a:b11c/128",
+            "interface": "eno2np1",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe13:666f/128",
+            "interface": "tap1df68fb5-f9",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe14:65fb/128",
+            "interface": "tap78b1ab69-36",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe26:ea51/128",
+            "interface": "tapadd1bc06-e8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2b:75d6/128",
+            "interface": "tapd7ff0608-f0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2c:597a/128",
+            "interface": "tapd4e69ee0-72",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe52:106e/128",
+            "interface": "tap334a688a-76",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe6c:c990/128",
+            "interface": "tap26b9063f-c8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe71:2243/128",
+            "interface": "tap50ee370b-a7",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe73:2490/128",
+            "interface": "tape545ab95-ab",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe77:e4da/128",
+            "interface": "tap3b66c516-59",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe7d:855b/128",
+            "interface": "tap6f653485-7f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe9f:7a65/128",
+            "interface": "tap0d667e3a-e2",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fecb:9779/128",
+            "interface": "tap87daf3f9-0f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fee2:ea0f/128",
+            "interface": "tape46b2f03-d0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           }
         ],
         "os": {
@@ -1740,12 +1971,28 @@
         "label": null,
         "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
         "connectionName": "azure-koreacentral",
-        "specId": "Standard_B2as_v2",
+        "specId": "Standard_A8m_v2",
         "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
         "vNetId": "mig-vnet-01",
         "subnetId": "mig-subnet-01",
         "securityGroupIds": [
           "mig-sg-01"
+        ],
+        "sshKeyId": "mig-sshkey-01",
+        "dataDiskIds": null
+      },
+      {
+        "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "subGroupSize": "",
+        "label": null,
+        "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "connectionName": "azure-koreacentral",
+        "specId": "Standard_A4m_v2",
+        "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
+        "vNetId": "mig-vnet-01",
+        "subnetId": "mig-subnet-01",
+        "securityGroupIds": [
+          "mig-sg-02"
         ],
         "sshKeyId": "mig-sshkey-01",
         "dataDiskIds": null
@@ -1783,18 +2030,19 @@
   },
   "targetVmSpecList": [
     {
-      "id": "azure+koreacentral+standard_b2as_v2",
-      "cspSpecName": "Standard_B2as_v2",
-      "name": "azure+koreacentral+standard_b2as_v2",
+      "id": "azure+koreacentral+standard_a8m_v2",
+      "cspSpecName": "Standard_A8m_v2",
+      "name": "azure+koreacentral+standard_a8m_v2",
       "namespace": "system",
       "connectionName": "azure-koreacentral",
       "providerName": "azure",
       "regionName": "koreacentral",
       "infraType": "vm",
       "architecture": "x86_64",
-      "vCPU": 2,
-      "memoryGiB": 7.8125,
-      "costPerHour": 0.0936,
+      "vCPU": 8,
+      "memoryGiB": 62.5,
+      "diskSizeGB": 85,
+      "costPerHour": 0.541,
       "orderInFilteredResult": 1,
       "evaluationScore01": -1,
       "evaluationScore02": -1,
@@ -1804,27 +2052,27 @@
       "evaluationScore06": -1,
       "evaluationScore07": -1,
       "evaluationScore08": -1,
-      "evaluationScore09": 0.99999946,
+      "evaluationScore09": 1.0000001,
       "evaluationScore10": -1,
       "rootDiskType": "",
-      "rootDiskSize": "0",
+      "rootDiskSize": "85",
       "systemLabel": "auto-gen",
       "details": [
         {
           "key": "MaxDataDiskCount",
-          "value": "4"
+          "value": "16"
         },
         {
           "key": "MemoryInMB",
-          "value": "8192"
+          "value": "65536"
         },
         {
           "key": "Name",
-          "value": "Standard_B2as_v2"
+          "value": "Standard_A8m_v2"
         },
         {
           "key": "NumberOfCores",
-          "value": "2"
+          "value": "8"
         },
         {
           "key": "OSDiskSizeInMB",
@@ -1832,7 +2080,62 @@
         },
         {
           "key": "ResourceDiskSizeInMB",
-          "value": "0"
+          "value": "81920"
+        }
+      ]
+    },
+    {
+      "id": "azure+koreacentral+standard_a4m_v2",
+      "cspSpecName": "Standard_A4m_v2",
+      "name": "azure+koreacentral+standard_a4m_v2",
+      "namespace": "system",
+      "connectionName": "azure-koreacentral",
+      "providerName": "azure",
+      "regionName": "koreacentral",
+      "infraType": "vm",
+      "architecture": "x86_64",
+      "vCPU": 4,
+      "memoryGiB": 31.25,
+      "diskSizeGB": 42,
+      "costPerHour": 0.27,
+      "orderInFilteredResult": 1,
+      "evaluationScore01": -1,
+      "evaluationScore02": -1,
+      "evaluationScore03": -1,
+      "evaluationScore04": -1,
+      "evaluationScore05": -1,
+      "evaluationScore06": -1,
+      "evaluationScore07": -1,
+      "evaluationScore08": -1,
+      "evaluationScore09": 1.0000001,
+      "evaluationScore10": -1,
+      "rootDiskType": "",
+      "rootDiskSize": "42",
+      "systemLabel": "auto-gen",
+      "details": [
+        {
+          "key": "MaxDataDiskCount",
+          "value": "8"
+        },
+        {
+          "key": "MemoryInMB",
+          "value": "32768"
+        },
+        {
+          "key": "Name",
+          "value": "Standard_A4m_v2"
+        },
+        {
+          "key": "NumberOfCores",
+          "value": "4"
+        },
+        {
+          "key": "OSDiskSizeInMB",
+          "value": "1047552"
+        },
+        {
+          "key": "ResourceDiskSizeInMB",
+          "value": "40960"
         }
       ]
     }
@@ -1849,7 +2152,7 @@
       "name": "azure+canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
       "connectionName": "azure-australiacentral",
       "infraType": "vm",
-      "fetchedTime": "2025.08.18 10:57:14 Mon",
+      "fetchedTime": "2025.08.19 12:25:02 Tue",
       "isKubernetesImage": true,
       "osType": "Ubuntu 22.04",
       "osArchitecture": "x86_64",
@@ -1903,257 +2206,20 @@
           "Protocol": "udp",
           "Direction": "inbound",
           "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "",
-          "Protocol": "icmp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "68",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "5353",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1900",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
+        }
+      ],
+      "cspResourceId": ""
+    },
+    {
+      "name": "mig-sg-02",
+      "connectionName": "azure-koreacentral",
+      "vNetId": "mig-vnet-01",
+      "description": "Recommended security group for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "firewallRules": [
         {
           "Ports": "22",
           "Protocol": "tcp",
           "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "80",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "8086",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8888",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9201",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9202",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9203",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9204",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9206",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9001",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "18080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "13000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9101",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9106",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9105",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9102",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9103",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9104",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "5672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "4369",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15675",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "25672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "16567",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "outbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "outbound",
           "CIDR": "0.0.0.0/0"
         }
       ],
@@ -2188,13 +2254,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i1344djuna1t4r4rl0",
+  "uid": "d2iss08eak5cr9n8jaq0",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2215,7 +2281,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i1344djuna1t4r4rl0"
+    "sys.uid": "d2iss08eak5cr9n8jaq0"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2223,12 +2289,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i1344djuna1t4r4rm0",
-      "cspResourceName": "d2i1344djuna1t4r4rm0",
-      "cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2i1344djuna1t4r4rm0",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2iss08eak5cr9n8jas0",
+      "cspResourceName": "d2iss08eak5cr9n8jas0",
+      "cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jas0",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "Korea Central",
         "latitude": 37.5665,
@@ -2240,32 +2306,32 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 05:55:01",
+      "createdTime": "2025-08-20 13:31:58",
       "label": {
         "sys.connectionName": "azure-koreacentral",
-        "sys.createdTime": "2025-08-19 05:55:01",
-        "sys.cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2i1344djuna1t4r4rm0",
-        "sys.cspResourceName": "d2i1344djuna1t4r4rm0",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 13:31:58",
+        "sys.cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jas0",
+        "sys.cspResourceName": "d2iss08eak5cr9n8jas0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i1344djuna1t4r4rm0"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2iss08eak5cr9n8jas0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "koreacentral",
         "Zone": "1"
       },
-      "publicIP": "20.196.73.10",
+      "publicIP": "20.196.112.16",
       "sshPort": "22",
       "publicDNS": "",
-      "privateIP": "192.168.110.4",
+      "privateIP": "192.168.110.5",
       "privateDNS": "",
-      "rootDiskType": "PremiumSSD",
+      "rootDiskType": "StandardHDD",
       "rootDiskSize": "30",
       "rootDiskName": "",
       "connectionName": "azure-koreacentral",
@@ -2298,21 +2364,21 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "Standard_B2as_v2",
-      "cspSpecName": "Standard_B2as_v2",
+      "specId": "Standard_A4m_v2",
+      "cspSpecName": "Standard_A4m_v2",
       "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
       "cspImageName": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2i12hcdjuna1t4r4rj0",
+      "cspVNetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2i12hcdjuna1t4r4rj0/subnets/d2i12hcdjuna1t4r4rjg",
-      "networkInterface": "d2i1344djuna1t4r4rm0-67994-VNic",
+      "cspSubnetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang/subnets/d2isr3geak5cr9n8jao0",
+      "networkInterface": "d2iss08eak5cr9n8jas0-51864-VNic",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/sshPublicKeys/d2i12mcdjuna1t4r4rk0",
+      "cspSshKeyId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/sshPublicKeys/d2isr68eak5cr9n8jaog",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
@@ -2321,11 +2387,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/networkInterfaces/d2i1344djuna1t4r4rm0-67994-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:d2i1344djuna1t4r4rm0,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDNH+S+iaO81WUcR9CjXu3X2dgu5shmckfkcYYMNGmv5sNRxZzSvml0JFyHhFS7S24HwgOLVwaCblBqObVNSURlbRAwIF30T4/7W7vh0/kfUnAd4ENpUZxFHHQPLbLViaU0epTU/0j99SbQ21OaX/Pbp/tw/iEKpuJ/rfHN8kMoXNSUvN5utBun6G4cGbs/bYARDKHtvKHbZA7q1jInBjWTNr+6B7zuE4V8y6r/7RcJqOp0ZhrzwIrHJLQIseC/GuuzcgCi18MVx2pqTwx7mswCcIqh6wRvuH83vR05fjCvzdrSym/FDzOW0lBB6p1cFCeaMFs3aMst1TjMjGUmdhBwnLK4WPSXXzREeV+cYtyTdlClAV2haOXQhNhZ38fZNlMrfSD4ocXLhjHTqULab14hP0VZempCCZ+l4+HopWkEVXPrvX6Dxyy/8JCEgnx6V9VsghXQCLz983OigdAQZhtFVbPbNYU89JO+ROfG54xuKcalux9Hc8KHT8D4wYDi0FW2VfEBMdEUYOJmWMAfQyeSS7qxBY/1ROeApRl6h64yoWYmRoWV9fYuIQaunnjIPlkNU/8f5EQphJp7RHg+DgjlsXyK4dVY2ok8LOLhrX1kknmdzR64n0siOPaeR3XDKepjBEnwQRR5mQH8nQA2rQlc9IuKLpcuBLAJnTtU47Ac3w==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202505210,offer:0001-com-ubuntu-server-jammy,publisher:Canonical,sku:22_04-lts,version:22.04.202505210},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/disks/d2i1344djuna1t4r4rm0_disk1_4ee35fb505af45d98488c3c8443909de,storageAccountType:Premium_LRS},name:d2i1344djuna1t4r4rm0_disk1_4ee35fb505af45d98488c3c8443909de,osType:Linux}},timeCreated:2025-08-19T05:54:35.1436706Z,vmId:0f421724-a7e1-464c-83e7-eec5b58d563a}"
+          "value": "{hardwareProfile:{vmSize:Standard_A4m_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/networkInterfaces/d2iss08eak5cr9n8jas0-51864-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:d2iss08eak5cr9n8jas0,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbG4Ph9f8Q1UOD2KDfG8tZG8uiqYBSPOtQPvq6CuBOseiFwIQxEpowF33V9jdG2/Dpa5P4ReylS5o3KPXf7fjEU/V2mFtxaBouSA4snJ+XVfk6Yb5MMMBPov3GNTAXCIXOT7p+hKEFV3yENW6WkHdVQNcJB4przSm4j4EACMV8aothE7yDDUagalSL2Lq/ycvDQwe4bEVVwiK95RPZKMUHL1pKjvEcvfbnXcrV2FDCJBLAIN7IO2xxGXmoPN2Girqd8z7v1m7mWEeBPYXMA/Jhm51VDXm9XrJHHjKUES+X8bgbxhNu3b3dclGR0lTNpTBHHvhgqFrFcOc97GPNMMAK/Yo7t7qALS0jRZ+O2bmpvaT3RChS0ZweVByDgEoPoVR3wEskYeq5FVszvYY2LMQnufMfVQcgH+AqPRj4K6kkarSKUDrYDXboF9dBfpas9fA9rmAa7h2i7unfxCZYgWjenvvedfs0Z02rs89E5mIYOLwhVhRLoajP65I/jYsJ7HsVes00jhYCCS5cJI3+wnJxicTY1Er9bS/hX+c+WNlLTadPuDBaNhC9+yp0PwC0PJqG0LJD7ClNTr+gGofxSfCDmiAIK9u2t1jtMRUAe6x8oogUq5N+kzmbUeo1SXSNW+r0ya37BOIo0aXCfpK/1KvxOjqpYFd4BjPV9HS5rrarEw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202505210,offer:0001-com-ubuntu-server-jammy,publisher:Canonical,sku:22_04-lts,version:22.04.202505210},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/disks/d2iss08eak5cr9n8jas0_OsDisk_1_dddfc72704394c3bb392e8ebc521733f,storageAccountType:Standard_LRS},name:d2iss08eak5cr9n8jas0_OsDisk_1_dddfc72704394c3bb392e8ebc521733f,osType:Linux}},timeCreated:2025-08-20T13:31:09.7030536Z,vmId:aa53aac1-4195-422b-8a2a-7b188b7e6236}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:d2i1344djuna1t4r4rm0,keypair:d2i12mcdjuna1t4r4rk0,publicip:d2i1344djuna1t4r4rm0-55254-PublicIP}"
+          "value": "{createdBy:d2iss08eak5cr9n8jas0,keypair:d2isr68eak5cr9n8jaog,publicip:d2iss08eak5cr9n8jas0-88318-PublicIP}"
         },
         {
           "key": "Zones",
@@ -2337,11 +2403,139 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2i1344djuna1t4r4rm0"
+          "value": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jas0"
         },
         {
           "key": "Name",
-          "value": "d2i1344djuna1t4r4rm0"
+          "value": "d2iss08eak5cr9n8jas0"
+        },
+        {
+          "key": "Type",
+          "value": "Microsoft.Compute/virtualMachines"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2iss08eak5cr9n8jar0",
+      "cspResourceName": "d2iss08eak5cr9n8jar0",
+      "cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jar0",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "Korea Central",
+        "latitude": 37.5665,
+        "longitude": 126.978
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:33:35",
+      "label": {
+        "sys.connectionName": "azure-koreacentral",
+        "sys.createdTime": "2025-08-20 13:33:35",
+        "sys.cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jar0",
+        "sys.cspResourceName": "d2iss08eak5cr9n8jar0",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2iss08eak5cr9n8jar0"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "koreacentral",
+        "Zone": "1"
+      },
+      "publicIP": "20.194.9.251",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.4",
+      "privateDNS": "",
+      "rootDiskType": "StandardHDD",
+      "rootDiskSize": "30",
+      "rootDiskName": "",
+      "connectionName": "azure-koreacentral",
+      "connectionConfig": {
+        "configName": "azure-koreacentral",
+        "providerName": "azure",
+        "driverName": "azure-driver-v1.0.so",
+        "credentialName": "azure",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "azure-koreacentral",
+        "regionZoneInfo": {
+          "assignedRegion": "koreacentral",
+          "assignedZone": "1"
+        },
+        "regionDetail": {
+          "regionId": "koreacentral",
+          "regionName": "koreacentral",
+          "description": "Korea Central",
+          "location": {
+            "display": "Korea Central",
+            "latitude": 37.5665,
+            "longitude": 126.978
+          },
+          "zones": [
+            "1",
+            "2",
+            "3"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "Standard_A8m_v2",
+      "cspSpecName": "Standard_A8m_v2",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang/subnets/d2isr3geak5cr9n8jao0",
+      "networkInterface": "d2iss08eak5cr9n8jar0-70216-VNic",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/sshPublicKeys/d2isr68eak5cr9n8jaog",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "Location",
+          "value": "koreacentral"
+        },
+        {
+          "key": "Properties",
+          "value": "{hardwareProfile:{vmSize:Standard_A8m_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/networkInterfaces/d2iss08eak5cr9n8jar0-70216-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:d2iss08eak5cr9n8jar0,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbG4Ph9f8Q1UOD2KDfG8tZG8uiqYBSPOtQPvq6CuBOseiFwIQxEpowF33V9jdG2/Dpa5P4ReylS5o3KPXf7fjEU/V2mFtxaBouSA4snJ+XVfk6Yb5MMMBPov3GNTAXCIXOT7p+hKEFV3yENW6WkHdVQNcJB4przSm4j4EACMV8aothE7yDDUagalSL2Lq/ycvDQwe4bEVVwiK95RPZKMUHL1pKjvEcvfbnXcrV2FDCJBLAIN7IO2xxGXmoPN2Girqd8z7v1m7mWEeBPYXMA/Jhm51VDXm9XrJHHjKUES+X8bgbxhNu3b3dclGR0lTNpTBHHvhgqFrFcOc97GPNMMAK/Yo7t7qALS0jRZ+O2bmpvaT3RChS0ZweVByDgEoPoVR3wEskYeq5FVszvYY2LMQnufMfVQcgH+AqPRj4K6kkarSKUDrYDXboF9dBfpas9fA9rmAa7h2i7unfxCZYgWjenvvedfs0Z02rs89E5mIYOLwhVhRLoajP65I/jYsJ7HsVes00jhYCCS5cJI3+wnJxicTY1Er9bS/hX+c+WNlLTadPuDBaNhC9+yp0PwC0PJqG0LJD7ClNTr+gGofxSfCDmiAIK9u2t1jtMRUAe6x8oogUq5N+kzmbUeo1SXSNW+r0ya37BOIo0aXCfpK/1KvxOjqpYFd4BjPV9HS5rrarEw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202505210,offer:0001-com-ubuntu-server-jammy,publisher:Canonical,sku:22_04-lts,version:22.04.202505210},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/disks/d2iss08eak5cr9n8jar0_OsDisk_1_a748798313044f97bad5814501b76d95,storageAccountType:Standard_LRS},name:d2iss08eak5cr9n8jar0_OsDisk_1_a748798313044f97bad5814501b76d95,osType:Linux}},timeCreated:2025-08-20T13:30:51.4527563Z,vmId:e10d07ea-f9c3-476d-a969-c86de2dc6daa}"
+        },
+        {
+          "key": "Tags",
+          "value": "{createdBy:d2iss08eak5cr9n8jar0,keypair:d2isr68eak5cr9n8jaog,publicip:d2iss08eak5cr9n8jar0-37536-PublicIP}"
+        },
+        {
+          "key": "Zones",
+          "value": "1"
+        },
+        {
+          "key": "Etag",
+          "value": "\\1\\"
+        },
+        {
+          "key": "ID",
+          "value": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jar0"
+        },
+        {
+          "key": "Name",
+          "value": "d2iss08eak5cr9n8jar0"
         },
         {
           "key": "Type",
@@ -2385,13 +2579,13 @@
     {
       "resourceType": "mci",
       "id": "mmci01",
-      "uid": "d2i1344djuna1t4r4rl0",
+      "uid": "d2iss08eak5cr9n8jaq0",
       "name": "mmci01",
-      "status": "Running:1 (R:1/1)",
+      "status": "Running:2 (R:2/2)",
       "statusCount": {
-        "countTotal": 1,
+        "countTotal": 2,
         "countCreating": 0,
-        "countRunning": 1,
+        "countRunning": 2,
         "countFailed": 0,
         "countSuspended": 0,
         "countRebooting": 0,
@@ -2412,8 +2606,80 @@
       "vm": [
         {
           "resourceType": "mci",
+          "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+          "uid": "d2iss08eak5cr9n8jaq0",
+          "name": "mmci01",
+          "subGroupId": "",
+          "location": {
+            "display": "",
+            "latitude": 0,
+            "longitude": 0
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "a recommended multi-cloud infrastructure",
+          "region": {
+            "Region": "",
+            "Zone": ""
+          },
+          "publicIP": "",
+          "sshPort": "",
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": "",
+          "rootDiskName": "",
+          "connectionName": "",
+          "connectionConfig": {
+            "configName": "",
+            "providerName": "",
+            "driverName": "",
+            "credentialName": "",
+            "credentialHolder": "",
+            "regionZoneInfoName": "",
+            "regionZoneInfo": {
+              "assignedRegion": "",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "",
+              "regionName": "",
+              "description": "",
+              "location": {
+                "display": "",
+                "latitude": 0,
+                "longitude": 0
+              },
+              "zones": null
+            },
+            "regionRepresentative": false,
+            "verified": false
+          },
+          "specId": "",
+          "cspSpecName": "",
+          "imageId": "",
+          "cspImageName": "",
+          "vNetId": "",
+          "cspVNetId": "",
+          "subnetId": "",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": null,
+          "dataDiskIds": null,
+          "sshKeyId": "",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "mci",
           "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-          "uid": "d2i1344djuna1t4r4rl0",
+          "uid": "d2iss08eak5cr9n8jaq0",
           "name": "mmci01",
           "subGroupId": "",
           "location": {
@@ -2545,13 +2811,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i1344djuna1t4r4rl0",
+  "uid": "d2iss08eak5cr9n8jaq0",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2572,7 +2838,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i1344djuna1t4r4rl0"
+    "sys.uid": "d2iss08eak5cr9n8jaq0"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2580,12 +2846,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i1344djuna1t4r4rm0",
-      "cspResourceName": "d2i1344djuna1t4r4rm0",
-      "cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2i1344djuna1t4r4rm0",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2iss08eak5cr9n8jas0",
+      "cspResourceName": "d2iss08eak5cr9n8jas0",
+      "cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jas0",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "Korea Central",
         "latitude": 37.5665,
@@ -2597,32 +2863,32 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 05:55:01",
+      "createdTime": "2025-08-20 13:31:58",
       "label": {
         "sys.connectionName": "azure-koreacentral",
-        "sys.createdTime": "2025-08-19 05:55:01",
-        "sys.cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2i1344djuna1t4r4rm0",
-        "sys.cspResourceName": "d2i1344djuna1t4r4rm0",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 13:31:58",
+        "sys.cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jas0",
+        "sys.cspResourceName": "d2iss08eak5cr9n8jas0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i1344djuna1t4r4rm0"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2iss08eak5cr9n8jas0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "koreacentral",
         "Zone": "1"
       },
-      "publicIP": "20.196.73.10",
+      "publicIP": "20.196.112.16",
       "sshPort": "22",
       "publicDNS": "",
-      "privateIP": "192.168.110.4",
+      "privateIP": "192.168.110.5",
       "privateDNS": "",
-      "rootDiskType": "PremiumSSD",
+      "rootDiskType": "StandardHDD",
       "rootDiskSize": "30",
       "rootDiskName": "",
       "connectionName": "azure-koreacentral",
@@ -2655,21 +2921,21 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "Standard_B2as_v2",
-      "cspSpecName": "Standard_B2as_v2",
+      "specId": "Standard_A4m_v2",
+      "cspSpecName": "Standard_A4m_v2",
       "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
       "cspImageName": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2i12hcdjuna1t4r4rj0",
+      "cspVNetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2i12hcdjuna1t4r4rj0/subnets/d2i12hcdjuna1t4r4rjg",
-      "networkInterface": "d2i1344djuna1t4r4rm0-67994-VNic",
+      "cspSubnetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang/subnets/d2isr3geak5cr9n8jao0",
+      "networkInterface": "d2iss08eak5cr9n8jas0-51864-VNic",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/sshPublicKeys/d2i12mcdjuna1t4r4rk0",
+      "cspSshKeyId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/sshPublicKeys/d2isr68eak5cr9n8jaog",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
@@ -2678,11 +2944,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/networkInterfaces/d2i1344djuna1t4r4rm0-67994-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:d2i1344djuna1t4r4rm0,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDNH+S+iaO81WUcR9CjXu3X2dgu5shmckfkcYYMNGmv5sNRxZzSvml0JFyHhFS7S24HwgOLVwaCblBqObVNSURlbRAwIF30T4/7W7vh0/kfUnAd4ENpUZxFHHQPLbLViaU0epTU/0j99SbQ21OaX/Pbp/tw/iEKpuJ/rfHN8kMoXNSUvN5utBun6G4cGbs/bYARDKHtvKHbZA7q1jInBjWTNr+6B7zuE4V8y6r/7RcJqOp0ZhrzwIrHJLQIseC/GuuzcgCi18MVx2pqTwx7mswCcIqh6wRvuH83vR05fjCvzdrSym/FDzOW0lBB6p1cFCeaMFs3aMst1TjMjGUmdhBwnLK4WPSXXzREeV+cYtyTdlClAV2haOXQhNhZ38fZNlMrfSD4ocXLhjHTqULab14hP0VZempCCZ+l4+HopWkEVXPrvX6Dxyy/8JCEgnx6V9VsghXQCLz983OigdAQZhtFVbPbNYU89JO+ROfG54xuKcalux9Hc8KHT8D4wYDi0FW2VfEBMdEUYOJmWMAfQyeSS7qxBY/1ROeApRl6h64yoWYmRoWV9fYuIQaunnjIPlkNU/8f5EQphJp7RHg+DgjlsXyK4dVY2ok8LOLhrX1kknmdzR64n0siOPaeR3XDKepjBEnwQRR5mQH8nQA2rQlc9IuKLpcuBLAJnTtU47Ac3w==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202505210,offer:0001-com-ubuntu-server-jammy,publisher:Canonical,sku:22_04-lts,version:22.04.202505210},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/disks/d2i1344djuna1t4r4rm0_disk1_4ee35fb505af45d98488c3c8443909de,storageAccountType:Premium_LRS},name:d2i1344djuna1t4r4rm0_disk1_4ee35fb505af45d98488c3c8443909de,osType:Linux}},timeCreated:2025-08-19T05:54:35.1436706Z,vmId:0f421724-a7e1-464c-83e7-eec5b58d563a}"
+          "value": "{hardwareProfile:{vmSize:Standard_A4m_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/networkInterfaces/d2iss08eak5cr9n8jas0-51864-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:d2iss08eak5cr9n8jas0,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbG4Ph9f8Q1UOD2KDfG8tZG8uiqYBSPOtQPvq6CuBOseiFwIQxEpowF33V9jdG2/Dpa5P4ReylS5o3KPXf7fjEU/V2mFtxaBouSA4snJ+XVfk6Yb5MMMBPov3GNTAXCIXOT7p+hKEFV3yENW6WkHdVQNcJB4przSm4j4EACMV8aothE7yDDUagalSL2Lq/ycvDQwe4bEVVwiK95RPZKMUHL1pKjvEcvfbnXcrV2FDCJBLAIN7IO2xxGXmoPN2Girqd8z7v1m7mWEeBPYXMA/Jhm51VDXm9XrJHHjKUES+X8bgbxhNu3b3dclGR0lTNpTBHHvhgqFrFcOc97GPNMMAK/Yo7t7qALS0jRZ+O2bmpvaT3RChS0ZweVByDgEoPoVR3wEskYeq5FVszvYY2LMQnufMfVQcgH+AqPRj4K6kkarSKUDrYDXboF9dBfpas9fA9rmAa7h2i7unfxCZYgWjenvvedfs0Z02rs89E5mIYOLwhVhRLoajP65I/jYsJ7HsVes00jhYCCS5cJI3+wnJxicTY1Er9bS/hX+c+WNlLTadPuDBaNhC9+yp0PwC0PJqG0LJD7ClNTr+gGofxSfCDmiAIK9u2t1jtMRUAe6x8oogUq5N+kzmbUeo1SXSNW+r0ya37BOIo0aXCfpK/1KvxOjqpYFd4BjPV9HS5rrarEw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202505210,offer:0001-com-ubuntu-server-jammy,publisher:Canonical,sku:22_04-lts,version:22.04.202505210},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/disks/d2iss08eak5cr9n8jas0_OsDisk_1_dddfc72704394c3bb392e8ebc521733f,storageAccountType:Standard_LRS},name:d2iss08eak5cr9n8jas0_OsDisk_1_dddfc72704394c3bb392e8ebc521733f,osType:Linux}},timeCreated:2025-08-20T13:31:09.7030536Z,vmId:aa53aac1-4195-422b-8a2a-7b188b7e6236}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:d2i1344djuna1t4r4rm0,keypair:d2i12mcdjuna1t4r4rk0,publicip:d2i1344djuna1t4r4rm0-55254-PublicIP}"
+          "value": "{createdBy:d2iss08eak5cr9n8jas0,keypair:d2isr68eak5cr9n8jaog,publicip:d2iss08eak5cr9n8jas0-88318-PublicIP}"
         },
         {
           "key": "Zones",
@@ -2694,11 +2960,139 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2i1344djuna1t4r4rm0"
+          "value": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jas0"
         },
         {
           "key": "Name",
-          "value": "d2i1344djuna1t4r4rm0"
+          "value": "d2iss08eak5cr9n8jas0"
+        },
+        {
+          "key": "Type",
+          "value": "Microsoft.Compute/virtualMachines"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2iss08eak5cr9n8jar0",
+      "cspResourceName": "d2iss08eak5cr9n8jar0",
+      "cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jar0",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "Korea Central",
+        "latitude": 37.5665,
+        "longitude": 126.978
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:33:35",
+      "label": {
+        "sys.connectionName": "azure-koreacentral",
+        "sys.createdTime": "2025-08-20 13:33:35",
+        "sys.cspResourceId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jar0",
+        "sys.cspResourceName": "d2iss08eak5cr9n8jar0",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2iss08eak5cr9n8jar0"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "koreacentral",
+        "Zone": "1"
+      },
+      "publicIP": "20.194.9.251",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.4",
+      "privateDNS": "",
+      "rootDiskType": "StandardHDD",
+      "rootDiskSize": "30",
+      "rootDiskName": "",
+      "connectionName": "azure-koreacentral",
+      "connectionConfig": {
+        "configName": "azure-koreacentral",
+        "providerName": "azure",
+        "driverName": "azure-driver-v1.0.so",
+        "credentialName": "azure",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "azure-koreacentral",
+        "regionZoneInfo": {
+          "assignedRegion": "koreacentral",
+          "assignedZone": "1"
+        },
+        "regionDetail": {
+          "regionId": "koreacentral",
+          "regionName": "koreacentral",
+          "description": "Korea Central",
+          "location": {
+            "display": "Korea Central",
+            "latitude": 37.5665,
+            "longitude": 126.978
+          },
+          "zones": [
+            "1",
+            "2",
+            "3"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "Standard_A8m_v2",
+      "cspSpecName": "Standard_A8m_v2",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/virtualNetworks/d2isr3geak5cr9n8jang/subnets/d2isr3geak5cr9n8jao0",
+      "networkInterface": "d2iss08eak5cr9n8jar0-70216-VNic",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/sshPublicKeys/d2isr68eak5cr9n8jaog",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "Location",
+          "value": "koreacentral"
+        },
+        {
+          "key": "Properties",
+          "value": "{hardwareProfile:{vmSize:Standard_A8m_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Network/networkInterfaces/d2iss08eak5cr9n8jar0-70216-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:d2iss08eak5cr9n8jar0,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbG4Ph9f8Q1UOD2KDfG8tZG8uiqYBSPOtQPvq6CuBOseiFwIQxEpowF33V9jdG2/Dpa5P4ReylS5o3KPXf7fjEU/V2mFtxaBouSA4snJ+XVfk6Yb5MMMBPov3GNTAXCIXOT7p+hKEFV3yENW6WkHdVQNcJB4przSm4j4EACMV8aothE7yDDUagalSL2Lq/ycvDQwe4bEVVwiK95RPZKMUHL1pKjvEcvfbnXcrV2FDCJBLAIN7IO2xxGXmoPN2Girqd8z7v1m7mWEeBPYXMA/Jhm51VDXm9XrJHHjKUES+X8bgbxhNu3b3dclGR0lTNpTBHHvhgqFrFcOc97GPNMMAK/Yo7t7qALS0jRZ+O2bmpvaT3RChS0ZweVByDgEoPoVR3wEskYeq5FVszvYY2LMQnufMfVQcgH+AqPRj4K6kkarSKUDrYDXboF9dBfpas9fA9rmAa7h2i7unfxCZYgWjenvvedfs0Z02rs89E5mIYOLwhVhRLoajP65I/jYsJ7HsVes00jhYCCS5cJI3+wnJxicTY1Er9bS/hX+c+WNlLTadPuDBaNhC9+yp0PwC0PJqG0LJD7ClNTr+gGofxSfCDmiAIK9u2t1jtMRUAe6x8oogUq5N+kzmbUeo1SXSNW+r0ya37BOIo0aXCfpK/1KvxOjqpYFd4BjPV9HS5rrarEw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202505210,offer:0001-com-ubuntu-server-jammy,publisher:Canonical,sku:22_04-lts,version:22.04.202505210},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/disks/d2iss08eak5cr9n8jar0_OsDisk_1_a748798313044f97bad5814501b76d95,storageAccountType:Standard_LRS},name:d2iss08eak5cr9n8jar0_OsDisk_1_a748798313044f97bad5814501b76d95,osType:Linux}},timeCreated:2025-08-20T13:30:51.4527563Z,vmId:e10d07ea-f9c3-476d-a969-c86de2dc6daa}"
+        },
+        {
+          "key": "Tags",
+          "value": "{createdBy:d2iss08eak5cr9n8jar0,keypair:d2isr68eak5cr9n8jaog,publicip:d2iss08eak5cr9n8jar0-37536-PublicIP}"
+        },
+        {
+          "key": "Zones",
+          "value": "1"
+        },
+        {
+          "key": "Etag",
+          "value": "\\1\\"
+        },
+        {
+          "key": "ID",
+          "value": "/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/koreacentral/providers/Microsoft.Compute/virtualMachines/d2iss08eak5cr9n8jar0"
+        },
+        {
+          "key": "Name",
+          "value": "d2iss08eak5cr9n8jar0"
         },
         {
           "key": "Type",

--- a/cmd/test-cli/testresult/beetle-test-results-gcp.md
+++ b/cmd/test-cli/testresult/beetle-test-results-gcp.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: v0.4.0 (76a9a3e)
+- CM-Beetle: v0.4.0 (81e984e)
 - cm-model: v0.0.11
 - CB-Tumblebug: v0.11.3
 - CB-Spider: v0.11.1
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: August 19, 2025
-- Test Time: 14:57:51 KST
-- Test Execution: 2025-08-19 14:57:51 KST
+- Test Date: August 20, 2025
+- Test Time: 22:36:54 KST
+- Test Execution: 2025-08-20 22:36:54 KST
 
 ### Scenario
 
@@ -39,18 +39,18 @@
 
 | Test | Endpoint | Status | Duration | Details |
 |------|----------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 330ms | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 7m30.554s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 416ms | Pass |
+| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 468ms | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 4m9.204s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 422ms | Pass |
 | 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 61ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 561ms | Pass |
-| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 8m9.645s | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 582ms | Pass |
+| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 3m18.052s | Pass |
 
 **Overall Result**: 6/6 tests passed ✅
 
-**Total Duration**: 16m11.794606s
+**Total Duration**: 7m58.997342298s
 
-*Test executed on August 19, 2025 at 14:57:51 KST (2025-08-19 14:57:51 KST) using CM-Beetle automated test CLI*
+*Test executed on August 20, 2025 at 22:36:54 KST (2025-08-20 22:36:54 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -86,6 +86,11 @@
             "ip": "192.168.110.254",
             "interfaceName": "br-ex",
             "machineId": "00a9f3d4-74b6-e811-906e-000ffee02d5c"
+          },
+          {
+            "ip": "192.168.110.254",
+            "interfaceName": "br-ex",
+            "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c"
           }
         ]
       },
@@ -106,9 +111,9 @@
         },
         "memory": {
           "type": "DDR4",
-          "totalSize": 8,
-          "available": 3,
-          "used": 5
+          "totalSize": 64,
+          "available": 30,
+          "used": 34
         },
         "rootDisk": {
           "label": "unknown",
@@ -1127,573 +1132,799 @@
             "protocol": "udp",
             "direction": "inbound",
             "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.5 LTS",
+          "version": "22.04.5 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "cm-web",
+        "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 2,
+          "cores": 18,
+          "threads": 36,
+          "maxSpeed": 3.7,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 32,
+          "available": 14,
+          "used": 18
+        },
+        "rootDisk": {
+          "label": "unknown",
+          "type": "HDD",
+          "totalSize": 1312,
+          "available": 1222,
+          "used": 23
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp24s0f0",
+            "macAddress": "b4:96:91:53:01:58",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "name": "enp24s0f1",
+            "macAddress": "b4:96:91:53:01:59",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "icmp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f0",
+            "macAddress": "b4:96:91:55:23:8c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "67",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "68",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno1np0",
+            "macAddress": "a4:bf:01:5a:b1:1b",
+            "ipv4CidrBlocks": [
+              "172.29.0.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "224.0.0.251/32",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f0",
+            "macAddress": "b4:96:91:53:01:6c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "239.255.255.250/32",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f1",
+            "macAddress": "b4:96:91:53:01:6d",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno2np1",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11c/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f1",
+            "macAddress": "b4:96:91:55:23:8e",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f0",
+            "macAddress": "b4:96:91:55:1e:04",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8086",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f1",
+            "macAddress": "b4:96:91:55:1e:06",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8888",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "ovs-system",
+            "macAddress": "6e:a8:ca:69:96:82",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9201",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-ex",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv4CidrBlocks": [
+              "192.168.110.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "2001::1000/64",
+              "fe80::7824:d2ff:fe2c:7330/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9202",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "genev_sys_6081",
+            "macAddress": "fa:e3:ea:20:21:0c",
+            "ipv6CidrBlocks": [
+              "fe80::2caf:1eff:fe7f:f78f/64"
+            ],
+            "mtu": 65000,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9203",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-int",
+            "macAddress": "ea:d0:e7:43:23:41",
+            "mtu": 1442
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9204",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap334a688a-76",
+            "macAddress": "fe:16:3e:52:10:6e",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe52:106e/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9206",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd4e69ee0-72",
+            "macAddress": "fe:16:3e:2c:59:7a",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2c:597a/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap50ee370b-a7",
+            "macAddress": "fe:16:3e:71:22:43",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe71:2243/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape46b2f03-d0",
+            "macAddress": "fe:16:3e:e2:ea:0f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fee2:ea0f/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap78b1ab69-36",
+            "macAddress": "fe:16:3e:14:65:fb",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe14:65fb/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape545ab95-ab",
+            "macAddress": "fe:16:3e:73:24:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe73:2490/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9001",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapadd1bc06-e8",
+            "macAddress": "fe:16:3e:26:ea:51",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe26:ea51/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "18080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd7ff0608-f0",
+            "macAddress": "fe:16:3e:2b:75:d6",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2b:75d6/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "13000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap26b9063f-c8",
+            "macAddress": "fe:16:3e:6c:c9:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe6c:c990/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9101",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap0d667e3a-e2",
+            "macAddress": "fe:16:3e:9f:7a:65",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe9f:7a65/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1df68fb5-f9",
+            "macAddress": "fe:16:3e:13:66:6f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe13:666f/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9106",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap3b66c516-59",
+            "macAddress": "fe:16:3e:77:e4:da",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe77:e4da/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9105",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap6f653485-7f",
+            "macAddress": "fe:16:3e:7d:85:5b",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe7d:855b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1479d90f-c0",
+            "macAddress": "02:b9:31:31:0d:fe",
+            "ipv6CidrBlocks": [
+              "fe80::b9:31ff:fe31:dfe/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9102",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap87daf3f9-0f",
+            "macAddress": "fe:16:3e:cb:97:79",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fecb:9779/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9103",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "172.29.0.0/24",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9104",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "192.168.110.0/24",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "5672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "1883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "4369",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15675",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "25672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "16567",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "destination": "fe80::/64",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "547",
-            "dstCIDR": "fe80::/10",
-            "dstPorts": "546",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::fb/128",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::f/128",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::1000/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::b9:31ff:fe31:dfe/128",
+            "interface": "tap1479d90f-c0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::2caf:1eff:fe7f:f78f/128",
+            "interface": "genev_sys_6081",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::7824:d2ff:fe2c:7330/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "deny"
+            "destination": "fe80::a6bf:1ff:fe5a:b11b/128",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::a6bf:1ff:fe5a:b11c/128",
+            "interface": "eno2np1",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe13:666f/128",
+            "interface": "tap1df68fb5-f9",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe14:65fb/128",
+            "interface": "tap78b1ab69-36",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe26:ea51/128",
+            "interface": "tapadd1bc06-e8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2b:75d6/128",
+            "interface": "tapd7ff0608-f0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2c:597a/128",
+            "interface": "tapd4e69ee0-72",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe52:106e/128",
+            "interface": "tap334a688a-76",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe6c:c990/128",
+            "interface": "tap26b9063f-c8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe71:2243/128",
+            "interface": "tap50ee370b-a7",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe73:2490/128",
+            "interface": "tape545ab95-ab",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe77:e4da/128",
+            "interface": "tap3b66c516-59",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe7d:855b/128",
+            "interface": "tap6f653485-7f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe9f:7a65/128",
+            "interface": "tap0d667e3a-e2",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fecb:9779/128",
+            "interface": "tap87daf3f9-0f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fee2:ea0f/128",
+            "interface": "tape46b2f03-d0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           }
         ],
         "os": {
@@ -1740,12 +1971,28 @@
         "label": null,
         "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
         "connectionName": "gcp-asia-northeast3",
-        "specId": "n1-highmem-2",
+        "specId": "c2d-highmem-8",
         "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
         "vNetId": "mig-vnet-01",
         "subnetId": "mig-subnet-01",
         "securityGroupIds": [
           "mig-sg-01"
+        ],
+        "sshKeyId": "mig-sshkey-01",
+        "dataDiskIds": null
+      },
+      {
+        "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "subGroupSize": "",
+        "label": null,
+        "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "connectionName": "gcp-asia-northeast3",
+        "specId": "c2d-highmem-4",
+        "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
+        "vNetId": "mig-vnet-01",
+        "subnetId": "mig-subnet-01",
+        "securityGroupIds": [
+          "mig-sg-02"
         ],
         "sshKeyId": "mig-sshkey-01",
         "dataDiskIds": null
@@ -1783,17 +2030,17 @@
   },
   "targetVmSpecList": [
     {
-      "id": "gcp+asia-northeast3+n1-highmem-2",
-      "cspSpecName": "n1-highmem-2",
-      "name": "gcp+asia-northeast3+n1-highmem-2",
+      "id": "gcp+asia-northeast3+c2d-highmem-8",
+      "cspSpecName": "c2d-highmem-8",
+      "name": "gcp+asia-northeast3+c2d-highmem-8",
       "namespace": "system",
       "connectionName": "gcp-asia-northeast3",
       "providerName": "gcp",
       "regionName": "asia-northeast3",
       "infraType": "vm",
       "architecture": "x86_64",
-      "vCPU": 2,
-      "memoryGiB": 12.6953125,
+      "vCPU": 8,
+      "memoryGiB": 62.5,
       "diskSizeGB": -1,
       "costPerHour": -1,
       "orderInFilteredResult": 1,
@@ -1817,19 +2064,19 @@
         },
         {
           "key": "Description",
-          "value": "2 vCPUs, 13 GB RAM"
+          "value": "8 vCPUs, 64 GB RAM"
         },
         {
           "key": "GuestCpus",
-          "value": "2"
+          "value": "8"
         },
         {
           "key": "Id",
-          "value": "5002"
+          "value": "1120008"
         },
         {
           "key": "ImageSpaceGb",
-          "value": "10"
+          "value": "0"
         },
         {
           "key": "IsSharedCpu",
@@ -1849,15 +2096,98 @@
         },
         {
           "key": "MemoryMb",
-          "value": "13312"
+          "value": "65536"
         },
         {
           "key": "Name",
-          "value": "n1-highmem-2"
+          "value": "c2d-highmem-8"
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/n1-highmem-2"
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/c2d-highmem-8"
+        },
+        {
+          "key": "Zone",
+          "value": "asia-northeast3-a"
+        }
+      ]
+    },
+    {
+      "id": "gcp+asia-northeast3+c2d-highmem-4",
+      "cspSpecName": "c2d-highmem-4",
+      "name": "gcp+asia-northeast3+c2d-highmem-4",
+      "namespace": "system",
+      "connectionName": "gcp-asia-northeast3",
+      "providerName": "gcp",
+      "regionName": "asia-northeast3",
+      "infraType": "vm",
+      "architecture": "x86_64",
+      "vCPU": 4,
+      "memoryGiB": 31.25,
+      "diskSizeGB": -1,
+      "costPerHour": -1,
+      "orderInFilteredResult": 1,
+      "evaluationScore01": -1,
+      "evaluationScore02": -1,
+      "evaluationScore03": -1,
+      "evaluationScore04": -1,
+      "evaluationScore05": -1,
+      "evaluationScore06": -1,
+      "evaluationScore07": -1,
+      "evaluationScore08": -1,
+      "evaluationScore09": 0,
+      "evaluationScore10": -1,
+      "rootDiskType": "",
+      "rootDiskSize": "-1",
+      "systemLabel": "auto-gen",
+      "details": [
+        {
+          "key": "CreationTimestamp",
+          "value": "1969-12-31T16:00:00.000-08:00"
+        },
+        {
+          "key": "Description",
+          "value": "4 vCPUs, 32 GB RAM"
+        },
+        {
+          "key": "GuestCpus",
+          "value": "4"
+        },
+        {
+          "key": "Id",
+          "value": "1120004"
+        },
+        {
+          "key": "ImageSpaceGb",
+          "value": "0"
+        },
+        {
+          "key": "IsSharedCpu",
+          "value": "false"
+        },
+        {
+          "key": "Kind",
+          "value": "compute#machineType"
+        },
+        {
+          "key": "MaximumPersistentDisks",
+          "value": "128"
+        },
+        {
+          "key": "MaximumPersistentDisksSizeGb",
+          "value": "263168"
+        },
+        {
+          "key": "MemoryMb",
+          "value": "32768"
+        },
+        {
+          "key": "Name",
+          "value": "c2d-highmem-4"
+        },
+        {
+          "key": "SelfLink",
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/c2d-highmem-4"
         },
         {
           "key": "Zone",
@@ -1878,7 +2208,7 @@
       "name": "gcp+https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
       "connectionName": "gcp-africa-south1",
       "infraType": "k8s|kubernetes|container",
-      "fetchedTime": "2025.08.18 10:53:29 Mon",
+      "fetchedTime": "2025.08.19 12:21:04 Tue",
       "isKubernetesImage": true,
       "osType": "Ubuntu 22.04",
       "osArchitecture": "x86_64",
@@ -2000,257 +2330,20 @@
           "Protocol": "udp",
           "Direction": "inbound",
           "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "",
-          "Protocol": "icmp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "68",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "5353",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1900",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
+        }
+      ],
+      "cspResourceId": ""
+    },
+    {
+      "name": "mig-sg-02",
+      "connectionName": "gcp-asia-northeast3",
+      "vNetId": "mig-vnet-01",
+      "description": "Recommended security group for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "firewallRules": [
         {
           "Ports": "22",
           "Protocol": "tcp",
           "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "80",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "8086",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8888",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9201",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9202",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9203",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9204",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9206",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9001",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "18080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "13000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9101",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9106",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9105",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9102",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9103",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9104",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "5672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "4369",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15675",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "25672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "16567",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "outbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "outbound",
           "CIDR": "0.0.0.0/0"
         }
       ],
@@ -2285,13 +2378,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i17lkdjuna1t4r4rp0",
+  "uid": "d2isvogeak5cr9n8jb00",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2312,7 +2405,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i17lkdjuna1t4r4rp0"
+    "sys.uid": "d2isvogeak5cr9n8jb00"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2320,10 +2413,214 @@
   "vm": [
     {
       "resourceType": "vm",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isvogeak5cr9n8jb20",
+      "cspResourceName": "d2isvogeak5cr9n8jb20",
+      "cspResourceId": "d2isvogeak5cr9n8jb20",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.2,
+        "longitude": 127
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:39:23",
+      "label": {
+        "sys.connectionName": "gcp-asia-northeast3",
+        "sys.createdTime": "2025-08-20 13:39:23",
+        "sys.cspResourceId": "d2isvogeak5cr9n8jb20",
+        "sys.cspResourceName": "d2isvogeak5cr9n8jb20",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isvogeak5cr9n8jb20"
+      },
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "asia-northeast3",
+        "Zone": "asia-northeast3-a"
+      },
+      "publicIP": "34.64.214.50",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.3",
+      "privateDNS": "",
+      "rootDiskType": "pd-standard",
+      "rootDiskSize": "10",
+      "rootDiskName": "",
+      "connectionName": "gcp-asia-northeast3",
+      "connectionConfig": {
+        "configName": "gcp-asia-northeast3",
+        "providerName": "gcp",
+        "driverName": "gcp-driver-v1.0.so",
+        "credentialName": "gcp",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "gcp-asia-northeast3",
+        "regionZoneInfo": {
+          "assignedRegion": "asia-northeast3",
+          "assignedZone": "asia-northeast3-a"
+        },
+        "regionDetail": {
+          "regionId": "asia-northeast3",
+          "regionName": "asia-northeast3",
+          "description": "Seoul South Korea",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.2,
+            "longitude": 127
+          },
+          "zones": [
+            "asia-northeast3-a",
+            "asia-northeast3-b",
+            "asia-northeast3-c"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "c2d-highmem-4",
+      "cspSpecName": "c2d-highmem-4",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "d2isv0geak5cr9n8jatg",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "d2isv0geak5cr9n8jau0",
+      "networkInterface": "nic0",
+      "securityGroupIds": [
+        "mig-sg-02"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isv98eak5cr9n8jaug",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "CanIpForward",
+          "value": "false"
+        },
+        {
+          "key": "CpuPlatform",
+          "value": "AMD Milan"
+        },
+        {
+          "key": "CreationTimestamp",
+          "value": "2025-08-20T06:38:51.040-07:00"
+        },
+        {
+          "key": "DeletionProtection",
+          "value": "false"
+        },
+        {
+          "key": "Description",
+          "value": "compute sample instance"
+        },
+        {
+          "key": "Disks",
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/disks/d2isvogeak5cr9n8jb20,type:PERSISTENT}"
+        },
+        {
+          "key": "Fingerprint",
+          "value": "ecp1yFEkFWw="
+        },
+        {
+          "key": "Id",
+          "value": "9132225296220057861"
+        },
+        {
+          "key": "Kind",
+          "value": "compute#instance"
+        },
+        {
+          "key": "LabelFingerprint",
+          "value": "lKCDzkP3IEM="
+        },
+        {
+          "key": "Labels",
+          "value": "{keypair:d2isv98eak5cr9n8jaug}"
+        },
+        {
+          "key": "LastStartTimestamp",
+          "value": "2025-08-20T06:38:58.599-07:00"
+        },
+        {
+          "key": "MachineType",
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/c2d-highmem-4"
+        },
+        {
+          "key": "Metadata",
+          "value": "{fingerprint:NcyvRIb221Q=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7E9PBsIN7ie4MeqioVZXxZWZMBuZLa871i83Qwy9vQ0s/3NQh1nR+q5BGBY44ZmTmqdDtXtMWteH/nFhqJ6rWSMAfbWM5PvZZURYtC2DGwYB3x/drEpCDy6pzDXdn8JJyJ/c9DtwGMWP/2SNLk9ksspnQbKJK7JlWXQCTGZ3uoOXog0ENE/AukRb6Im2ygM25YimIiKwLbAcvR31q1OuM2citjGMtWz4iZhkolPnYXQZIIvKXN68aGnbLvtNlK8fu+9ATylNRpLPIId3wTEOiYe/donKGDDhW2DFfFzX3SO2p8HjBQ1ghVZy5TbSyu9Fk08uxC79pcSmSbQwt0BORccanNL4wSGBH3VGl2pVaQpRMQswI4a0MiX7gTbKMB5OHdZ/idvw4bGABIdTQwpASIw8VxBp9RyGDMnDyls7IfP0kIGl/syP9p5KnRcbM2QLy7S4g6AbDETrXmFbf0QUrNLO4kTVR5X6eiFoTNFjzoWt+N/6206u7Cj48lEQROzsoiEjBShxNYqiZ6Gu17/iPH4bhW5YMoS0NJXCMWpR90iwTpe51DMWW6Z/e2Qw7c04rHGsAUQKrT4k4ZOaJK7Kl+09+wRYMPq85JXc+rT0btToHbpKgwZzUFZwrCs1ki62ndk57zIcBwrnmv4bUBv4gmNrXYPq2L5lGPIwc7SIWuQ== cb-user}],kind:compute#metadata}"
+        },
+        {
+          "key": "Name",
+          "value": "d2isvogeak5cr9n8jb20"
+        },
+        {
+          "key": "NetworkInterfaces",
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.214.50,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:LesecAI0A-c=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/ykkim-etri/global/networks/d2isv0geak5cr9n8jatg,networkIP:192.168.110.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/ykkim-etri/regions/asia-northeast3/subnetworks/d2isv0geak5cr9n8jau0}"
+        },
+        {
+          "key": "SatisfiesPzi",
+          "value": "true"
+        },
+        {
+          "key": "SatisfiesPzs",
+          "value": "false"
+        },
+        {
+          "key": "Scheduling",
+          "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
+        },
+        {
+          "key": "SelfLink",
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/instances/d2isvogeak5cr9n8jb20"
+        },
+        {
+          "key": "ServiceAccounts",
+          "value": "{email:kimy-service-account@ykkim-etri.iam.gserviceaccount.com,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
+        },
+        {
+          "key": "ShieldedInstanceConfig",
+          "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
+        },
+        {
+          "key": "ShieldedInstanceIntegrityPolicy",
+          "value": "{updateAutoLearnPolicy:true}"
+        },
+        {
+          "key": "StartRestricted",
+          "value": "false"
+        },
+        {
+          "key": "Status",
+          "value": "RUNNING"
+        },
+        {
+          "key": "Tags",
+          "value": "{fingerprint:oNeC24O-Lbk=,items:[d2isvjgeak5cr9n8javg]}"
+        },
+        {
+          "key": "Zone",
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
       "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i17lkdjuna1t4r4rq0",
-      "cspResourceName": "d2i17lkdjuna1t4r4rq0",
-      "cspResourceId": "d2i17lkdjuna1t4r4rq0",
+      "uid": "d2isvogeak5cr9n8jb10",
+      "cspResourceName": "d2isvogeak5cr9n8jb10",
+      "cspResourceId": "d2isvogeak5cr9n8jb10",
       "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
       "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
       "location": {
@@ -2337,12 +2634,12 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 06:04:54",
+      "createdTime": "2025-08-20 13:41:02",
       "label": {
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2025-08-19 06:04:54",
-        "sys.cspResourceId": "d2i17lkdjuna1t4r4rq0",
-        "sys.cspResourceName": "d2i17lkdjuna1t4r4rq0",
+        "sys.createdTime": "2025-08-20 13:41:02",
+        "sys.cspResourceId": "d2isvogeak5cr9n8jb10",
+        "sys.cspResourceName": "d2isvogeak5cr9n8jb10",
         "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
@@ -2350,14 +2647,14 @@
         "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
         "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i17lkdjuna1t4r4rq0"
+        "sys.uid": "d2isvogeak5cr9n8jb10"
       },
       "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
       "region": {
         "Region": "asia-northeast3",
         "Zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.209.223",
+      "publicIP": "34.64.254.73",
       "sshPort": "22",
       "publicDNS": "",
       "privateIP": "192.168.110.2",
@@ -2395,21 +2692,21 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "n1-highmem-2",
-      "cspSpecName": "n1-highmem-2",
+      "specId": "c2d-highmem-8",
+      "cspSpecName": "c2d-highmem-8",
       "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
       "cspImageName": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "d2i14q4djuna1t4r4rn0",
+      "cspVNetId": "d2isv0geak5cr9n8jatg",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "d2i14q4djuna1t4r4rng",
+      "cspSubnetId": "d2isv0geak5cr9n8jau0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "mig-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i151kdjuna1t4r4ro0",
+      "cspSshKeyId": "d2isv98eak5cr9n8jaug",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
@@ -2418,11 +2715,11 @@
         },
         {
           "key": "CpuPlatform",
-          "value": "Intel Skylake"
+          "value": "AMD Milan"
         },
         {
           "key": "CreationTimestamp",
-          "value": "2025-08-18T23:04:19.871-07:00"
+          "value": "2025-08-20T06:38:47.650-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -2434,15 +2731,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/disks/d2i17lkdjuna1t4r4rq0,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/disks/d2isvogeak5cr9n8jb10,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "wtiCBohlOaQ="
+          "value": "yjzAObLCk_Q="
         },
         {
           "key": "Id",
-          "value": "87000376725318924"
+          "value": "2991990215629369608"
         },
         {
           "key": "Kind",
@@ -2450,31 +2747,31 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "IKigMlSTtyY="
+          "value": "lKCDzkP3IEM="
         },
         {
           "key": "Labels",
-          "value": "{keypair:d2i151kdjuna1t4r4ro0}"
+          "value": "{keypair:d2isv98eak5cr9n8jaug}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2025-08-18T23:04:29.010-07:00"
+          "value": "2025-08-20T06:38:55.117-07:00"
         },
         {
           "key": "MachineType",
-          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/n1-highmem-2"
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/c2d-highmem-8"
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:zuKysvDOzJo=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDhsYsUqiOfvEf9xZLZHlSh/Z2GKF7uP0X3bYZYjF2JtOt9K2vXRoHLElTGremj0eLxydUoRDC65Y3x3M20Mu3mDvvCD6XtVn2hHV4Z9hVtPqnbBcGxowLlBrT5elCQLEhmTyWW07Tpn8nbmuucwbOF2HBIhEs7+yg2bTffj2Pu6XdbrhGrAbS0/PPmclfD/zekqjlDX5yzLsI60eOsMajc8HFbxb7sCR0I43b7Sn1geDIj/tFOSfknzkm4RiUAcIAZyeXXitv3zFQDpCdMvlqlnWjgAvFJb/1a4+6TCWs8ZYAmeJ3jUZ2pYwiRY7AjmuzPi7QhjMaTQFfAd2GwxP3pniCdUHzg9WFpmIM0Qkr7YAoRxgjOe3JS8NeQv1lo0jQ+e0uYwn/pMhHqy0zfOMbgARrYpPLKmttP8DRMupz5w28RMy9wQZyklMtwiihT8RO7v0QrbqR4icNzEGHmwIFOXEWG3R346k9Etg58kYGxFTOnbJVIycv2grmJZezJ8hIrgjvoaULbA+jYO1IRalBSz3pqtvWXgFjL/xu5xktKgHmQvM6blleIenXRdN3mPw1Ua371YmRne3mR/CV6ruRBNUTMyAiCHONgykqE/LLPA3ZsBu5bVIvHPCSBnTvn/UxK+w6JOgIDcUApgy2xA3cfT2IOeGHAf+XVyzZk5XnZfw== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:NcyvRIb221Q=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7E9PBsIN7ie4MeqioVZXxZWZMBuZLa871i83Qwy9vQ0s/3NQh1nR+q5BGBY44ZmTmqdDtXtMWteH/nFhqJ6rWSMAfbWM5PvZZURYtC2DGwYB3x/drEpCDy6pzDXdn8JJyJ/c9DtwGMWP/2SNLk9ksspnQbKJK7JlWXQCTGZ3uoOXog0ENE/AukRb6Im2ygM25YimIiKwLbAcvR31q1OuM2citjGMtWz4iZhkolPnYXQZIIvKXN68aGnbLvtNlK8fu+9ATylNRpLPIId3wTEOiYe/donKGDDhW2DFfFzX3SO2p8HjBQ1ghVZy5TbSyu9Fk08uxC79pcSmSbQwt0BORccanNL4wSGBH3VGl2pVaQpRMQswI4a0MiX7gTbKMB5OHdZ/idvw4bGABIdTQwpASIw8VxBp9RyGDMnDyls7IfP0kIGl/syP9p5KnRcbM2QLy7S4g6AbDETrXmFbf0QUrNLO4kTVR5X6eiFoTNFjzoWt+N/6206u7Cj48lEQROzsoiEjBShxNYqiZ6Gu17/iPH4bhW5YMoS0NJXCMWpR90iwTpe51DMWW6Z/e2Qw7c04rHGsAUQKrT4k4ZOaJK7Kl+09+wRYMPq85JXc+rT0btToHbpKgwZzUFZwrCs1ki62ndk57zIcBwrnmv4bUBv4gmNrXYPq2L5lGPIwc7SIWuQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "d2i17lkdjuna1t4r4rq0"
+          "value": "d2isvogeak5cr9n8jb10"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.209.223,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:c4tf8J5zADg=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/ykkim-etri/global/networks/d2i14q4djuna1t4r4rn0,networkIP:192.168.110.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/ykkim-etri/regions/asia-northeast3/subnetworks/d2i14q4djuna1t4r4rng}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.254.73,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:DwdiuMiAvjY=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/ykkim-etri/global/networks/d2isv0geak5cr9n8jatg,networkIP:192.168.110.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/ykkim-etri/regions/asia-northeast3/subnetworks/d2isv0geak5cr9n8jau0}"
         },
         {
           "key": "SatisfiesPzi",
@@ -2490,7 +2787,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/instances/d2i17lkdjuna1t4r4rq0"
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/instances/d2isvogeak5cr9n8jb10"
         },
         {
           "key": "ServiceAccounts",
@@ -2514,7 +2811,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:RHcUVvwXZqM=,items:[d2i151sdjuna1t4r4rog]}"
+          "value": "{fingerprint:VytnMY0q16Q=,items:[d2isv9geak5cr9n8jav0]}"
         },
         {
           "key": "Zone",
@@ -2558,13 +2855,13 @@
     {
       "resourceType": "mci",
       "id": "mmci01",
-      "uid": "d2i17lkdjuna1t4r4rp0",
+      "uid": "d2isvogeak5cr9n8jb00",
       "name": "mmci01",
-      "status": "Running:1 (R:1/1)",
+      "status": "Running:2 (R:2/2)",
       "statusCount": {
-        "countTotal": 1,
+        "countTotal": 2,
         "countCreating": 0,
-        "countRunning": 1,
+        "countRunning": 2,
         "countFailed": 0,
         "countSuspended": 0,
         "countRebooting": 0,
@@ -2585,8 +2882,80 @@
       "vm": [
         {
           "resourceType": "mci",
+          "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+          "uid": "d2isvogeak5cr9n8jb00",
+          "name": "mmci01",
+          "subGroupId": "",
+          "location": {
+            "display": "",
+            "latitude": 0,
+            "longitude": 0
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "a recommended multi-cloud infrastructure",
+          "region": {
+            "Region": "",
+            "Zone": ""
+          },
+          "publicIP": "",
+          "sshPort": "",
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": "",
+          "rootDiskName": "",
+          "connectionName": "",
+          "connectionConfig": {
+            "configName": "",
+            "providerName": "",
+            "driverName": "",
+            "credentialName": "",
+            "credentialHolder": "",
+            "regionZoneInfoName": "",
+            "regionZoneInfo": {
+              "assignedRegion": "",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "",
+              "regionName": "",
+              "description": "",
+              "location": {
+                "display": "",
+                "latitude": 0,
+                "longitude": 0
+              },
+              "zones": null
+            },
+            "regionRepresentative": false,
+            "verified": false
+          },
+          "specId": "",
+          "cspSpecName": "",
+          "imageId": "",
+          "cspImageName": "",
+          "vNetId": "",
+          "cspVNetId": "",
+          "subnetId": "",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": null,
+          "dataDiskIds": null,
+          "sshKeyId": "",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "mci",
           "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-          "uid": "d2i17lkdjuna1t4r4rp0",
+          "uid": "d2isvogeak5cr9n8jb00",
           "name": "mmci01",
           "subGroupId": "",
           "location": {
@@ -2718,13 +3087,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i17lkdjuna1t4r4rp0",
+  "uid": "d2isvogeak5cr9n8jb00",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2745,7 +3114,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i17lkdjuna1t4r4rp0"
+    "sys.uid": "d2isvogeak5cr9n8jb00"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2753,10 +3122,214 @@
   "vm": [
     {
       "resourceType": "vm",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isvogeak5cr9n8jb20",
+      "cspResourceName": "d2isvogeak5cr9n8jb20",
+      "cspResourceId": "d2isvogeak5cr9n8jb20",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.2,
+        "longitude": 127
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:39:23",
+      "label": {
+        "sys.connectionName": "gcp-asia-northeast3",
+        "sys.createdTime": "2025-08-20 13:39:23",
+        "sys.cspResourceId": "d2isvogeak5cr9n8jb20",
+        "sys.cspResourceName": "d2isvogeak5cr9n8jb20",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isvogeak5cr9n8jb20"
+      },
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "asia-northeast3",
+        "Zone": "asia-northeast3-a"
+      },
+      "publicIP": "34.64.214.50",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.3",
+      "privateDNS": "",
+      "rootDiskType": "pd-standard",
+      "rootDiskSize": "10",
+      "rootDiskName": "",
+      "connectionName": "gcp-asia-northeast3",
+      "connectionConfig": {
+        "configName": "gcp-asia-northeast3",
+        "providerName": "gcp",
+        "driverName": "gcp-driver-v1.0.so",
+        "credentialName": "gcp",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "gcp-asia-northeast3",
+        "regionZoneInfo": {
+          "assignedRegion": "asia-northeast3",
+          "assignedZone": "asia-northeast3-a"
+        },
+        "regionDetail": {
+          "regionId": "asia-northeast3",
+          "regionName": "asia-northeast3",
+          "description": "Seoul South Korea",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.2,
+            "longitude": 127
+          },
+          "zones": [
+            "asia-northeast3-a",
+            "asia-northeast3-b",
+            "asia-northeast3-c"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "c2d-highmem-4",
+      "cspSpecName": "c2d-highmem-4",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "d2isv0geak5cr9n8jatg",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "d2isv0geak5cr9n8jau0",
+      "networkInterface": "nic0",
+      "securityGroupIds": [
+        "mig-sg-02"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isv98eak5cr9n8jaug",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "CanIpForward",
+          "value": "false"
+        },
+        {
+          "key": "CpuPlatform",
+          "value": "AMD Milan"
+        },
+        {
+          "key": "CreationTimestamp",
+          "value": "2025-08-20T06:38:51.040-07:00"
+        },
+        {
+          "key": "DeletionProtection",
+          "value": "false"
+        },
+        {
+          "key": "Description",
+          "value": "compute sample instance"
+        },
+        {
+          "key": "Disks",
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/disks/d2isvogeak5cr9n8jb20,type:PERSISTENT}"
+        },
+        {
+          "key": "Fingerprint",
+          "value": "ecp1yFEkFWw="
+        },
+        {
+          "key": "Id",
+          "value": "9132225296220057861"
+        },
+        {
+          "key": "Kind",
+          "value": "compute#instance"
+        },
+        {
+          "key": "LabelFingerprint",
+          "value": "lKCDzkP3IEM="
+        },
+        {
+          "key": "Labels",
+          "value": "{keypair:d2isv98eak5cr9n8jaug}"
+        },
+        {
+          "key": "LastStartTimestamp",
+          "value": "2025-08-20T06:38:58.599-07:00"
+        },
+        {
+          "key": "MachineType",
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/c2d-highmem-4"
+        },
+        {
+          "key": "Metadata",
+          "value": "{fingerprint:NcyvRIb221Q=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7E9PBsIN7ie4MeqioVZXxZWZMBuZLa871i83Qwy9vQ0s/3NQh1nR+q5BGBY44ZmTmqdDtXtMWteH/nFhqJ6rWSMAfbWM5PvZZURYtC2DGwYB3x/drEpCDy6pzDXdn8JJyJ/c9DtwGMWP/2SNLk9ksspnQbKJK7JlWXQCTGZ3uoOXog0ENE/AukRb6Im2ygM25YimIiKwLbAcvR31q1OuM2citjGMtWz4iZhkolPnYXQZIIvKXN68aGnbLvtNlK8fu+9ATylNRpLPIId3wTEOiYe/donKGDDhW2DFfFzX3SO2p8HjBQ1ghVZy5TbSyu9Fk08uxC79pcSmSbQwt0BORccanNL4wSGBH3VGl2pVaQpRMQswI4a0MiX7gTbKMB5OHdZ/idvw4bGABIdTQwpASIw8VxBp9RyGDMnDyls7IfP0kIGl/syP9p5KnRcbM2QLy7S4g6AbDETrXmFbf0QUrNLO4kTVR5X6eiFoTNFjzoWt+N/6206u7Cj48lEQROzsoiEjBShxNYqiZ6Gu17/iPH4bhW5YMoS0NJXCMWpR90iwTpe51DMWW6Z/e2Qw7c04rHGsAUQKrT4k4ZOaJK7Kl+09+wRYMPq85JXc+rT0btToHbpKgwZzUFZwrCs1ki62ndk57zIcBwrnmv4bUBv4gmNrXYPq2L5lGPIwc7SIWuQ== cb-user}],kind:compute#metadata}"
+        },
+        {
+          "key": "Name",
+          "value": "d2isvogeak5cr9n8jb20"
+        },
+        {
+          "key": "NetworkInterfaces",
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.214.50,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:LesecAI0A-c=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/ykkim-etri/global/networks/d2isv0geak5cr9n8jatg,networkIP:192.168.110.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/ykkim-etri/regions/asia-northeast3/subnetworks/d2isv0geak5cr9n8jau0}"
+        },
+        {
+          "key": "SatisfiesPzi",
+          "value": "true"
+        },
+        {
+          "key": "SatisfiesPzs",
+          "value": "false"
+        },
+        {
+          "key": "Scheduling",
+          "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
+        },
+        {
+          "key": "SelfLink",
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/instances/d2isvogeak5cr9n8jb20"
+        },
+        {
+          "key": "ServiceAccounts",
+          "value": "{email:kimy-service-account@ykkim-etri.iam.gserviceaccount.com,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
+        },
+        {
+          "key": "ShieldedInstanceConfig",
+          "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
+        },
+        {
+          "key": "ShieldedInstanceIntegrityPolicy",
+          "value": "{updateAutoLearnPolicy:true}"
+        },
+        {
+          "key": "StartRestricted",
+          "value": "false"
+        },
+        {
+          "key": "Status",
+          "value": "RUNNING"
+        },
+        {
+          "key": "Tags",
+          "value": "{fingerprint:oNeC24O-Lbk=,items:[d2isvjgeak5cr9n8javg]}"
+        },
+        {
+          "key": "Zone",
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
       "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i17lkdjuna1t4r4rq0",
-      "cspResourceName": "d2i17lkdjuna1t4r4rq0",
-      "cspResourceId": "d2i17lkdjuna1t4r4rq0",
+      "uid": "d2isvogeak5cr9n8jb10",
+      "cspResourceName": "d2isvogeak5cr9n8jb10",
+      "cspResourceId": "d2isvogeak5cr9n8jb10",
       "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
       "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
       "location": {
@@ -2770,12 +3343,12 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 06:04:54",
+      "createdTime": "2025-08-20 13:41:02",
       "label": {
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2025-08-19 06:04:54",
-        "sys.cspResourceId": "d2i17lkdjuna1t4r4rq0",
-        "sys.cspResourceName": "d2i17lkdjuna1t4r4rq0",
+        "sys.createdTime": "2025-08-20 13:41:02",
+        "sys.cspResourceId": "d2isvogeak5cr9n8jb10",
+        "sys.cspResourceName": "d2isvogeak5cr9n8jb10",
         "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
@@ -2783,14 +3356,14 @@
         "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
         "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i17lkdjuna1t4r4rq0"
+        "sys.uid": "d2isvogeak5cr9n8jb10"
       },
       "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
       "region": {
         "Region": "asia-northeast3",
         "Zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.209.223",
+      "publicIP": "34.64.254.73",
       "sshPort": "22",
       "publicDNS": "",
       "privateIP": "192.168.110.2",
@@ -2828,21 +3401,21 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "n1-highmem-2",
-      "cspSpecName": "n1-highmem-2",
+      "specId": "c2d-highmem-8",
+      "cspSpecName": "c2d-highmem-8",
       "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
       "cspImageName": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250815",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "d2i14q4djuna1t4r4rn0",
+      "cspVNetId": "d2isv0geak5cr9n8jatg",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "d2i14q4djuna1t4r4rng",
+      "cspSubnetId": "d2isv0geak5cr9n8jau0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "mig-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i151kdjuna1t4r4ro0",
+      "cspSshKeyId": "d2isv98eak5cr9n8jaug",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
@@ -2851,11 +3424,11 @@
         },
         {
           "key": "CpuPlatform",
-          "value": "Intel Skylake"
+          "value": "AMD Milan"
         },
         {
           "key": "CreationTimestamp",
-          "value": "2025-08-18T23:04:19.871-07:00"
+          "value": "2025-08-20T06:38:47.650-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -2867,15 +3440,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/disks/d2i17lkdjuna1t4r4rq0,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/disks/d2isvogeak5cr9n8jb10,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "wtiCBohlOaQ="
+          "value": "yjzAObLCk_Q="
         },
         {
           "key": "Id",
-          "value": "87000376725318924"
+          "value": "2991990215629369608"
         },
         {
           "key": "Kind",
@@ -2883,31 +3456,31 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "IKigMlSTtyY="
+          "value": "lKCDzkP3IEM="
         },
         {
           "key": "Labels",
-          "value": "{keypair:d2i151kdjuna1t4r4ro0}"
+          "value": "{keypair:d2isv98eak5cr9n8jaug}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2025-08-18T23:04:29.010-07:00"
+          "value": "2025-08-20T06:38:55.117-07:00"
         },
         {
           "key": "MachineType",
-          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/n1-highmem-2"
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/machineTypes/c2d-highmem-8"
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:zuKysvDOzJo=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDhsYsUqiOfvEf9xZLZHlSh/Z2GKF7uP0X3bYZYjF2JtOt9K2vXRoHLElTGremj0eLxydUoRDC65Y3x3M20Mu3mDvvCD6XtVn2hHV4Z9hVtPqnbBcGxowLlBrT5elCQLEhmTyWW07Tpn8nbmuucwbOF2HBIhEs7+yg2bTffj2Pu6XdbrhGrAbS0/PPmclfD/zekqjlDX5yzLsI60eOsMajc8HFbxb7sCR0I43b7Sn1geDIj/tFOSfknzkm4RiUAcIAZyeXXitv3zFQDpCdMvlqlnWjgAvFJb/1a4+6TCWs8ZYAmeJ3jUZ2pYwiRY7AjmuzPi7QhjMaTQFfAd2GwxP3pniCdUHzg9WFpmIM0Qkr7YAoRxgjOe3JS8NeQv1lo0jQ+e0uYwn/pMhHqy0zfOMbgARrYpPLKmttP8DRMupz5w28RMy9wQZyklMtwiihT8RO7v0QrbqR4icNzEGHmwIFOXEWG3R346k9Etg58kYGxFTOnbJVIycv2grmJZezJ8hIrgjvoaULbA+jYO1IRalBSz3pqtvWXgFjL/xu5xktKgHmQvM6blleIenXRdN3mPw1Ua371YmRne3mR/CV6ruRBNUTMyAiCHONgykqE/LLPA3ZsBu5bVIvHPCSBnTvn/UxK+w6JOgIDcUApgy2xA3cfT2IOeGHAf+XVyzZk5XnZfw== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:NcyvRIb221Q=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7E9PBsIN7ie4MeqioVZXxZWZMBuZLa871i83Qwy9vQ0s/3NQh1nR+q5BGBY44ZmTmqdDtXtMWteH/nFhqJ6rWSMAfbWM5PvZZURYtC2DGwYB3x/drEpCDy6pzDXdn8JJyJ/c9DtwGMWP/2SNLk9ksspnQbKJK7JlWXQCTGZ3uoOXog0ENE/AukRb6Im2ygM25YimIiKwLbAcvR31q1OuM2citjGMtWz4iZhkolPnYXQZIIvKXN68aGnbLvtNlK8fu+9ATylNRpLPIId3wTEOiYe/donKGDDhW2DFfFzX3SO2p8HjBQ1ghVZy5TbSyu9Fk08uxC79pcSmSbQwt0BORccanNL4wSGBH3VGl2pVaQpRMQswI4a0MiX7gTbKMB5OHdZ/idvw4bGABIdTQwpASIw8VxBp9RyGDMnDyls7IfP0kIGl/syP9p5KnRcbM2QLy7S4g6AbDETrXmFbf0QUrNLO4kTVR5X6eiFoTNFjzoWt+N/6206u7Cj48lEQROzsoiEjBShxNYqiZ6Gu17/iPH4bhW5YMoS0NJXCMWpR90iwTpe51DMWW6Z/e2Qw7c04rHGsAUQKrT4k4ZOaJK7Kl+09+wRYMPq85JXc+rT0btToHbpKgwZzUFZwrCs1ki62ndk57zIcBwrnmv4bUBv4gmNrXYPq2L5lGPIwc7SIWuQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "d2i17lkdjuna1t4r4rq0"
+          "value": "d2isvogeak5cr9n8jb10"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.209.223,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:c4tf8J5zADg=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/ykkim-etri/global/networks/d2i14q4djuna1t4r4rn0,networkIP:192.168.110.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/ykkim-etri/regions/asia-northeast3/subnetworks/d2i14q4djuna1t4r4rng}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.254.73,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:DwdiuMiAvjY=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/ykkim-etri/global/networks/d2isv0geak5cr9n8jatg,networkIP:192.168.110.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/ykkim-etri/regions/asia-northeast3/subnetworks/d2isv0geak5cr9n8jau0}"
         },
         {
           "key": "SatisfiesPzi",
@@ -2923,7 +3496,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/instances/d2i17lkdjuna1t4r4rq0"
+          "value": "https://www.googleapis.com/compute/v1/projects/ykkim-etri/zones/asia-northeast3-a/instances/d2isvogeak5cr9n8jb10"
         },
         {
           "key": "ServiceAccounts",
@@ -2947,7 +3520,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:RHcUVvwXZqM=,items:[d2i151sdjuna1t4r4rog]}"
+          "value": "{fingerprint:VytnMY0q16Q=,items:[d2isv9geak5cr9n8jav0]}"
         },
         {
           "key": "Zone",

--- a/cmd/test-cli/testresult/beetle-test-results-ncp.md
+++ b/cmd/test-cli/testresult/beetle-test-results-ncp.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: v0.4.0 (76a9a3e)
+- CM-Beetle: v0.4.0 (b20b7be)
 - cm-model: v0.0.11
 - CB-Tumblebug: v0.11.3
 - CB-Spider: v0.11.1
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: August 19, 2025
-- Test Time: 15:12:56 KST
-- Test Execution: 2025-08-19 15:12:56 KST
+- Test Date: August 20, 2025
+- Test Time: 22:01:51 KST
+- Test Execution: 2025-08-20 22:01:51 KST
 
 ### Scenario
 
@@ -39,18 +39,18 @@
 
 | Test | Endpoint | Status | Duration | Details |
 |------|----------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 246ms | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 3m7.284s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 140ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 69ms | Pass |
+| 1 | `POST /beetle/recommendation/mci` | ✅ **PASS** | 344ms | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 5m25.65s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 205ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 60ms | Pass |
 | 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 137ms | Pass |
-| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 3m26.448s | Pass |
+| 6 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 1m38.581s | Pass |
 
 **Overall Result**: 6/6 tests passed ✅
 
-**Total Duration**: 7m4.540328445s
+**Total Duration**: 7m35.176379266s
 
-*Test executed on August 19, 2025 at 15:12:56 KST (2025-08-19 15:12:56 KST) using CM-Beetle automated test CLI*
+*Test executed on August 20, 2025 at 22:01:51 KST (2025-08-20 22:01:51 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -86,6 +86,11 @@
             "ip": "192.168.110.254",
             "interfaceName": "br-ex",
             "machineId": "00a9f3d4-74b6-e811-906e-000ffee02d5c"
+          },
+          {
+            "ip": "192.168.110.254",
+            "interfaceName": "br-ex",
+            "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c"
           }
         ]
       },
@@ -106,9 +111,9 @@
         },
         "memory": {
           "type": "DDR4",
-          "totalSize": 8,
-          "available": 3,
-          "used": 5
+          "totalSize": 255,
+          "available": 146,
+          "used": 109
         },
         "rootDisk": {
           "label": "unknown",
@@ -1127,573 +1132,799 @@
             "protocol": "udp",
             "direction": "inbound",
             "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.5 LTS",
+          "version": "22.04.5 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "cm-web",
+        "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 2,
+          "cores": 18,
+          "threads": 36,
+          "maxSpeed": 3.7,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 255,
+          "available": 89,
+          "used": 166
+        },
+        "rootDisk": {
+          "label": "unknown",
+          "type": "HDD",
+          "totalSize": 1312,
+          "available": 1222,
+          "used": 23
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp24s0f0",
+            "macAddress": "b4:96:91:53:01:58",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "name": "enp24s0f1",
+            "macAddress": "b4:96:91:53:01:59",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "icmp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f0",
+            "macAddress": "b4:96:91:55:23:8c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "67",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "68",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno1np0",
+            "macAddress": "a4:bf:01:5a:b1:1b",
+            "ipv4CidrBlocks": [
+              "172.29.0.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "224.0.0.251/32",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f0",
+            "macAddress": "b4:96:91:53:01:6c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "239.255.255.250/32",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f1",
+            "macAddress": "b4:96:91:53:01:6d",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno2np1",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv6CidrBlocks": [
+              "fe80::a6bf:1ff:fe5a:b11c/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f1",
+            "macAddress": "b4:96:91:55:23:8e",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f0",
+            "macAddress": "b4:96:91:55:1e:04",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8086",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f1",
+            "macAddress": "b4:96:91:55:1e:06",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8888",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "ovs-system",
+            "macAddress": "6e:a8:ca:69:96:82",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9201",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-ex",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv4CidrBlocks": [
+              "192.168.110.103/24"
+            ],
+            "ipv6CidrBlocks": [
+              "2001::1000/64",
+              "fe80::7824:d2ff:fe2c:7330/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9202",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "genev_sys_6081",
+            "macAddress": "fa:e3:ea:20:21:0c",
+            "ipv6CidrBlocks": [
+              "fe80::2caf:1eff:fe7f:f78f/64"
+            ],
+            "mtu": 65000,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9203",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-int",
+            "macAddress": "ea:d0:e7:43:23:41",
+            "mtu": 1442
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9204",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap334a688a-76",
+            "macAddress": "fe:16:3e:52:10:6e",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe52:106e/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9206",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd4e69ee0-72",
+            "macAddress": "fe:16:3e:2c:59:7a",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2c:597a/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap50ee370b-a7",
+            "macAddress": "fe:16:3e:71:22:43",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe71:2243/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape46b2f03-d0",
+            "macAddress": "fe:16:3e:e2:ea:0f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fee2:ea0f/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap78b1ab69-36",
+            "macAddress": "fe:16:3e:14:65:fb",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe14:65fb/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape545ab95-ab",
+            "macAddress": "fe:16:3e:73:24:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe73:2490/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9001",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapadd1bc06-e8",
+            "macAddress": "fe:16:3e:26:ea:51",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe26:ea51/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "18080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd7ff0608-f0",
+            "macAddress": "fe:16:3e:2b:75:d6",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe2b:75d6/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "13000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap26b9063f-c8",
+            "macAddress": "fe:16:3e:6c:c9:90",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe6c:c990/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9101",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap0d667e3a-e2",
+            "macAddress": "fe:16:3e:9f:7a:65",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe9f:7a65/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1df68fb5-f9",
+            "macAddress": "fe:16:3e:13:66:6f",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe13:666f/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9106",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap3b66c516-59",
+            "macAddress": "fe:16:3e:77:e4:da",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe77:e4da/64"
+            ],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9105",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap6f653485-7f",
+            "macAddress": "fe:16:3e:7d:85:5b",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fe7d:855b/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1479d90f-c0",
+            "macAddress": "02:b9:31:31:0d:fe",
+            "ipv6CidrBlocks": [
+              "fe80::b9:31ff:fe31:dfe/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9102",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap87daf3f9-0f",
+            "macAddress": "fe:16:3e:cb:97:79",
+            "ipv6CidrBlocks": [
+              "fe80::fc16:3eff:fecb:9779/64"
+            ],
+            "mtu": 1500,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9103",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "172.29.0.0/24",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9104",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "192.168.110.0/24",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "5672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "1883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "4369",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15675",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "25672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "16567",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "destination": "fe80::/64",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "547",
-            "dstCIDR": "fe80::/10",
-            "dstPorts": "546",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::fb/128",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::f/128",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::1000/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::b9:31ff:fe31:dfe/128",
+            "interface": "tap1479d90f-c0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::2caf:1eff:fe7f:f78f/128",
+            "interface": "genev_sys_6081",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::7824:d2ff:fe2c:7330/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "deny"
+            "destination": "fe80::a6bf:1ff:fe5a:b11b/128",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::a6bf:1ff:fe5a:b11c/128",
+            "interface": "eno2np1",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe13:666f/128",
+            "interface": "tap1df68fb5-f9",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe14:65fb/128",
+            "interface": "tap78b1ab69-36",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe26:ea51/128",
+            "interface": "tapadd1bc06-e8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2b:75d6/128",
+            "interface": "tapd7ff0608-f0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2c:597a/128",
+            "interface": "tapd4e69ee0-72",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe52:106e/128",
+            "interface": "tap334a688a-76",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe6c:c990/128",
+            "interface": "tap26b9063f-c8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe71:2243/128",
+            "interface": "tap50ee370b-a7",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe73:2490/128",
+            "interface": "tape545ab95-ab",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe77:e4da/128",
+            "interface": "tap3b66c516-59",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe7d:855b/128",
+            "interface": "tap6f653485-7f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe9f:7a65/128",
+            "interface": "tap0d667e3a-e2",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fecb:9779/128",
+            "interface": "tap87daf3f9-0f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fee2:ea0f/128",
+            "interface": "tape46b2f03-d0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           }
         ],
         "os": {
@@ -1740,12 +1971,28 @@
         "label": null,
         "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
         "connectionName": "ncpvpc-kr",
-        "specId": "s2-g3a",
+        "specId": "m32-g3a",
         "imageId": "23214590",
         "vNetId": "mig-vnet-01",
         "subnetId": "mig-subnet-01",
         "securityGroupIds": [
           "mig-sg-01"
+        ],
+        "sshKeyId": "mig-sshkey-01",
+        "dataDiskIds": null
+      },
+      {
+        "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "subGroupSize": "",
+        "label": null,
+        "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "connectionName": "ncpvpc-kr",
+        "specId": "m32-g3a",
+        "imageId": "23214590",
+        "vNetId": "mig-vnet-01",
+        "subnetId": "mig-subnet-01",
+        "securityGroupIds": [
+          "mig-sg-02"
         ],
         "sshKeyId": "mig-sshkey-01",
         "dataDiskIds": null
@@ -1783,19 +2030,19 @@
   },
   "targetVmSpecList": [
     {
-      "id": "ncpvpc+kr+s2-g3a",
-      "cspSpecName": "s2-g3a",
-      "name": "ncpvpc+kr+s2-g3a",
+      "id": "ncpvpc+kr+m32-g3a",
+      "cspSpecName": "m32-g3a",
+      "name": "ncpvpc+kr+m32-g3a",
       "namespace": "system",
       "connectionName": "ncpvpc-kr",
       "providerName": "ncpvpc",
       "regionName": "kr",
       "infraType": "vm",
       "architecture": "x86_64",
-      "vCPU": 2,
-      "memoryGiB": 8,
+      "vCPU": 32,
+      "memoryGiB": 256,
       "diskSizeGB": -1,
-      "costPerHour": 0.0848,
+      "costPerHour": 1.9602,
       "orderInFilteredResult": 1,
       "evaluationScore01": -1,
       "evaluationScore02": -1,
@@ -1805,7 +2052,7 @@
       "evaluationScore06": -1,
       "evaluationScore07": -1,
       "evaluationScore08": -1,
-      "evaluationScore09": 1.0000001,
+      "evaluationScore09": 1,
       "evaluationScore10": -1,
       "rootDiskType": "default",
       "rootDiskSize": "-1",
@@ -1813,7 +2060,7 @@
       "details": [
         {
           "key": "ServerSpecCode",
-          "value": "s2-g3a"
+          "value": "m32-g3a"
         },
         {
           "key": "GenerationCode",
@@ -1821,11 +2068,11 @@
         },
         {
           "key": "CpuCount",
-          "value": "2"
+          "value": "32"
         },
         {
           "key": "MemorySize",
-          "value": "8589934592"
+          "value": "274877906944"
         },
         {
           "key": "HypervisorType",
@@ -1841,15 +2088,15 @@
         },
         {
           "key": "BlockStorageMaxIops",
-          "value": "4725"
+          "value": "40000"
         },
         {
           "key": "BlockStorageMaxThroughput",
-          "value": "81"
+          "value": "850"
         },
         {
           "key": "NetworkPerformance",
-          "value": "1000000000"
+          "value": "10000000000"
         },
         {
           "key": "NetworkInterfaceMaxCount",
@@ -1857,11 +2104,11 @@
         },
         {
           "key": "ServerProductCode",
-          "value": "SVR.VSVR.AMD.STAND.C002.M008.G003"
+          "value": "SVR.VSVR.AMD.HIMEM.C032.M256.G003"
         },
         {
           "key": "ServerSpecDescription",
-          "value": "vCPU 2EA, Memory 8GB"
+          "value": "vCPU 32EA, Memory 256GB"
         },
         {
           "key": "CorrespondingImageIds",
@@ -1881,7 +2128,7 @@
       "id": "ncpvpc+23214590",
       "name": "ncpvpc+23214590",
       "connectionName": "ncpvpc-kr",
-      "fetchedTime": "2025.08.18 10:52:57 Mon",
+      "fetchedTime": "2025.08.19 12:20:30 Tue",
       "osType": "Ubuntu 22.04",
       "osArchitecture": "x86_64",
       "osPlatform": "Linux/UNIX",
@@ -1977,257 +2224,20 @@
           "Protocol": "udp",
           "Direction": "inbound",
           "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "",
-          "Protocol": "icmp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "68",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "5353",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1900",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
+        }
+      ],
+      "cspResourceId": ""
+    },
+    {
+      "name": "mig-sg-02",
+      "connectionName": "ncpvpc-kr",
+      "vNetId": "mig-vnet-01",
+      "description": "Recommended security group for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
+      "firewallRules": [
         {
           "Ports": "22",
           "Protocol": "tcp",
           "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "80",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "8086",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8888",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9201",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9202",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9203",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9204",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9206",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "3000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8443",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9001",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "18080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "13000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9101",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9100",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9106",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9105",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8080",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9102",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9103",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "9104",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "5672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "4369",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "15675",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "25672",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8883",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "16567",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "8000",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "192.168.110.0/24"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "inbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "tcp",
-          "Direction": "outbound",
-          "CIDR": "0.0.0.0/0"
-        },
-        {
-          "Ports": "1-65535",
-          "Protocol": "udp",
-          "Direction": "outbound",
           "CIDR": "0.0.0.0/0"
         }
       ],
@@ -2262,13 +2272,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i1c8cdjuna1t4r4rt0",
+  "uid": "d2isf18eak5cr9n8jae0",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2289,7 +2299,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i1c8cdjuna1t4r4rt0"
+    "sys.uid": "d2isf18eak5cr9n8jae0"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2297,12 +2307,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i1c8cdjuna1t4r4ru0",
-      "cspResourceName": "d2i1c8cdjuna1t4r4ru0",
-      "cspResourceId": "108250326",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isf18eak5cr9n8jag0",
+      "cspResourceName": "d2isf18eak5cr9n8jag0",
+      "cspResourceId": "108292651",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -2314,27 +2324,27 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 06:15:58",
+      "createdTime": "2025-08-20 13:05:35",
       "label": {
         "sys.connectionName": "ncpvpc-kr",
-        "sys.createdTime": "2025-08-19 06:15:58",
-        "sys.cspResourceId": "108250326",
-        "sys.cspResourceName": "d2i1c8cdjuna1t4r4ru0",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 13:05:35",
+        "sys.cspResourceId": "108292651",
+        "sys.cspResourceName": "d2isf18eak5cr9n8jag0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i1c8cdjuna1t4r4ru0"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isf18eak5cr9n8jag0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "KR",
         "Zone": "KR-1"
       },
-      "publicIP": "101.79.8.56",
+      "publicIP": "223.130.131.232",
       "sshPort": "22",
       "publicDNS": "",
       "privateIP": "192.168.110.6",
@@ -2371,38 +2381,38 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "s2-g3a",
-      "cspSpecName": "s2-g3a",
+      "specId": "m32-g3a",
+      "cspSpecName": "m32-g3a",
       "imageId": "23214590",
       "cspImageName": "23214590",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "119520",
+      "cspVNetId": "119764",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "251917",
+      "cspSubnetId": "252646",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i1c2kdjuna1t4r4rs0",
+      "cspSshKeyId": "d2isep0eak5cr9n8jacg",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "108250326"
+          "value": "108292651"
         },
         {
           "key": "ServerName",
-          "value": "d2i1c8cdjuna1t4r4ru0"
+          "value": "d2isf18eak5cr9n8jag0"
         },
         {
           "key": "CpuCount",
-          "value": "2"
+          "value": "32"
         },
         {
           "key": "MemorySize",
-          "value": "8589934592"
+          "value": "274877906944"
         },
         {
           "key": "PlatformType",
@@ -2410,7 +2420,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "d2i1c2kdjuna1t4r4rs0"
+          "value": "d2isep0eak5cr9n8jacg"
         },
         {
           "key": "ServerInstanceStatus",
@@ -2426,11 +2436,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2025-08-19T15:13:54+0900"
+          "value": "2025-08-20T22:03:15+0900"
         },
         {
           "key": "Uptime",
-          "value": "2025-08-19T15:15:54+0900"
+          "value": "2025-08-20T22:05:28+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -2438,7 +2448,7 @@
         },
         {
           "key": "ServerProductCode",
-          "value": "SVR.VSVR.AMD.STAND.C002.M008.G003"
+          "value": "SVR.VSVR.AMD.HIMEM.C032.M256.G003"
         },
         {
           "key": "IsProtectServerTermination",
@@ -2454,23 +2464,23 @@
         },
         {
           "key": "VpcNo",
-          "value": "119520"
+          "value": "119764"
         },
         {
           "key": "SubnetNo",
-          "value": "251917"
+          "value": "252646"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "4902335"
+          "value": "4906118"
         },
         {
           "key": "InitScriptNo",
-          "value": "135227"
+          "value": "135432"
         },
         {
           "key": "ServerInstanceType",
-          "value": "{code:STAND,codeName:Standard}"
+          "value": "{code:HIMEM,codeName:High Memory}"
         },
         {
           "key": "BaseBlockStorageDiskType",
@@ -2490,7 +2500,206 @@
         },
         {
           "key": "ServerSpecCode",
-          "value": "s2-g3a"
+          "value": "m32-g3a"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2isf18eak5cr9n8jaf0",
+      "cspResourceName": "d2isf18eak5cr9n8jaf0",
+      "cspResourceId": "108292656",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
+        "latitude": 37.4754,
+        "longitude": 126.8831
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:07:13",
+      "label": {
+        "sys.connectionName": "ncpvpc-kr",
+        "sys.createdTime": "2025-08-20 13:07:13",
+        "sys.cspResourceId": "108292656",
+        "sys.cspResourceName": "d2isf18eak5cr9n8jaf0",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isf18eak5cr9n8jaf0"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "KR",
+        "Zone": "KR-1"
+      },
+      "publicIP": "49.50.133.3",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.7",
+      "privateDNS": "",
+      "rootDiskType": "SSD",
+      "rootDiskSize": "10",
+      "rootDiskName": "",
+      "connectionName": "ncpvpc-kr",
+      "connectionConfig": {
+        "configName": "ncpvpc-kr",
+        "providerName": "ncpvpc",
+        "driverName": "ncpvpc-driver-v1.0.so",
+        "credentialName": "ncpvpc",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "ncpvpc-kr",
+        "regionZoneInfo": {
+          "assignedRegion": "KR",
+          "assignedZone": "KR-1"
+        },
+        "regionDetail": {
+          "regionId": "KR",
+          "regionName": "kr",
+          "description": "Korea 1",
+          "location": {
+            "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
+            "latitude": 37.4754,
+            "longitude": 126.8831
+          },
+          "zones": [
+            "KR-1",
+            "KR-2"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "m32-g3a",
+      "cspSpecName": "m32-g3a",
+      "imageId": "23214590",
+      "cspImageName": "23214590",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "119764",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "252646",
+      "networkInterface": "eth0",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isep0eak5cr9n8jacg",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "ServerInstanceNo",
+          "value": "108292656"
+        },
+        {
+          "key": "ServerName",
+          "value": "d2isf18eak5cr9n8jaf0"
+        },
+        {
+          "key": "CpuCount",
+          "value": "32"
+        },
+        {
+          "key": "MemorySize",
+          "value": "274877906944"
+        },
+        {
+          "key": "PlatformType",
+          "value": "{code:UBD64,codeName:Ubuntu Desktop 64 Bit}"
+        },
+        {
+          "key": "LoginKeyName",
+          "value": "d2isep0eak5cr9n8jacg"
+        },
+        {
+          "key": "ServerInstanceStatus",
+          "value": "{code:RUN,codeName:서버 RUN 상태}"
+        },
+        {
+          "key": "ServerInstanceOperation",
+          "value": "{code:NULL,codeName:서버 NULL OP}"
+        },
+        {
+          "key": "ServerInstanceStatusName",
+          "value": "running"
+        },
+        {
+          "key": "CreateDate",
+          "value": "2025-08-20T22:03:21+0900"
+        },
+        {
+          "key": "Uptime",
+          "value": "2025-08-20T22:05:12+0900"
+        },
+        {
+          "key": "ServerImageProductCode",
+          "value": "SW.VSVR.OS.LNX64.UBNTU.SVR22.G003"
+        },
+        {
+          "key": "ServerProductCode",
+          "value": "SVR.VSVR.AMD.HIMEM.C032.M256.G003"
+        },
+        {
+          "key": "IsProtectServerTermination",
+          "value": "false"
+        },
+        {
+          "key": "ZoneCode",
+          "value": "KR-1"
+        },
+        {
+          "key": "RegionCode",
+          "value": "KR"
+        },
+        {
+          "key": "VpcNo",
+          "value": "119764"
+        },
+        {
+          "key": "SubnetNo",
+          "value": "252646"
+        },
+        {
+          "key": "NetworkInterfaceNoList",
+          "value": "4906119"
+        },
+        {
+          "key": "InitScriptNo",
+          "value": "135433"
+        },
+        {
+          "key": "ServerInstanceType",
+          "value": "{code:HIMEM,codeName:High Memory}"
+        },
+        {
+          "key": "BaseBlockStorageDiskType",
+          "value": "{code:NET,codeName:네트웍 스토리지}"
+        },
+        {
+          "key": "BaseBlockStorageDiskDetailType",
+          "value": "{code:SSD,codeName:SSD}"
+        },
+        {
+          "key": "HypervisorType",
+          "value": "{code:KVM,codeName:KVM}"
+        },
+        {
+          "key": "ServerImageNo",
+          "value": "23214590"
+        },
+        {
+          "key": "ServerSpecCode",
+          "value": "m32-g3a"
         }
       ]
     }
@@ -2530,13 +2739,13 @@
     {
       "resourceType": "mci",
       "id": "mmci01",
-      "uid": "d2i1c8cdjuna1t4r4rt0",
+      "uid": "d2isf18eak5cr9n8jae0",
       "name": "mmci01",
-      "status": "Running:1 (R:1/1)",
+      "status": "Running:2 (R:2/2)",
       "statusCount": {
-        "countTotal": 1,
+        "countTotal": 2,
         "countCreating": 0,
-        "countRunning": 1,
+        "countRunning": 2,
         "countFailed": 0,
         "countSuspended": 0,
         "countRebooting": 0,
@@ -2557,8 +2766,80 @@
       "vm": [
         {
           "resourceType": "mci",
+          "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+          "uid": "d2isf18eak5cr9n8jae0",
+          "name": "mmci01",
+          "subGroupId": "",
+          "location": {
+            "display": "",
+            "latitude": 0,
+            "longitude": 0
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "a recommended multi-cloud infrastructure",
+          "region": {
+            "Region": "",
+            "Zone": ""
+          },
+          "publicIP": "",
+          "sshPort": "",
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": "",
+          "rootDiskName": "",
+          "connectionName": "",
+          "connectionConfig": {
+            "configName": "",
+            "providerName": "",
+            "driverName": "",
+            "credentialName": "",
+            "credentialHolder": "",
+            "regionZoneInfoName": "",
+            "regionZoneInfo": {
+              "assignedRegion": "",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "",
+              "regionName": "",
+              "description": "",
+              "location": {
+                "display": "",
+                "latitude": 0,
+                "longitude": 0
+              },
+              "zones": null
+            },
+            "regionRepresentative": false,
+            "verified": false
+          },
+          "specId": "",
+          "cspSpecName": "",
+          "imageId": "",
+          "cspImageName": "",
+          "vNetId": "",
+          "cspVNetId": "",
+          "subnetId": "",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": null,
+          "dataDiskIds": null,
+          "sshKeyId": "",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "mci",
           "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-          "uid": "d2i1c8cdjuna1t4r4rt0",
+          "uid": "d2isf18eak5cr9n8jae0",
           "name": "mmci01",
           "subGroupId": "",
           "location": {
@@ -2690,13 +2971,13 @@
 {
   "resourceType": "mci",
   "id": "mmci01",
-  "uid": "d2i1c8cdjuna1t4r4rt0",
+  "uid": "d2isf18eak5cr9n8jae0",
   "name": "mmci01",
-  "status": "Running:1 (R:1/1)",
+  "status": "Running:2 (R:2/2)",
   "statusCount": {
-    "countTotal": 1,
+    "countTotal": 2,
     "countCreating": 0,
-    "countRunning": 1,
+    "countRunning": 2,
     "countFailed": 0,
     "countSuspended": 0,
     "countRebooting": 0,
@@ -2717,7 +2998,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "mmci01",
     "sys.namespace": "mig01",
-    "sys.uid": "d2i1c8cdjuna1t4r4rt0"
+    "sys.uid": "d2isf18eak5cr9n8jae0"
   },
   "systemLabel": "",
   "systemMessage": "",
@@ -2725,12 +3006,12 @@
   "vm": [
     {
       "resourceType": "vm",
-      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "uid": "d2i1c8cdjuna1t4r4ru0",
-      "cspResourceName": "d2i1c8cdjuna1t4r4ru0",
-      "cspResourceId": "108250326",
-      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
-      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "uid": "d2isf18eak5cr9n8jag0",
+      "cspResourceName": "d2isf18eak5cr9n8jag0",
+      "cspResourceId": "108292651",
+      "name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -2742,27 +3023,27 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2025-08-19 06:15:58",
+      "createdTime": "2025-08-20 13:05:35",
       "label": {
         "sys.connectionName": "ncpvpc-kr",
-        "sys.createdTime": "2025-08-19 06:15:58",
-        "sys.cspResourceId": "108250326",
-        "sys.cspResourceName": "d2i1c8cdjuna1t4r4ru0",
-        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.createdTime": "2025-08-20 13:05:35",
+        "sys.cspResourceId": "108292651",
+        "sys.cspResourceName": "d2isf18eak5cr9n8jag0",
+        "sys.id": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.labelType": "vm",
         "sys.manager": "cb-tumblebug",
         "sys.mciId": "mmci01",
-        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.name": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1",
         "sys.namespace": "mig01",
-        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
-        "sys.uid": "d2i1c8cdjuna1t4r4ru0"
+        "sys.subGroupId": "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isf18eak5cr9n8jag0"
       },
-      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "description": "a recommended virtual machine 02 for 0036e4b9-c8b4-e811-906e-000ffee02d5c",
       "region": {
         "Region": "KR",
         "Zone": "KR-1"
       },
-      "publicIP": "101.79.8.56",
+      "publicIP": "223.130.131.232",
       "sshPort": "22",
       "publicDNS": "",
       "privateIP": "192.168.110.6",
@@ -2799,38 +3080,38 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "s2-g3a",
-      "cspSpecName": "s2-g3a",
+      "specId": "m32-g3a",
+      "cspSpecName": "m32-g3a",
       "imageId": "23214590",
       "cspImageName": "23214590",
       "vNetId": "mig-vnet-01",
-      "cspVNetId": "119520",
+      "cspVNetId": "119764",
       "subnetId": "mig-subnet-01",
-      "cspSubnetId": "251917",
+      "cspSubnetId": "252646",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "mig-sg-01"
+        "mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "mig-sshkey-01",
-      "cspSshKeyId": "d2i1c2kdjuna1t4r4rs0",
+      "cspSshKeyId": "d2isep0eak5cr9n8jacg",
       "vmUserName": "cb-user",
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "108250326"
+          "value": "108292651"
         },
         {
           "key": "ServerName",
-          "value": "d2i1c8cdjuna1t4r4ru0"
+          "value": "d2isf18eak5cr9n8jag0"
         },
         {
           "key": "CpuCount",
-          "value": "2"
+          "value": "32"
         },
         {
           "key": "MemorySize",
-          "value": "8589934592"
+          "value": "274877906944"
         },
         {
           "key": "PlatformType",
@@ -2838,7 +3119,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "d2i1c2kdjuna1t4r4rs0"
+          "value": "d2isep0eak5cr9n8jacg"
         },
         {
           "key": "ServerInstanceStatus",
@@ -2854,11 +3135,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2025-08-19T15:13:54+0900"
+          "value": "2025-08-20T22:03:15+0900"
         },
         {
           "key": "Uptime",
-          "value": "2025-08-19T15:15:54+0900"
+          "value": "2025-08-20T22:05:28+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -2866,7 +3147,7 @@
         },
         {
           "key": "ServerProductCode",
-          "value": "SVR.VSVR.AMD.STAND.C002.M008.G003"
+          "value": "SVR.VSVR.AMD.HIMEM.C032.M256.G003"
         },
         {
           "key": "IsProtectServerTermination",
@@ -2882,23 +3163,23 @@
         },
         {
           "key": "VpcNo",
-          "value": "119520"
+          "value": "119764"
         },
         {
           "key": "SubnetNo",
-          "value": "251917"
+          "value": "252646"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "4902335"
+          "value": "4906118"
         },
         {
           "key": "InitScriptNo",
-          "value": "135227"
+          "value": "135432"
         },
         {
           "key": "ServerInstanceType",
-          "value": "{code:STAND,codeName:Standard}"
+          "value": "{code:HIMEM,codeName:High Memory}"
         },
         {
           "key": "BaseBlockStorageDiskType",
@@ -2918,7 +3199,206 @@
         },
         {
           "key": "ServerSpecCode",
-          "value": "s2-g3a"
+          "value": "m32-g3a"
+        }
+      ]
+    },
+    {
+      "resourceType": "vm",
+      "id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "uid": "d2isf18eak5cr9n8jaf0",
+      "cspResourceName": "d2isf18eak5cr9n8jaf0",
+      "cspResourceId": "108292656",
+      "name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+      "subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "location": {
+        "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
+        "latitude": 37.4754,
+        "longitude": 126.8831
+      },
+      "status": "Running",
+      "targetStatus": "None",
+      "targetAction": "None",
+      "monAgentStatus": "notInstalled",
+      "networkAgentStatus": "notInstalled",
+      "systemMessage": "",
+      "createdTime": "2025-08-20 13:07:13",
+      "label": {
+        "sys.connectionName": "ncpvpc-kr",
+        "sys.createdTime": "2025-08-20 13:07:13",
+        "sys.cspResourceId": "108292656",
+        "sys.cspResourceName": "d2isf18eak5cr9n8jaf0",
+        "sys.id": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.labelType": "vm",
+        "sys.manager": "cb-tumblebug",
+        "sys.mciId": "mmci01",
+        "sys.name": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c-1",
+        "sys.namespace": "mig01",
+        "sys.subGroupId": "migrated-00a9f3d4-74b6-e811-906e-000ffee02d5c",
+        "sys.uid": "d2isf18eak5cr9n8jaf0"
+      },
+      "description": "a recommended virtual machine 01 for 00a9f3d4-74b6-e811-906e-000ffee02d5c",
+      "region": {
+        "Region": "KR",
+        "Zone": "KR-1"
+      },
+      "publicIP": "49.50.133.3",
+      "sshPort": "22",
+      "publicDNS": "",
+      "privateIP": "192.168.110.7",
+      "privateDNS": "",
+      "rootDiskType": "SSD",
+      "rootDiskSize": "10",
+      "rootDiskName": "",
+      "connectionName": "ncpvpc-kr",
+      "connectionConfig": {
+        "configName": "ncpvpc-kr",
+        "providerName": "ncpvpc",
+        "driverName": "ncpvpc-driver-v1.0.so",
+        "credentialName": "ncpvpc",
+        "credentialHolder": "admin",
+        "regionZoneInfoName": "ncpvpc-kr",
+        "regionZoneInfo": {
+          "assignedRegion": "KR",
+          "assignedZone": "KR-1"
+        },
+        "regionDetail": {
+          "regionId": "KR",
+          "regionName": "kr",
+          "description": "Korea 1",
+          "location": {
+            "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
+            "latitude": 37.4754,
+            "longitude": 126.8831
+          },
+          "zones": [
+            "KR-1",
+            "KR-2"
+          ]
+        },
+        "regionRepresentative": true,
+        "verified": true
+      },
+      "specId": "m32-g3a",
+      "cspSpecName": "m32-g3a",
+      "imageId": "23214590",
+      "cspImageName": "23214590",
+      "vNetId": "mig-vnet-01",
+      "cspVNetId": "119764",
+      "subnetId": "mig-subnet-01",
+      "cspSubnetId": "252646",
+      "networkInterface": "eth0",
+      "securityGroupIds": [
+        "mig-sg-01"
+      ],
+      "dataDiskIds": null,
+      "sshKeyId": "mig-sshkey-01",
+      "cspSshKeyId": "d2isep0eak5cr9n8jacg",
+      "vmUserName": "cb-user",
+      "addtionalDetails": [
+        {
+          "key": "ServerInstanceNo",
+          "value": "108292656"
+        },
+        {
+          "key": "ServerName",
+          "value": "d2isf18eak5cr9n8jaf0"
+        },
+        {
+          "key": "CpuCount",
+          "value": "32"
+        },
+        {
+          "key": "MemorySize",
+          "value": "274877906944"
+        },
+        {
+          "key": "PlatformType",
+          "value": "{code:UBD64,codeName:Ubuntu Desktop 64 Bit}"
+        },
+        {
+          "key": "LoginKeyName",
+          "value": "d2isep0eak5cr9n8jacg"
+        },
+        {
+          "key": "ServerInstanceStatus",
+          "value": "{code:RUN,codeName:서버 RUN 상태}"
+        },
+        {
+          "key": "ServerInstanceOperation",
+          "value": "{code:NULL,codeName:서버 NULL OP}"
+        },
+        {
+          "key": "ServerInstanceStatusName",
+          "value": "running"
+        },
+        {
+          "key": "CreateDate",
+          "value": "2025-08-20T22:03:21+0900"
+        },
+        {
+          "key": "Uptime",
+          "value": "2025-08-20T22:05:12+0900"
+        },
+        {
+          "key": "ServerImageProductCode",
+          "value": "SW.VSVR.OS.LNX64.UBNTU.SVR22.G003"
+        },
+        {
+          "key": "ServerProductCode",
+          "value": "SVR.VSVR.AMD.HIMEM.C032.M256.G003"
+        },
+        {
+          "key": "IsProtectServerTermination",
+          "value": "false"
+        },
+        {
+          "key": "ZoneCode",
+          "value": "KR-1"
+        },
+        {
+          "key": "RegionCode",
+          "value": "KR"
+        },
+        {
+          "key": "VpcNo",
+          "value": "119764"
+        },
+        {
+          "key": "SubnetNo",
+          "value": "252646"
+        },
+        {
+          "key": "NetworkInterfaceNoList",
+          "value": "4906119"
+        },
+        {
+          "key": "InitScriptNo",
+          "value": "135433"
+        },
+        {
+          "key": "ServerInstanceType",
+          "value": "{code:HIMEM,codeName:High Memory}"
+        },
+        {
+          "key": "BaseBlockStorageDiskType",
+          "value": "{code:NET,codeName:네트웍 스토리지}"
+        },
+        {
+          "key": "BaseBlockStorageDiskDetailType",
+          "value": "{code:SSD,codeName:SSD}"
+        },
+        {
+          "key": "HypervisorType",
+          "value": "{code:KVM,codeName:KVM}"
+        },
+        {
+          "key": "ServerImageNo",
+          "value": "23214590"
+        },
+        {
+          "key": "ServerSpecCode",
+          "value": "m32-g3a"
         }
       ]
     }

--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
 services:
   # cm-beetle
   cm-beetle:
-    image: cloudbaristaorg/cm-beetle:0.3.4
+    image: cloudbaristaorg/cm-beetle:0.3.5
     container_name: cm-beetle
     build:
       context: ${COMPOSE_PROJECT_ROOT}
@@ -84,7 +84,7 @@ services:
       - TB_SPIDER_REST_URL=http://cb-spider:1024/spider
       - TB_ETCD_ENDPOINTS=http://cb-tumblebug-etcd:2379
       - TB_TERRARIUM_REST_URL=http://mc-terrarium:8055/terrarium
-      - TB_IAM_MANAGER_REST_URL=http://mc-iam-manager:5000
+      # - TB_IAM_MANAGER_REST_URL=http://mc-iam-manager:5000
       # - TB_ETCD_AUTH_ENABLED=false
       # - TB_ETCD_USERNAME=default
       # - TB_ETCD_PASSWORD=default

--- a/docs/beetle-v0.4.0-integration-and-testing-with-tumblebug-honeybee-and-model.md
+++ b/docs/beetle-v0.4.0-integration-and-testing-with-tumblebug-honeybee-and-model.md
@@ -10,9 +10,9 @@
 > [!NOTE]
 > It will continue to be updated until the v0.4.0 release.
 
-- Beetle v0.3.4
+- Beetle v0.3.5
 - cm-model v0.0.11 (It may be applied to Damselfly)
-- Honeybee v0.3.1
+- Honeybee v0.3.3 (?) (Used always-running server)
 - Tumblebug v0.11.3 (Spider v0.11.1, CB-MapUI v0.11.4)
 
 ### Scenario
@@ -21,7 +21,7 @@
 1. Get the refined source computing infra info via Honeybee
 
 - Refined source computing infra info = on-premise model (a.k.a computing infra source model)
-- **Used 2 servers info** as dicussed (i.e., web, nfs)
+- **Used 2 servers info** as dicussed (i.e., cm-web, cm-nfs)
 
 1. Recommend a target model for computing infra via Beetle
 1. Migrate the computing infra as defined in the target model via Beetle
@@ -34,53 +34,89 @@
 
 > [!Note]
 > The Honeybee has been providing the always-running servers. The server has been used.
+> Honeybee Server Swagger UI: http://210.207.104.224:8081/honeybee/api/index.html
 
 ### Get a list of source group
-
-> [!NOTE]
-> To be updated
 
 - API: `GET /source_group`
 - Request body: None
 - Response body:
 
-```json
-
-```
-
-### Get the refined computing infra info
-
-> [!NOTE]
-> To be updated
-
-- API: `GET /source_group/{sgId}/infra/refined`
-- sgId: `db652288-047b-480b-ac86-3ef7ed57f68e`
-- Request body: None
-- Response body:
-
 <details>
-  <summary> <ins>Click to see the response body </ins> </summary>
+  <summary>Click to see the response body</summary>
 
 ```json
-
+{
+  "source_group": [
+    {
+      "id": "db652288-047b-480b-ac86-3ef7ed57f68e",
+      "name": "cm-test",
+      "description": "Cloud-Migrator Test Source Group",
+      "connection_info_status_count": {
+        "count_connection_success": 5,
+        "count_connection_failed": 0,
+        "count_agent_success": 5,
+        "count_agent_failed": 0,
+        "connection_info_total": 5
+      }
+    },
+    {
+      "id": "ddcfa917-17e0-4718-a878-f1e99f97ed6d",
+      "name": "migration-test",
+      "description": "Migration Test Group",
+      "connection_info_status_count": {
+        "count_connection_success": 2,
+        "count_connection_failed": 0,
+        "count_agent_success": 2,
+        "count_agent_failed": 0,
+        "connection_info_total": 2
+      }
+    }
+  ],
+  "connection_info_status_count": {
+    "count_connection_success": 7,
+    "count_connection_failed": 0,
+    "count_agent_success": 7,
+    "count_agent_failed": 0,
+    "connection_info_total": 7
+  }
+}
 ```
 
 </details>
 
-> [!NOTE]
+### Get the refined computing infra info
+
+> [!INFO]
 > Tests were performed using the onpremiseInfraModel provided in advance by the Honeybee maintainer. Thank you!
 
-> [!INFO]  
-> We are testing with a lower memory specification (8GiB instead of 255GiB) than the actual infrastructure.
+> [!NOTE]  
+> We are testing with a lower memory specification (e.g, 8GiB, 16GiB, 32GiB, 64GiB) than the actual infrastructure one (i.e., 255GiB).
 >
 > - Reason: **This prevents test failures caused by cloud provider quota limits**, which are unrelated to our system's core functionality.
 > - Note 1: Default VM quotas vary by Cloud Service Provider (CSP)—some are even zero—and may require users to request an increase.
 > - Note 2: If infrastructure creation fails due to quota issues, all deployed resources must be rolled back **one by one**.
 
-<details>
-  <summary><ins>Click to see the onpremise model</ins></summary>
+(Original Memory spec)
 
-(Onpremise Infra Model)
+```json
+    "memory": {
+     "type": "DDR4",
+     "totalSize": 255,
+     "available": 146,
+     "used": 109
+    }
+```
+
+- API: `GET /source_group/{sgId}/infra/refined`
+- sgId: `ddcfa917-17e0-4718-a878-f1e99f97ed6d`
+- Request body: None
+- Response body:
+
+<details>
+  <summary> <ins>Click to see the response body (onpremise model) </ins> </summary>
+
+Note: Downgraded memory spec
 
 ```json
 {
@@ -92,6 +128,11 @@
             "ip": "192.168.110.254",
             "interfaceName": "br-ex",
             "machineId": "00a9f3d4-74b6-e811-906e-000ffee02d5c"
+          },
+          {
+            "ip": "192.168.110.254",
+            "interfaceName": "br-ex",
+            "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c"
           }
         ]
       },
@@ -112,9 +153,9 @@
         },
         "memory": {
           "type": "DDR4",
-          "totalSize": 8,
-          "available": 3,
-          "used": 5
+          "totalSize": 64,
+          "available": 30,
+          "used": 34
         },
         "rootDisk": {
           "label": "unknown",
@@ -1063,573 +1104,752 @@
             "protocol": "udp",
             "direction": "inbound",
             "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.5 LTS",
+          "version": "22.04.5 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "cm-web",
+        "machineId": "0036e4b9-c8b4-e811-906e-000ffee02d5c",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 2,
+          "cores": 18,
+          "threads": 36,
+          "maxSpeed": 3.7,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 32,
+          "available": 14,
+          "used": 18
+        },
+        "rootDisk": {
+          "label": "unknown",
+          "type": "HDD",
+          "totalSize": 1312,
+          "available": 1222,
+          "used": 23
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": ["127.0.0.1/8"],
+            "ipv6CidrBlocks": ["::1/128"],
+            "mtu": 65536,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp24s0f0",
+            "macAddress": "b4:96:91:53:01:58",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "name": "enp24s0f1",
+            "macAddress": "b4:96:91:53:01:59",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "icmp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f0",
+            "macAddress": "b4:96:91:55:23:8c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "67",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "68",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno1np0",
+            "macAddress": "a4:bf:01:5a:b1:1b",
+            "ipv4CidrBlocks": ["172.29.0.103/24"],
+            "ipv6CidrBlocks": ["fe80::a6bf:1ff:fe5a:b11b/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "224.0.0.251/32",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f0",
+            "macAddress": "b4:96:91:53:01:6c",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "239.255.255.250/32",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp26s0f1",
+            "macAddress": "b4:96:91:53:01:6d",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "eno2np1",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv6CidrBlocks": ["fe80::a6bf:1ff:fe5a:b11c/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp175s0f1",
+            "macAddress": "b4:96:91:55:23:8e",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f0",
+            "macAddress": "b4:96:91:55:1e:04",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8086",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "enp177s0f1",
+            "macAddress": "b4:96:91:55:1e:06",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8888",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "ovs-system",
+            "macAddress": "6e:a8:ca:69:96:82",
+            "mtu": 1500
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9201",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-ex",
+            "macAddress": "a4:bf:01:5a:b1:1c",
+            "ipv4CidrBlocks": ["192.168.110.103/24"],
+            "ipv6CidrBlocks": ["2001::1000/64", "fe80::7824:d2ff:fe2c:7330/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9202",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "genev_sys_6081",
+            "macAddress": "fa:e3:ea:20:21:0c",
+            "ipv6CidrBlocks": ["fe80::2caf:1eff:fe7f:f78f/64"],
+            "mtu": 65000,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9203",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "br-int",
+            "macAddress": "ea:d0:e7:43:23:41",
+            "mtu": 1442
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9204",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap334a688a-76",
+            "macAddress": "fe:16:3e:52:10:6e",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe52:106e/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9206",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd4e69ee0-72",
+            "macAddress": "fe:16:3e:2c:59:7a",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe2c:597a/64"],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap50ee370b-a7",
+            "macAddress": "fe:16:3e:71:22:43",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe71:2243/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "3000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape46b2f03-d0",
+            "macAddress": "fe:16:3e:e2:ea:0f",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fee2:ea0f/64"],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap78b1ab69-36",
+            "macAddress": "fe:16:3e:14:65:fb",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe14:65fb/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tape545ab95-ab",
+            "macAddress": "fe:16:3e:73:24:90",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe73:2490/64"],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9001",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapadd1bc06-e8",
+            "macAddress": "fe:16:3e:26:ea:51",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe26:ea51/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "18080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tapd7ff0608-f0",
+            "macAddress": "fe:16:3e:2b:75:d6",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe2b:75d6/64"],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "13000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap26b9063f-c8",
+            "macAddress": "fe:16:3e:6c:c9:90",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe6c:c990/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9101",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap0d667e3a-e2",
+            "macAddress": "fe:16:3e:9f:7a:65",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe9f:7a65/64"],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9100",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1df68fb5-f9",
+            "macAddress": "fe:16:3e:13:66:6f",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe13:666f/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9106",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap3b66c516-59",
+            "macAddress": "fe:16:3e:77:e4:da",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe77:e4da/64"],
+            "mtu": 1442,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9105",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap6f653485-7f",
+            "macAddress": "fe:16:3e:7d:85:5b",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fe7d:855b/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8080",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap1479d90f-c0",
+            "macAddress": "02:b9:31:31:0d:fe",
+            "ipv6CidrBlocks": ["fe80::b9:31ff:fe31:dfe/64"],
+            "mtu": 1500,
+            "state": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9102",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "name": "tap87daf3f9-0f",
+            "macAddress": "fe:16:3e:cb:97:79",
+            "ipv6CidrBlocks": ["fe80::fc16:3eff:fecb:9779/64"],
+            "mtu": 1500,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9103",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "172.29.0.0/24",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "9104",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "192.168.110.0/24",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "5672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "1883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "4369",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "15675",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "25672",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8883",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "16567",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "192.168.110.0/24",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "8000",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "0.0.0.0/0",
-            "srcPorts": "*",
-            "dstCIDR": "0.0.0.0/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "inbound",
-            "action": "deny"
+            "destination": "fe80::/64",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "547",
-            "dstCIDR": "fe80::/10",
-            "dstPorts": "546",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::fb/128",
-            "dstPorts": "5353",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "ff02::f/128",
-            "dstPorts": "1900",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::/64",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "22",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "80",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "443",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "2001::1000/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::b9:31ff:fe31:dfe/128",
+            "interface": "tap1479d90f-c0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "inbound",
-            "action": "allow"
+            "destination": "fe80::2caf:1eff:fe7f:f78f/128",
+            "interface": "genev_sys_6081",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::7824:d2ff:fe2c:7330/128",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "*",
-            "direction": "outbound",
-            "action": "deny"
+            "destination": "fe80::a6bf:1ff:fe5a:b11b/128",
+            "interface": "eno1np0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::a6bf:1ff:fe5a:b11c/128",
+            "interface": "eno2np1",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "fe80::/10",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "icmpv6",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe13:666f/128",
+            "interface": "tap1df68fb5-f9",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "tcp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe14:65fb/128",
+            "interface": "tap78b1ab69-36",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           },
           {
-            "srcCIDR": "::/0",
-            "srcPorts": "*",
-            "dstCIDR": "::/0",
-            "dstPorts": "*",
-            "protocol": "udp",
-            "direction": "outbound",
-            "action": "allow"
+            "destination": "fe80::fc16:3eff:fe26:ea51/128",
+            "interface": "tapadd1bc06-e8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2b:75d6/128",
+            "interface": "tapd7ff0608-f0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe2c:597a/128",
+            "interface": "tapd4e69ee0-72",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe52:106e/128",
+            "interface": "tap334a688a-76",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe6c:c990/128",
+            "interface": "tap26b9063f-c8",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe71:2243/128",
+            "interface": "tap50ee370b-a7",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe73:2490/128",
+            "interface": "tape545ab95-ab",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe77:e4da/128",
+            "interface": "tap3b66c516-59",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe7d:855b/128",
+            "interface": "tap6f653485-7f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fe9f:7a65/128",
+            "interface": "tap0d667e3a-e2",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fecb:9779/128",
+            "interface": "tap87daf3f9-0f",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::fc16:3eff:fee2:ea0f/128",
+            "interface": "tape46b2f03-d0",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno2np1",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "eno1np0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "192.168.110.254",
+            "interface": "br-ex",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "genev_sys_6081",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap334a688a-76",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd4e69ee0-72",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap50ee370b-a7",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape46b2f03-d0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap78b1ab69-36",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tape545ab95-ab",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapadd1bc06-e8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tapd7ff0608-f0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap26b9063f-c8",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap0d667e3a-e2",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1df68fb5-f9",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap3b66c516-59",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap6f653485-7f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap1479d90f-c0",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "interface": "tap87daf3f9-0f",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
           }
         ],
         "os": {
@@ -1647,17 +1867,6 @@
 }
 ```
 
-(Original Memory spec)
-
-```json
-    "memory": {
-     "type": "DDR4",
-     "totalSize": 255,
-     "available": 146,
-     "used": 109
-    }
-```
-
 </details>
 
 ## Beetle section
@@ -1666,10 +1875,14 @@ Testing was performed by `test-cli`.
 
 - ✅ [Test result for AWS](../cmd/test-cli/testresult/beetle-test-results-aws.md)
 - ✅ [Test result for Azure](../cmd/test-cli/testresult/beetle-test-results-azure.md)
+  - Note: May not be recommended if the image and spec are suitable for high memory (i.e., 255GiB) / (ok: 32GiB, 64GiB)
 - ✅ [Test result for GCP](../cmd/test-cli/testresult/beetle-test-results-gcp.md)
+  - Note: May not be recommended if the image and spec are suitable for high memory (i.e., 255GiB) / (ok: 32GiB, 64GiB)
   - Note: Unable to create a vNet/Subnet if the quota is full. However, the error message was `Subnet ID not found`.
 - ⚠️ [Test result for Alibaba](../cmd/test-cli/testresult/beetle-test-results-alibaba.md)
-  - Note: Failed to delete vNet/subnet
-- ⚠️ [Test result for NCP](../cmd/test-cli/testresult/beetle-test-results-ncp.md)
-  - Note: Deadline excceeded when deleting MCI if the image and spec are configured improperly (may not be compatible)
+  - Note: vNet/subnet is sometimes not completely deleted.
+- ✅ [Test result for NCP](../cmd/test-cli/testresult/beetle-test-results-ncp.md)
+  - Note: Deadline exceeded when deleting MCI if the image and spec are configured improperly (may not be compatible)
+  - Note: May not be recommended if the image and spec are suitable for high memory (i.e., 255GiB)
+    - Default Quota of High Memory M-g3 is 0.
 - TBD


### PR DESCRIPTION
- Make NVMe driver optional for Xen AMIs on Nitro instances
- Remove hardcoded instance family lists for maintainability
- Allow Xen-on-Nitro compatibility with ENA driver support only
- Add permissive fallback for unknown driver compatibility cases
- Enable debug logging in development environment
- Testing on 5 CSPs