### PR TITLE
fix(recommendation): handle 'all' protocol in SG rules

### DIFF
--- a/pkg/core/recommendation/resource-sg.go
+++ b/pkg/core/recommendation/resource-sg.go
@@ -281,16 +281,16 @@ func generateSecurityGroupRules(rules []onpremmodel.FirewallRuleProperty) []clou
 
 			protocolLower := strings.ToLower(protocol)
 			switch protocolLower {
-			case "icmp":
+			case "icmp", "all":
 				tbRule := cloudmodel.FirewallRuleReq{
 					Direction: rule.Direction,
 					Protocol:  protocol,
 					CIDR:      srcCIDR,
 				}
 				tbRules = append(tbRules, tbRule)
-				log.Debug().Msgf("Created inbound rule for 'ICMP' protocol: %+v", tbRule)
+				log.Debug().Msgf("Created inbound rule for '%s' protocol: %+v", protocol, tbRule)
 
-			case "tcp", "udp", "all":
+			case "tcp", "udp":
 				var dstPorts string
 				// Handle wildcard ports based on protocol
 				if rule.DstPorts == "*" {


### PR DESCRIPTION
- Move 'all' protocol to ICMP case (no port needed)
- Remove 'all' from TCP/UDP case (port required)
- Fix log message to show actual protocol

refs) 
- https://github.com/cloud-barista/cm-beetle/issues/240#issuecomment-3489250854
- https://github.com/cloud-barista/cb-tumblebug/pull/2198
