### PR TITLE
feat(experimental): Add data migration API with transx integration

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -66,6 +66,59 @@ const docTemplate = `{
                 }
             }
         },
+        "/migration/data": {
+            "post": {
+                "description": "Migrate data from source to target\n\n* Only relay mode is supported for now (both source and destination should be remote endpoints).\n* Supported methods: rsync, object storage API (AWS S3 style)\n* Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Migration] Data (experimental)"
+                ],
+                "summary": "Migrate data from source to target",
+                "operationId": "MigrateData",
+                "parameters": [
+                    {
+                        "description": "Request Body",
+                        "name": "reqBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/transx.DataMigrationModel"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/migration/ns/{nsId}/mci": {
             "get": {
                 "description": "Get the migrated multi-cloud infrastructure (MCI)",
@@ -5061,6 +5114,214 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.VNetInfo"
                     }
+                }
+            }
+        },
+        "transx.DataMigrationModel": {
+            "type": "object",
+            "required": [
+                "destination",
+                "destinationTransferOptions",
+                "source",
+                "sourceTransferOptions"
+            ],
+            "properties": {
+                "destination": {
+                    "description": "Destination endpoint configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.EndpointDetails"
+                        }
+                    ]
+                },
+                "destinationTransferOptions": {
+                    "description": "Destination-specific transfer options",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.TransferOptions"
+                        }
+                    ]
+                },
+                "source": {
+                    "description": "Source endpoint configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.EndpointDetails"
+                        }
+                    ]
+                },
+                "sourceTransferOptions": {
+                    "description": "Source-specific transfer options",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.TransferOptions"
+                        }
+                    ]
+                }
+            }
+        },
+        "transx.EndpointDetails": {
+            "type": "object",
+            "required": [
+                "dataPath"
+            ],
+            "properties": {
+                "backupCmd": {
+                    "description": "Command execution",
+                    "type": "string"
+                },
+                "dataPath": {
+                    "description": "Data location (required)",
+                    "type": "string"
+                },
+                "endpoint": {
+                    "description": "Endpoint configuration (auto-detects protocol based on provided fields)",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Port for SSH host/IP (default: 22) or Object Storage API endpoint (default: 1024)",
+                    "type": "integer"
+                },
+                "restoreCmd": {
+                    "description": "Restore command string to be executed on this endpoint",
+                    "type": "string"
+                }
+            }
+        },
+        "transx.ObjectStorageTransferOption": {
+            "type": "object",
+            "required": [
+                "accessKeyId"
+            ],
+            "properties": {
+                "accessKeyId": {
+                    "description": "AWS S3 Authentication (REQUIRED - must be provided by user)",
+                    "type": "string"
+                },
+                "expiresIn": {
+                    "description": "Presigned URL configuration",
+                    "type": "integer",
+                    "default": 3600
+                },
+                "maxRetries": {
+                    "description": "Maximum number of retry attempts (default: 3)",
+                    "type": "integer",
+                    "default": 3
+                },
+                "timeout": {
+                    "description": "HTTP request configuration (optional)",
+                    "type": "integer",
+                    "default": 300
+                },
+                "verifySSL": {
+                    "description": "Verify SSL certificates (CB-Spider default: false)",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "transx.RsyncOption": {
+            "type": "object",
+            "properties": {
+                "archive": {
+                    "description": "-a, --archive: Archive mode; equals -rlptgoD (no -H,-A,-X)",
+                    "type": "boolean",
+                    "default": true
+                },
+                "compress": {
+                    "description": "Rsync-specific options",
+                    "type": "boolean",
+                    "default": true
+                },
+                "connectTimeout": {
+                    "description": "SSH connection timeout in seconds",
+                    "type": "integer",
+                    "default": 30
+                },
+                "delete": {
+                    "description": "--delete: Delete extraneous files from dest dirs",
+                    "type": "boolean",
+                    "default": false
+                },
+                "dryRun": {
+                    "description": "Perform a trial run with no changes made",
+                    "type": "boolean",
+                    "default": false
+                },
+                "exclude": {
+                    "description": "--exclude=PATTERN: List of patterns to exclude",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include": {
+                    "description": "--include=PATTERN: List of patterns to include",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "insecureSkipHostKeyVerification": {
+                    "description": "InsecureSkipHostKeyVerification, if true, relaxes host key checking for SSH connections.\nAdds \"-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null\" options.\nWarning: This can be a security risk and should only be used in trusted environments.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "progress": {
+                    "description": "Show progress during transfer",
+                    "type": "boolean",
+                    "default": false
+                },
+                "rsyncPath": {
+                    "description": "Path to the rsync executable (if empty, uses system PATH)",
+                    "type": "string",
+                    "default": "rsync"
+                },
+                "sshPrivateKeyPath": {
+                    "description": "SSH private key path",
+                    "type": "string"
+                },
+                "transferDirContentsOnly": {
+                    "description": "TransferDirContentsOnly, if true, adds a trailing slash to source paths\nto transfer only the contents of the directory and not the directory itself.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "username": {
+                    "description": "SSH connection \u0026 authentication options (integrated)",
+                    "type": "string"
+                },
+                "verbose": {
+                    "description": "Transfer behavior options",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "transx.TransferOptions": {
+            "type": "object",
+            "required": [
+                "method"
+            ],
+            "properties": {
+                "method": {
+                    "description": "Transfer method specification (required)",
+                    "type": "string"
+                },
+                "objectStorageTransferOptions": {
+                    "description": "Object Storage-specific options (CB-Spider, AWS S3, etc.)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.ObjectStorageTransferOption"
+                        }
+                    ]
+                },
+                "rsyncOptions": {
+                    "description": "Rsync-specific options",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.RsyncOption"
+                        }
+                    ]
                 }
             }
         }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -60,6 +60,59 @@
                 }
             }
         },
+        "/migration/data": {
+            "post": {
+                "description": "Migrate data from source to target\n\n* Only relay mode is supported for now (both source and destination should be remote endpoints).\n* Supported methods: rsync, object storage API (AWS S3 style)\n* Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Migration] Data (experimental)"
+                ],
+                "summary": "Migrate data from source to target",
+                "operationId": "MigrateData",
+                "parameters": [
+                    {
+                        "description": "Request Body",
+                        "name": "reqBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/transx.DataMigrationModel"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/migration/ns/{nsId}/mci": {
             "get": {
                 "description": "Get the migrated multi-cloud infrastructure (MCI)",
@@ -5055,6 +5108,214 @@
                     "items": {
                         "$ref": "#/definitions/model.VNetInfo"
                     }
+                }
+            }
+        },
+        "transx.DataMigrationModel": {
+            "type": "object",
+            "required": [
+                "destination",
+                "destinationTransferOptions",
+                "source",
+                "sourceTransferOptions"
+            ],
+            "properties": {
+                "destination": {
+                    "description": "Destination endpoint configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.EndpointDetails"
+                        }
+                    ]
+                },
+                "destinationTransferOptions": {
+                    "description": "Destination-specific transfer options",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.TransferOptions"
+                        }
+                    ]
+                },
+                "source": {
+                    "description": "Source endpoint configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.EndpointDetails"
+                        }
+                    ]
+                },
+                "sourceTransferOptions": {
+                    "description": "Source-specific transfer options",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.TransferOptions"
+                        }
+                    ]
+                }
+            }
+        },
+        "transx.EndpointDetails": {
+            "type": "object",
+            "required": [
+                "dataPath"
+            ],
+            "properties": {
+                "backupCmd": {
+                    "description": "Command execution",
+                    "type": "string"
+                },
+                "dataPath": {
+                    "description": "Data location (required)",
+                    "type": "string"
+                },
+                "endpoint": {
+                    "description": "Endpoint configuration (auto-detects protocol based on provided fields)",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Port for SSH host/IP (default: 22) or Object Storage API endpoint (default: 1024)",
+                    "type": "integer"
+                },
+                "restoreCmd": {
+                    "description": "Restore command string to be executed on this endpoint",
+                    "type": "string"
+                }
+            }
+        },
+        "transx.ObjectStorageTransferOption": {
+            "type": "object",
+            "required": [
+                "accessKeyId"
+            ],
+            "properties": {
+                "accessKeyId": {
+                    "description": "AWS S3 Authentication (REQUIRED - must be provided by user)",
+                    "type": "string"
+                },
+                "expiresIn": {
+                    "description": "Presigned URL configuration",
+                    "type": "integer",
+                    "default": 3600
+                },
+                "maxRetries": {
+                    "description": "Maximum number of retry attempts (default: 3)",
+                    "type": "integer",
+                    "default": 3
+                },
+                "timeout": {
+                    "description": "HTTP request configuration (optional)",
+                    "type": "integer",
+                    "default": 300
+                },
+                "verifySSL": {
+                    "description": "Verify SSL certificates (CB-Spider default: false)",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "transx.RsyncOption": {
+            "type": "object",
+            "properties": {
+                "archive": {
+                    "description": "-a, --archive: Archive mode; equals -rlptgoD (no -H,-A,-X)",
+                    "type": "boolean",
+                    "default": true
+                },
+                "compress": {
+                    "description": "Rsync-specific options",
+                    "type": "boolean",
+                    "default": true
+                },
+                "connectTimeout": {
+                    "description": "SSH connection timeout in seconds",
+                    "type": "integer",
+                    "default": 30
+                },
+                "delete": {
+                    "description": "--delete: Delete extraneous files from dest dirs",
+                    "type": "boolean",
+                    "default": false
+                },
+                "dryRun": {
+                    "description": "Perform a trial run with no changes made",
+                    "type": "boolean",
+                    "default": false
+                },
+                "exclude": {
+                    "description": "--exclude=PATTERN: List of patterns to exclude",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include": {
+                    "description": "--include=PATTERN: List of patterns to include",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "insecureSkipHostKeyVerification": {
+                    "description": "InsecureSkipHostKeyVerification, if true, relaxes host key checking for SSH connections.\nAdds \"-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null\" options.\nWarning: This can be a security risk and should only be used in trusted environments.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "progress": {
+                    "description": "Show progress during transfer",
+                    "type": "boolean",
+                    "default": false
+                },
+                "rsyncPath": {
+                    "description": "Path to the rsync executable (if empty, uses system PATH)",
+                    "type": "string",
+                    "default": "rsync"
+                },
+                "sshPrivateKeyPath": {
+                    "description": "SSH private key path",
+                    "type": "string"
+                },
+                "transferDirContentsOnly": {
+                    "description": "TransferDirContentsOnly, if true, adds a trailing slash to source paths\nto transfer only the contents of the directory and not the directory itself.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "username": {
+                    "description": "SSH connection \u0026 authentication options (integrated)",
+                    "type": "string"
+                },
+                "verbose": {
+                    "description": "Transfer behavior options",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "transx.TransferOptions": {
+            "type": "object",
+            "required": [
+                "method"
+            ],
+            "properties": {
+                "method": {
+                    "description": "Transfer method specification (required)",
+                    "type": "string"
+                },
+                "objectStorageTransferOptions": {
+                    "description": "Object Storage-specific options (CB-Spider, AWS S3, etc.)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.ObjectStorageTransferOption"
+                        }
+                    ]
+                },
+                "rsyncOptions": {
+                    "description": "Rsync-specific options",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/transx.RsyncOption"
+                        }
+                    ]
                 }
             }
         }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2521,6 +2521,156 @@ definitions:
           $ref: '#/definitions/model.VNetInfo'
         type: array
     type: object
+  transx.DataMigrationModel:
+    properties:
+      destination:
+        allOf:
+        - $ref: '#/definitions/transx.EndpointDetails'
+        description: Destination endpoint configuration
+      destinationTransferOptions:
+        allOf:
+        - $ref: '#/definitions/transx.TransferOptions'
+        description: Destination-specific transfer options
+      source:
+        allOf:
+        - $ref: '#/definitions/transx.EndpointDetails'
+        description: Source endpoint configuration
+      sourceTransferOptions:
+        allOf:
+        - $ref: '#/definitions/transx.TransferOptions'
+        description: Source-specific transfer options
+    required:
+    - destination
+    - destinationTransferOptions
+    - source
+    - sourceTransferOptions
+    type: object
+  transx.EndpointDetails:
+    properties:
+      backupCmd:
+        description: Command execution
+        type: string
+      dataPath:
+        description: Data location (required)
+        type: string
+      endpoint:
+        description: Endpoint configuration (auto-detects protocol based on provided
+          fields)
+        type: string
+      port:
+        description: 'Port for SSH host/IP (default: 22) or Object Storage API endpoint
+          (default: 1024)'
+        type: integer
+      restoreCmd:
+        description: Restore command string to be executed on this endpoint
+        type: string
+    required:
+    - dataPath
+    type: object
+  transx.ObjectStorageTransferOption:
+    properties:
+      accessKeyId:
+        description: AWS S3 Authentication (REQUIRED - must be provided by user)
+        type: string
+      expiresIn:
+        default: 3600
+        description: Presigned URL configuration
+        type: integer
+      maxRetries:
+        default: 3
+        description: 'Maximum number of retry attempts (default: 3)'
+        type: integer
+      timeout:
+        default: 300
+        description: HTTP request configuration (optional)
+        type: integer
+      verifySSL:
+        default: false
+        description: 'Verify SSL certificates (CB-Spider default: false)'
+        type: boolean
+    required:
+    - accessKeyId
+    type: object
+  transx.RsyncOption:
+    properties:
+      archive:
+        default: true
+        description: '-a, --archive: Archive mode; equals -rlptgoD (no -H,-A,-X)'
+        type: boolean
+      compress:
+        default: true
+        description: Rsync-specific options
+        type: boolean
+      connectTimeout:
+        default: 30
+        description: SSH connection timeout in seconds
+        type: integer
+      delete:
+        default: false
+        description: '--delete: Delete extraneous files from dest dirs'
+        type: boolean
+      dryRun:
+        default: false
+        description: Perform a trial run with no changes made
+        type: boolean
+      exclude:
+        description: '--exclude=PATTERN: List of patterns to exclude'
+        items:
+          type: string
+        type: array
+      include:
+        description: '--include=PATTERN: List of patterns to include'
+        items:
+          type: string
+        type: array
+      insecureSkipHostKeyVerification:
+        default: false
+        description: |-
+          InsecureSkipHostKeyVerification, if true, relaxes host key checking for SSH connections.
+          Adds "-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null" options.
+          Warning: This can be a security risk and should only be used in trusted environments.
+        type: boolean
+      progress:
+        default: false
+        description: Show progress during transfer
+        type: boolean
+      rsyncPath:
+        default: rsync
+        description: Path to the rsync executable (if empty, uses system PATH)
+        type: string
+      sshPrivateKeyPath:
+        description: SSH private key path
+        type: string
+      transferDirContentsOnly:
+        default: false
+        description: |-
+          TransferDirContentsOnly, if true, adds a trailing slash to source paths
+          to transfer only the contents of the directory and not the directory itself.
+        type: boolean
+      username:
+        description: SSH connection & authentication options (integrated)
+        type: string
+      verbose:
+        default: false
+        description: Transfer behavior options
+        type: boolean
+    type: object
+  transx.TransferOptions:
+    properties:
+      method:
+        description: Transfer method specification (required)
+        type: string
+      objectStorageTransferOptions:
+        allOf:
+        - $ref: '#/definitions/transx.ObjectStorageTransferOption'
+        description: Object Storage-specific options (CB-Spider, AWS S3, etc.)
+      rsyncOptions:
+        allOf:
+        - $ref: '#/definitions/transx.RsyncOption'
+        description: Rsync-specific options
+    required:
+    - method
+    type: object
 externalDocs:
   description: ▶▶▶ CB-Tumblebug REST API (access via Beetle's reverse proxy)
   url: http://localhost:8056/tumblebug/api/index.html
@@ -2566,6 +2716,46 @@ paths:
       summary: Check HTTP version of incoming request
       tags:
       - '[Admin] System management'
+  /migration/data:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Migrate data from source to target
+
+        * Only relay mode is supported for now (both source and destination should be remote endpoints).
+        * Supported methods: rsync, object storage API (AWS S3 style)
+        * Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples
+      operationId: MigrateData
+      parameters:
+      - description: Request Body
+        in: body
+        name: reqBody
+        required: true
+        schema:
+          $ref: '#/definitions/transx.DataMigrationModel'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Migrate data from source to target
+      tags:
+      - '[Migration] Data (experimental)'
   /migration/ns/{nsId}/mci:
     get:
       consumes:

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yunkon-kim/transx v0.0.1 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.12 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.12 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yunkon-kim/transx v0.0.1 h1:ifjv0VdxniRdwOU98fZBLr6k+hbAjSporE4GntLr1N4=
+github.com/yunkon-kim/transx v0.0.1/go.mod h1:S8Sp4FcqJMvseBnI5KhA4DX6v3D1nWhlbsYR9sG0i8E=
 go.etcd.io/etcd/api/v3 v3.5.12 h1:W4sw5ZoU2Juc9gBWuLk5U6fHfNVyY1WC5g9uiXZio/c=
 go.etcd.io/etcd/api/v3 v3.5.12/go.mod h1:Ot+o0SWSyT6uHhA56al1oCED0JImsRiU9Dc26+C2a+4=
 go.etcd.io/etcd/client/pkg/v3 v3.5.12 h1:EYDL6pWwyOsylrQyLp2w+HkQ46ATiOvoEdMarindU2A=

--- a/pkg/api/rest/controller/migration-data.go
+++ b/pkg/api/rest/controller/migration-data.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller has handlers and their request/response bodies for migration APIs
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
+	"github.com/yunkon-kim/transx"
+)
+
+// MigrateData godoc
+// @ID MigrateData
+// @Summary Migrate data from source to target
+// @Description Migrate data from source to target
+// @Description
+// @Description * Only relay mode is supported for now (both source and destination should be remote endpoints).
+// @Description * Supported methods: rsync, object storage API (AWS S3 style)
+// @Description * Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples
+// @Tags [Migration] Data (experimental)
+// @Accept  json
+// @Produce  json
+// @Param reqBody body transx.DataMigrationModel true "Request Body"
+// @Success 200 {object} common.SimpleMsg "OK"
+// @Failure 400 {object} common.SimpleMsg "Bad Request"
+// @Failure 404 {object} common.SimpleMsg "Not Found"
+// @Failure 500 {object} common.SimpleMsg "Internal Server Error"
+// @Router /migration/data [post]
+func MigrateData(c echo.Context) error {
+
+	req := new(transx.DataMigrationModel)
+	if err := c.Bind(req); err != nil {
+		log.Error().Err(err).Msg("failed to bind the request")
+		return c.JSON(http.StatusBadRequest, common.SimpleMsg{Message: err.Error()})
+	}
+
+	err := transx.Validate(*req)
+	if err != nil {
+		log.Error().Err(err).Msg("invalid request")
+		return c.JSON(http.StatusBadRequest, common.SimpleMsg{Message: err.Error()})
+	}
+
+	if !(req.Source.IsRemote() && req.Destination.IsRemote()) {
+		err := fmt.Errorf("%s", "both source and destination should be remote endpoints")
+		log.Error().Err(err).Msg("invalid request")
+		return c.JSON(http.StatusBadRequest, common.SimpleMsg{Message: err.Error()})
+	}
+
+	log.Info().Msgf("Migrate data from %s (%s) to %s (%s)", req.Source.GetEndpoint(), req.Source.DataPath, req.Destination.GetEndpoint(), req.Destination.DataPath)
+
+	err = transx.Transfer(*req)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to migrate data")
+		return c.JSON(http.StatusInternalServerError, common.SimpleMsg{Message: err.Error()})
+	}
+
+	log.Info().Msg("Data migration completed successfully")
+	return c.JSON(http.StatusOK, common.SimpleMsg{Message: "Data migration completed successfully"})
+
+}

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -207,13 +207,6 @@ func RunServer(port string) {
 	// Test utility APIs
 	gBeetle.GET("/test/tracing", rest_common.TestTracing)
 
-	// Namespace API group
-	// gNamespace := gBeetle.Group("/ns")
-	// gNamespace.POST("", controller.RestPostNs)
-	// gNamespace.GET("", controller.RestGetAllNs)
-	// gNamespace.GET("/:nsId", controller.RestGetNs)
-	// gNamespace.DELETE("/:nsId", controller.RestDeleteNs)
-
 	/*
 	 * API group for computing infra recommendation
 	 */
@@ -238,6 +231,13 @@ func RunServer(port string) {
 	gMigration := gBeetle.Group("/migration")
 	// Custom middleware to check if the Tumblebug is initialized
 	gMigration.Use(middlewares.TumblebugInitChecker)
+
+	// Namespace APIs
+	// gNamespace := gBeetle.Group("/ns")
+	// gNamespace.POST("", controller.RestPostNs)
+	// gNamespace.GET("", controller.RestGetAllNs)
+	// gNamespace.GET("/:nsId", controller.RestGetNs)
+	// gNamespace.DELETE("/:nsId", controller.RestDeleteNs)
 
 	// Migration APIs for VM infrastructure
 	gMigration.POST("/ns/:nsId/mciWithDefaults", controller.MigrateInfraWithDefaults)
@@ -277,6 +277,9 @@ func RunServer(port string) {
 	gMigration.POST("/ns/:nsId/resources/sshKey", controller.CreateMigratedSSHKey)
 	gMigration.GET("/ns/:nsId/resources/sshKey/:sshKeyId", controller.GetMigratedSSHKey)
 	gMigration.DELETE("/ns/:nsId/resources/sshKey/:sshKeyId", controller.DeleteMigratedSSHKey)
+
+	// APIs for data migration (Experimental)
+	gMigration.POST("/data", controller.MigrateData)
 
 	// Start API server
 	selfEndpoint := config.Beetle.Self.Endpoint


### PR DESCRIPTION
* Integrate transx library and add experimental data migration API for transferring data between remote endpoints using rsync and S3-style methods
* Support relay mode data migration with validation and error handling for remote-to-remote transfers