### PR TITLE
docs(api): standardize CSP terminology in object storage

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -68,7 +68,7 @@ const docTemplate = `{
         },
         "/migration/data": {
             "post": {
-                "description": "Migrate data from source to target\n\n* Only relay mode is supported for now (both source and destination should be remote endpoints).\n* Supported methods: rsync, object storage API (AWS S3 style)\n* Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples",
+                "description": "Migrate data from source to target\n\n[Note]\n* Only relay mode is supported for now (both source and destination should be remote endpoints).\n* Supported methods: rsync, object storage\n\n[Note]\n* Examples(test result): https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -121,7 +121,7 @@ const docTemplate = `{
         },
         "/migration/middleware/objectStorage": {
             "get": {
-                "description": "Get the list of all object storages (buckets) in the specified cloud provider and region\n\n[Note] Connection name format: ` + "`" + `{provider}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)",
+                "description": "Get the list of all object storages (buckets) in the specified cloud service provider and region\n\n[Note] Connection name format: ` + "`" + `{csp}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)",
                 "consumes": [
                     "application/json"
                 ],
@@ -137,15 +137,12 @@ const docTemplate = `{
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -186,7 +183,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note] This API creates object storages (buckets) in the target cloud.\n- Input should be the output from RecommendObjectStorage API\n- Connection name format: ` + "`" + `{provider}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)",
+                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note] This API creates object storages (buckets) in the target cloud.\n- Input should be the output from RecommendObjectStorage API\n- Connection name format: ` + "`" + `{csp}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)\n\n[Note]\n* Examples(test result): https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -236,7 +233,7 @@ const docTemplate = `{
         },
         "/migration/middleware/objectStorage/{objectStorageName}": {
             "get": {
-                "description": "Get details of a specific object storage (bucket)\n\n[Note] Connection name format: ` + "`" + `{provider}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)",
+                "description": "Get details of a specific object storage (bucket)\n\n[Note] Connection name format: ` + "`" + `{csp}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)",
                 "consumes": [
                     "application/json"
                 ],
@@ -259,15 +256,12 @@ const docTemplate = `{
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -314,7 +308,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Delete a specific object storage (bucket)\n\n[Note]\n- Connection name format: ` + "`" + `{provider}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)\n- The bucket must be empty before deletion",
+                "description": "Delete a specific object storage (bucket)\n\n[Note]\n- Connection name format: ` + "`" + `{csp}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)\n- The bucket must be empty before deletion",
                 "consumes": [
                     "application/json"
                 ],
@@ -337,15 +331,12 @@ const docTemplate = `{
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -389,7 +380,7 @@ const docTemplate = `{
                 }
             },
             "head": {
-                "description": "Check if a specific object storage (bucket) exists\n\n[Note]\n- Connection name format: ` + "`" + `{provider}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)\n- Returns 200 OK if the bucket exists, 404 Not Found if it doesn't exist",
+                "description": "Check if a specific object storage (bucket) exists\n\n[Note]\n- Connection name format: ` + "`" + `{csp}-{region}` + "`" + ` (e.g., aws-ap-northeast-2)\n- Returns 200 OK if the bucket exists, 404 Not Found if it doesn't exist",
                 "consumes": [
                     "application/json"
                 ],
@@ -412,15 +403,12 @@ const docTemplate = `{
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -1943,7 +1931,7 @@ const docTemplate = `{
         },
         "/recommendation/middleware/objectStorage": {
             "post": {
-                "description": "Recommend an appropriate object storage for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
+                "description": "Recommend an appropriate object storage for cloud migration\n\n[Note] ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n[Warning] the recommended bucket name may be globally unique.\n- Beetle supports adding a suffix based on the existing bucket name to ensure uniqueness.\n- Suppose that the existing bucket name is unique enough.\n- Generate a suffix based on the existing bucket name.\n- e.g., \"my-bucket\" -\u003e SHA256 hash -\u003e base64 URL-safe encoding (6 bytes) -\u003e lowercase -\u003e \"my-bucket-{suffix}\"",
                 "consumes": [
                     "application/json"
                 ],
@@ -1975,8 +1963,8 @@ const docTemplate = `{
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
+                        "description": "CSP (e.g., aws, azure, gcp)",
+                        "name": "desiredCsp",
                         "in": "query"
                     },
                     {
@@ -4618,7 +4606,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "bucketName": {
-                    "description": "Recommended target bucket name with random suffix by xid pkg",
+                    "description": "Recommended target bucket name with deterministic suffix",
                     "type": "string"
                 },
                 "corsEnabled": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -62,7 +62,7 @@
         },
         "/migration/data": {
             "post": {
-                "description": "Migrate data from source to target\n\n* Only relay mode is supported for now (both source and destination should be remote endpoints).\n* Supported methods: rsync, object storage API (AWS S3 style)\n* Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples",
+                "description": "Migrate data from source to target\n\n[Note]\n* Only relay mode is supported for now (both source and destination should be remote endpoints).\n* Supported methods: rsync, object storage\n\n[Note]\n* Examples(test result): https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -115,7 +115,7 @@
         },
         "/migration/middleware/objectStorage": {
             "get": {
-                "description": "Get the list of all object storages (buckets) in the specified cloud provider and region\n\n[Note] Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)",
+                "description": "Get the list of all object storages (buckets) in the specified cloud service provider and region\n\n[Note] Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)",
                 "consumes": [
                     "application/json"
                 ],
@@ -131,15 +131,12 @@
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -180,7 +177,7 @@
                 }
             },
             "post": {
-                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note] This API creates object storages (buckets) in the target cloud.\n- Input should be the output from RecommendObjectStorage API\n- Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)",
+                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note] This API creates object storages (buckets) in the target cloud.\n- Input should be the output from RecommendObjectStorage API\n- Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)\n\n[Note]\n* Examples(test result): https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -230,7 +227,7 @@
         },
         "/migration/middleware/objectStorage/{objectStorageName}": {
             "get": {
-                "description": "Get details of a specific object storage (bucket)\n\n[Note] Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)",
+                "description": "Get details of a specific object storage (bucket)\n\n[Note] Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)",
                 "consumes": [
                     "application/json"
                 ],
@@ -253,15 +250,12 @@
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -308,7 +302,7 @@
                 }
             },
             "delete": {
-                "description": "Delete a specific object storage (bucket)\n\n[Note]\n- Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)\n- The bucket must be empty before deletion",
+                "description": "Delete a specific object storage (bucket)\n\n[Note]\n- Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)\n- The bucket must be empty before deletion",
                 "consumes": [
                     "application/json"
                 ],
@@ -331,15 +325,12 @@
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -383,7 +374,7 @@
                 }
             },
             "head": {
-                "description": "Check if a specific object storage (bucket) exists\n\n[Note]\n- Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)\n- Returns 200 OK if the bucket exists, 404 Not Found if it doesn't exist",
+                "description": "Check if a specific object storage (bucket) exists\n\n[Note]\n- Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)\n- Returns 200 OK if the bucket exists, 404 Not Found if it doesn't exist",
                 "consumes": [
                     "application/json"
                 ],
@@ -406,15 +397,12 @@
                     {
                         "enum": [
                             "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
+                            "alibaba"
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Cloud provider",
-                        "name": "provider",
+                        "description": "Cloud service provider",
+                        "name": "csp",
                         "in": "query",
                         "required": true
                     },
@@ -1937,7 +1925,7 @@
         },
         "/recommendation/middleware/objectStorage": {
             "post": {
-                "description": "Recommend an appropriate object storage for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
+                "description": "Recommend an appropriate object storage for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n[Warning] the recommended bucket name may be globally unique.\n- Beetle supports adding a suffix based on the existing bucket name to ensure uniqueness.\n- Suppose that the existing bucket name is unique enough.\n- Generate a suffix based on the existing bucket name.\n- e.g., \"my-bucket\" -\u003e SHA256 hash -\u003e base64 URL-safe encoding (6 bytes) -\u003e lowercase -\u003e \"my-bucket-{suffix}\"",
                 "consumes": [
                     "application/json"
                 ],
@@ -1969,8 +1957,8 @@
                         ],
                         "type": "string",
                         "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
+                        "description": "CSP (e.g., aws, azure, gcp)",
+                        "name": "desiredCsp",
                         "in": "query"
                     },
                     {
@@ -4612,7 +4600,7 @@
             "type": "object",
             "properties": {
                 "bucketName": {
-                    "description": "Recommended target bucket name with random suffix by xid pkg",
+                    "description": "Recommended target bucket name with deterministic suffix",
                     "type": "string"
                 },
                 "corsEnabled": {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1713,7 +1713,7 @@ definitions:
   controller.TargetObjectStorageProperty:
     properties:
       bucketName:
-        description: Recommended target bucket name with random suffix by xid pkg
+        description: Recommended target bucket name with deterministic suffix
         type: string
       corsEnabled:
         description: Whether CORS is configured
@@ -2940,12 +2940,15 @@ paths:
     post:
       consumes:
       - application/json
-      description: |-
+      description: |
         Migrate data from source to target
 
+        [Note]
         * Only relay mode is supported for now (both source and destination should be remote endpoints).
-        * Supported methods: rsync, object storage API (AWS S3 style)
-        * Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples
+        * Supported methods: rsync, object storage
+
+        [Note]
+        * Examples(test result): https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md
       operationId: MigrateData
       parameters:
       - description: Request Body
@@ -2981,21 +2984,18 @@ paths:
       consumes:
       - application/json
       description: |-
-        Get the list of all object storages (buckets) in the specified cloud provider and region
+        Get the list of all object storages (buckets) in the specified cloud service provider and region
 
-        [Note] Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)
+        [Note] Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)
       operationId: ListObjectStorages
       parameters:
       - default: aws
-        description: Cloud provider
+        description: Cloud service provider
         enum:
         - aws
-        - azure
-        - gcp
         - alibaba
-        - ncp
         in: query
-        name: provider
+        name: csp
         required: true
         type: string
       - default: ap-northeast-2
@@ -3029,12 +3029,15 @@ paths:
     post:
       consumes:
       - application/json
-      description: |-
+      description: |
         Migrate object storages to cloud based on recommendation results
 
         [Note] This API creates object storages (buckets) in the target cloud.
         - Input should be the output from RecommendObjectStorage API
-        - Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)
+        - Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)
+
+        [Note]
+        * Examples(test result): https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md
       operationId: MigrateObjectStorage
       parameters:
       - description: Object storage migration request (use RecommendObjectStorage
@@ -3072,7 +3075,7 @@ paths:
         Delete a specific object storage (bucket)
 
         [Note]
-        - Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)
+        - Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)
         - The bucket must be empty before deletion
       operationId: DeleteObjectStorage
       parameters:
@@ -3082,15 +3085,12 @@ paths:
         required: true
         type: string
       - default: aws
-        description: Cloud provider
+        description: Cloud service provider
         enum:
         - aws
-        - azure
-        - gcp
         - alibaba
-        - ncp
         in: query
-        name: provider
+        name: csp
         required: true
         type: string
       - default: ap-northeast-2
@@ -3129,7 +3129,7 @@ paths:
       description: |-
         Get details of a specific object storage (bucket)
 
-        [Note] Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)
+        [Note] Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)
       operationId: GetObjectStorage
       parameters:
       - description: Object Storage Name (bucket name)
@@ -3138,15 +3138,12 @@ paths:
         required: true
         type: string
       - default: aws
-        description: Cloud provider
+        description: Cloud service provider
         enum:
         - aws
-        - azure
-        - gcp
         - alibaba
-        - ncp
         in: query
-        name: provider
+        name: csp
         required: true
         type: string
       - default: ap-northeast-2
@@ -3188,7 +3185,7 @@ paths:
         Check if a specific object storage (bucket) exists
 
         [Note]
-        - Connection name format: `{provider}-{region}` (e.g., aws-ap-northeast-2)
+        - Connection name format: `{csp}-{region}` (e.g., aws-ap-northeast-2)
         - Returns 200 OK if the bucket exists, 404 Not Found if it doesn't exist
       operationId: ExistObjectStorage
       parameters:
@@ -3198,15 +3195,12 @@ paths:
         required: true
         type: string
       - default: aws
-        description: Cloud provider
+        description: Cloud service provider
         enum:
         - aws
-        - azure
-        - gcp
         - alibaba
-        - ncp
         in: query
-        name: provider
+        name: csp
         required: true
         type: string
       - default: ap-northeast-2
@@ -4276,10 +4270,16 @@ paths:
       description: |-
         Recommend an appropriate object storage for cloud migration
 
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
+        [Note] `desiredCsp` and `desiredRegion` are required.
+        - `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.
 
-        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
+        - If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.
+
+        [Warning] the recommended bucket name may be globally unique.
+        - Beetle supports adding a suffix based on the existing bucket name to ensure uniqueness.
+        - Suppose that the existing bucket name is unique enough.
+        - Generate a suffix based on the existing bucket name.
+        - e.g., "my-bucket" -> SHA256 hash -> base64 URL-safe encoding (6 bytes) -> lowercase -> "my-bucket-{suffix}"
       operationId: RecommendObjectStorage
       parameters:
       - description: Specify the your object storage to be migrated
@@ -4289,7 +4289,7 @@ paths:
         schema:
           $ref: '#/definitions/controller.RecommendObjectStorageRequest'
       - default: aws
-        description: Provider (e.g., aws, azure, gcp)
+        description: CSP (e.g., aws, azure, gcp)
         enum:
         - aws
         - azure
@@ -4297,7 +4297,7 @@ paths:
         - alibaba
         - ncp
         in: query
-        name: desiredProvider
+        name: desiredCsp
         type: string
       - default: ap-northeast-2
         description: Region (e.g., ap-northeast-2)

--- a/docs/test-results-data-migration.md
+++ b/docs/test-results-data-migration.md
@@ -1,8 +1,9 @@
 # Data Migration API Test Results
 
 > [!IMPORTANT]
-> * Beetle provides a **relay-style data migration** API for security reasons.
-> * `transx` package supports both **direct and relay-style data transfer**.
+>
+> - Beetle provides a **relay-style data migration** API for security reasons.
+> - `transx` package supports both **direct and relay-style data transfer**.
 
 **Test Date:** October 29, 2025  
 **Source Bucket Name:** `aws-ap-northeast-2-bucket-2uk0i5`  
@@ -135,10 +136,11 @@ cd ~/dev/cloud-barista/cm-beetle/transx/examples/object-storage
 ./migrate.sh -c config-spider-upload.json -v
 ```
 
-**(sample) config-spider-upload.json** 
+**(sample) config-spider-upload.json**
 
 > [!NOTE]
-> * masking secrets (e.g. xxxxxxxxxxxxxxxxx)
+>
+> - masking secrets (e.g. xxxxxxxxxxxxxxxxx)
 
 ```json
 {
@@ -168,8 +170,6 @@ cd ~/dev/cloud-barista/cm-beetle/transx/examples/object-storage
 
 <img width="1651" height="1230" alt="image" src="https://github.com/user-attachments/assets/160c908e-0846-47dd-8c56-3d2bb8c5b3f8" />
 
-
-
 ## Test: Migrate Data from Source to Target Object Storage
 
 **Status:** ✅ SUCCESS
@@ -177,10 +177,11 @@ cd ~/dev/cloud-barista/cm-beetle/transx/examples/object-storage
 **Request:**
 
 > [!NOTE]
-> * masking secrets (e.g. xxxxxxxxxxxxxxxxx)
-> * Use `minio` clinet to access and download data from the source object storage
-> * Use `spider` client to access and upload data to the target object storage
-> * Set spider endpoint `http://cb-spider:1024/spider/s3` on Cloud-Migrator platform
+>
+> - masking secrets (e.g. xxxxxxxxxxxxxxxxx)
+> - Use `minio` clinet to access and download data from the source object storage
+> - Use `spider` client to access and upload data to the target object storage
+> - Set spider endpoint `http://cb-spider:1024/spider/s3` on Cloud-Migrator platform
 
 ```bash
 curl -s -X POST http://localhost:8056/beetle/migration/data \
@@ -242,9 +243,9 @@ curl -s -X POST http://localhost:8056/beetle/migration/data \
 
 ### Test Results
 
-| Test | API                               | Method | Status     | Response Time |
-| ---- | --------------------------------- | ------ | ---------- | ------------- |
-| 1    | MigrateData                       | POST   | ✅ SUCCESS | ~4s           |
+| Test | API         | Method | Status     | Response Time |
+| ---- | ----------- | ------ | ---------- | ------------- |
+| 1    | MigrateData | POST   | ✅ SUCCESS | ~4s           |
 
 --
 

--- a/docs/test-results-object-storage.md
+++ b/docs/test-results-object-storage.md
@@ -180,7 +180,7 @@ curl -X POST http://localhost:8056/beetle/migration/middleware/objectStorage \
 
 - This API returns HTTP status code only (no response body)
 - Bucket `beetle-bucket-10jqka-panpn5tv` successfully created in AWS S3 ap-northeast-2
-- Connection name format: `aws-ap-northeast-2` (auto-generated from provider + region)
+- Connection name format: `aws-ap-northeast-2` (auto-generated from csp + region)
 
 ---
 
@@ -191,7 +191,7 @@ curl -X POST http://localhost:8056/beetle/migration/middleware/objectStorage \
 **Request:**
 
 ```bash
-curl -X GET "http://localhost:8056/beetle/migration/middleware/objectStorage?provider=aws&region=ap-northeast-2" \
+curl -X GET "http://localhost:8056/beetle/migration/middleware/objectStorage?csp=aws&region=ap-northeast-2" \
   -H "Content-Type: application/json" \
   -u "default:default"
 ```
@@ -225,7 +225,7 @@ curl -X GET "http://localhost:8056/beetle/migration/middleware/objectStorage?pro
 **Request:**
 
 ```bash
-curl -X HEAD "http://localhost:8056/beetle/migration/middleware/objectStorage/beetle-bucket-10jqka-panpn5tv?provider=aws&region=ap-northeast-2" \
+curl -X HEAD "http://localhost:8056/beetle/migration/middleware/objectStorage/beetle-bucket-10jqka-panpn5tv?csp=aws&region=ap-northeast-2" \
   -u "default:default"
 ```
 
@@ -251,7 +251,7 @@ curl -X HEAD "http://localhost:8056/beetle/migration/middleware/objectStorage/be
 **Request:**
 
 ```bash
-curl -X GET "http://localhost:8056/beetle/migration/middleware/objectStorage/beetle-bucket-10jqka-panpn5tv?provider=aws&region=ap-northeast-2" \
+curl -X GET "http://localhost:8056/beetle/migration/middleware/objectStorage/beetle-bucket-10jqka-panpn5tv?csp=aws&region=ap-northeast-2" \
   -H "Content-Type: application/json" \
   -u "default:default"
 ```
@@ -285,7 +285,7 @@ curl -X GET "http://localhost:8056/beetle/migration/middleware/objectStorage/bee
 **Request:**
 
 ```bash
-curl -X DELETE "http://localhost:8056/beetle/migration/middleware/objectStorage/beetle-bucket-10jqka-panpn5tv?provider=aws&region=ap-northeast-2" \
+curl -X DELETE "http://localhost:8056/beetle/migration/middleware/objectStorage/beetle-bucket-10jqka-panpn5tv?csp=aws&region=ap-northeast-2" \
   -H "Content-Type: application/json" \
   -u "default:default"
 ```
@@ -415,4 +415,3 @@ The APIs are production-ready and provide comprehensive object storage managemen
 **Source and target (migrated) object storages**
 
 <img width="1653" height="573" alt="image" src="https://github.com/user-attachments/assets/c675f512-c513-4f91-9839-8dbda0379ca9" />
-

--- a/pkg/api/rest/controller/migration-data.go
+++ b/pkg/api/rest/controller/migration-data.go
@@ -29,9 +29,13 @@ import (
 // @Summary Migrate data from source to target
 // @Description Migrate data from source to target
 // @Description
+// @Description [Note]
 // @Description * Only relay mode is supported for now (both source and destination should be remote endpoints).
-// @Description * Supported methods: rsync, object storage API (AWS S3 style)
-// @Description * Examples: https://github.com/yunkon-kim/transx?tab=readme-ov-file#examples
+// @Description * Supported methods: rsync, object storage
+// @Description
+// @Description [Note] 
+// @Description * Examples(test result): https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md
+// @Description
 // @Tags [Migration] Data (incubating)
 // @Accept  json
 // @Produce  json


### PR DESCRIPTION
- Replace "provider" with "csp" in API parameters
- Update Swagger docs with test result references
- Remove unsupported CSPs from enum (azure, gcp, ncp)