### PR TITLE
feat(api): add HTML format to summary/report APIs

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2307,12 +2307,13 @@ const docTemplate = `{
         },
         "/report/migration/ns/{nsId}/mci/{mciId}": {
             "post": {
-                "description": "Generate a comprehensive migration report comparing source infrastructure with target cloud VMs, including resource mappings, network/security analysis, cost summary, and recommendations",
+                "description": "Generate a comprehensive migration report comparing source infrastructure with target cloud VMs, including resource mappings, network/security analysis, cost summary, and recommendations in Markdown or HTML format",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
-                    "text/plain"
+                    "text/markdown",
+                    "text/html"
                 ],
                 "tags": [
                     "[Summary/Report] Infrastructure Analysis for Migration"
@@ -2339,6 +2340,28 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "enum": [
+                            "md",
+                            "html"
+                        ],
+                        "type": "string",
+                        "default": "md",
+                        "description": "Report format: md or html",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "default": "false",
+                        "description": "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)",
+                        "name": "download",
+                        "in": "query"
+                    },
+                    {
                         "description": "Source infrastructure data from on-premise",
                         "name": "onpremiseInfraModel",
                         "in": "body",
@@ -2350,9 +2373,19 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Markdown formatted migration report",
+                        "description": "Migration report in markdown or HTML format",
                         "schema": {
                             "type": "string"
+                        },
+                        "headers": {
+                            "Content-Disposition": {
+                                "type": "string",
+                                "description": "inline; filename=\\\"migration-report.md\\\" or \\\"migration-report.html\\\" (or attachment when download=true)"
+                            },
+                            "Content-Type": {
+                                "type": "string",
+                                "description": "text/markdown; charset=utf-8 or text/html; charset=utf-8"
+                            }
                         }
                     },
                     "400": {
@@ -2372,13 +2405,14 @@ const docTemplate = `{
         },
         "/summary/source": {
             "post": {
-                "description": "Generate a comprehensive source infrastructure summary from on-premise data in JSON or Markdown format",
+                "description": "Generate a comprehensive source infrastructure summary from on-premise data in JSON, Markdown, or HTML format",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json",
-                    "text/markdown"
+                    "text/markdown",
+                    "text/html"
                 ],
                 "tags": [
                     "[Summary/Report] Infrastructure Analysis for Migration"
@@ -2389,12 +2423,24 @@ const docTemplate = `{
                     {
                         "enum": [
                             "json",
-                            "md"
+                            "md",
+                            "html"
                         ],
                         "type": "string",
                         "default": "md",
-                        "description": "Summary format: json or md",
+                        "description": "Summary format: json, md, or html",
                         "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "default": "false",
+                        "description": "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)",
+                        "name": "download",
                         "in": "query"
                     },
                     {
@@ -2415,7 +2461,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Different return types: json format returns SourceInfraSummary object, md format returns markdown string",
+                        "description": "Different return types: json format returns SourceInfraSummary object, md format returns markdown string, html format returns HTML string",
                         "schema": {
                             "allOf": [
                                 {
@@ -2424,6 +2470,9 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
+                                        "[HTML]": {
+                                            "type": "string"
+                                        },
                                         "[JSON]": {
                                             "$ref": "#/definitions/summary.SourceInfraSummary"
                                         },
@@ -2433,6 +2482,16 @@ const docTemplate = `{
                                     }
                                 }
                             ]
+                        },
+                        "headers": {
+                            "Content-Disposition": {
+                                "type": "string",
+                                "description": "inline; filename=\\\"source-summary.md\\\" or \\\"source-summary.html\\\" (or attachment when download=true)"
+                            },
+                            "Content-Type": {
+                                "type": "string",
+                                "description": "text/markdown; charset=utf-8 or text/html; charset=utf-8"
+                            }
                         }
                     },
                     "400": {
@@ -2452,13 +2511,14 @@ const docTemplate = `{
         },
         "/summary/target/ns/{nsId}/mci/{mciId}": {
             "get": {
-                "description": "Generate a comprehensive target infrastructure summary in JSON or Markdown format",
+                "description": "Generate a comprehensive target infrastructure summary in JSON, Markdown, or HTML format",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json",
-                    "text/markdown"
+                    "text/markdown",
+                    "text/html"
                 ],
                 "tags": [
                     "[Summary/Report] Infrastructure Analysis for Migration"
@@ -2485,12 +2545,24 @@ const docTemplate = `{
                     {
                         "enum": [
                             "json",
-                            "md"
+                            "md",
+                            "html"
                         ],
                         "type": "string",
                         "default": "md",
-                        "description": "Summary format: json or md",
+                        "description": "Summary format: json, md, or html",
                         "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "default": "false",
+                        "description": "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)",
+                        "name": "download",
                         "in": "query"
                     },
                     {
@@ -2502,7 +2574,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Different return types: json format returns TargetInfraSummary object, md format returns markdown string",
+                        "description": "Different return types: json format returns TargetInfraSummary object, md format returns markdown string, html format returns HTML string",
                         "schema": {
                             "allOf": [
                                 {
@@ -2511,6 +2583,9 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
+                                        "[HTML]": {
+                                            "type": "string"
+                                        },
                                         "[JSON]": {
                                             "$ref": "#/definitions/summary.TargetInfraSummary"
                                         },
@@ -2520,6 +2595,16 @@ const docTemplate = `{
                                     }
                                 }
                             ]
+                        },
+                        "headers": {
+                            "Content-Disposition": {
+                                "type": "string",
+                                "description": "inline; filename=\\\"target-summary.md\\\" or \\\"target-summary.html\\\" (or attachment when download=true)"
+                            },
+                            "Content-Type": {
+                                "type": "string",
+                                "description": "text/markdown; charset=utf-8 or text/html; charset=utf-8"
+                            }
                         }
                     },
                     "400": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2301,12 +2301,13 @@
         },
         "/report/migration/ns/{nsId}/mci/{mciId}": {
             "post": {
-                "description": "Generate a comprehensive migration report comparing source infrastructure with target cloud VMs, including resource mappings, network/security analysis, cost summary, and recommendations",
+                "description": "Generate a comprehensive migration report comparing source infrastructure with target cloud VMs, including resource mappings, network/security analysis, cost summary, and recommendations in Markdown or HTML format",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
-                    "text/plain"
+                    "text/markdown",
+                    "text/html"
                 ],
                 "tags": [
                     "[Summary/Report] Infrastructure Analysis for Migration"
@@ -2333,6 +2334,28 @@
                         "required": true
                     },
                     {
+                        "enum": [
+                            "md",
+                            "html"
+                        ],
+                        "type": "string",
+                        "default": "md",
+                        "description": "Report format: md or html",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "default": "false",
+                        "description": "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)",
+                        "name": "download",
+                        "in": "query"
+                    },
+                    {
                         "description": "Source infrastructure data from on-premise",
                         "name": "onpremiseInfraModel",
                         "in": "body",
@@ -2344,9 +2367,19 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Markdown formatted migration report",
+                        "description": "Migration report in markdown or HTML format",
                         "schema": {
                             "type": "string"
+                        },
+                        "headers": {
+                            "Content-Disposition": {
+                                "type": "string",
+                                "description": "inline; filename=\\\"migration-report.md\\\" or \\\"migration-report.html\\\" (or attachment when download=true)"
+                            },
+                            "Content-Type": {
+                                "type": "string",
+                                "description": "text/markdown; charset=utf-8 or text/html; charset=utf-8"
+                            }
                         }
                     },
                     "400": {
@@ -2366,13 +2399,14 @@
         },
         "/summary/source": {
             "post": {
-                "description": "Generate a comprehensive source infrastructure summary from on-premise data in JSON or Markdown format",
+                "description": "Generate a comprehensive source infrastructure summary from on-premise data in JSON, Markdown, or HTML format",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json",
-                    "text/markdown"
+                    "text/markdown",
+                    "text/html"
                 ],
                 "tags": [
                     "[Summary/Report] Infrastructure Analysis for Migration"
@@ -2383,12 +2417,24 @@
                     {
                         "enum": [
                             "json",
-                            "md"
+                            "md",
+                            "html"
                         ],
                         "type": "string",
                         "default": "md",
-                        "description": "Summary format: json or md",
+                        "description": "Summary format: json, md, or html",
                         "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "default": "false",
+                        "description": "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)",
+                        "name": "download",
                         "in": "query"
                     },
                     {
@@ -2409,7 +2455,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Different return types: json format returns SourceInfraSummary object, md format returns markdown string",
+                        "description": "Different return types: json format returns SourceInfraSummary object, md format returns markdown string, html format returns HTML string",
                         "schema": {
                             "allOf": [
                                 {
@@ -2418,6 +2464,9 @@
                                 {
                                     "type": "object",
                                     "properties": {
+                                        "[HTML]": {
+                                            "type": "string"
+                                        },
                                         "[JSON]": {
                                             "$ref": "#/definitions/summary.SourceInfraSummary"
                                         },
@@ -2427,6 +2476,16 @@
                                     }
                                 }
                             ]
+                        },
+                        "headers": {
+                            "Content-Disposition": {
+                                "type": "string",
+                                "description": "inline; filename=\\\"source-summary.md\\\" or \\\"source-summary.html\\\" (or attachment when download=true)"
+                            },
+                            "Content-Type": {
+                                "type": "string",
+                                "description": "text/markdown; charset=utf-8 or text/html; charset=utf-8"
+                            }
                         }
                     },
                     "400": {
@@ -2446,13 +2505,14 @@
         },
         "/summary/target/ns/{nsId}/mci/{mciId}": {
             "get": {
-                "description": "Generate a comprehensive target infrastructure summary in JSON or Markdown format",
+                "description": "Generate a comprehensive target infrastructure summary in JSON, Markdown, or HTML format",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json",
-                    "text/markdown"
+                    "text/markdown",
+                    "text/html"
                 ],
                 "tags": [
                     "[Summary/Report] Infrastructure Analysis for Migration"
@@ -2479,12 +2539,24 @@
                     {
                         "enum": [
                             "json",
-                            "md"
+                            "md",
+                            "html"
                         ],
                         "type": "string",
                         "default": "md",
-                        "description": "Summary format: json or md",
+                        "description": "Summary format: json, md, or html",
                         "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "default": "false",
+                        "description": "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)",
+                        "name": "download",
                         "in": "query"
                     },
                     {
@@ -2496,7 +2568,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Different return types: json format returns TargetInfraSummary object, md format returns markdown string",
+                        "description": "Different return types: json format returns TargetInfraSummary object, md format returns markdown string, html format returns HTML string",
                         "schema": {
                             "allOf": [
                                 {
@@ -2505,6 +2577,9 @@
                                 {
                                     "type": "object",
                                     "properties": {
+                                        "[HTML]": {
+                                            "type": "string"
+                                        },
                                         "[JSON]": {
                                             "$ref": "#/definitions/summary.TargetInfraSummary"
                                         },
@@ -2514,6 +2589,16 @@
                                     }
                                 }
                             ]
+                        },
+                        "headers": {
+                            "Content-Disposition": {
+                                "type": "string",
+                                "description": "inline; filename=\\\"target-summary.md\\\" or \\\"target-summary.html\\\" (or attachment when download=true)"
+                            },
+                            "Content-Type": {
+                                "type": "string",
+                                "description": "text/markdown; charset=utf-8 or text/html; charset=utf-8"
+                            }
                         }
                     },
                     "400": {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5545,7 +5545,7 @@ paths:
       - application/json
       description: Generate a comprehensive migration report comparing source infrastructure
         with target cloud VMs, including resource mappings, network/security analysis,
-        cost summary, and recommendations
+        cost summary, and recommendations in Markdown or HTML format
       operationId: GenerateMigrationReport
       parameters:
       - default: mig01
@@ -5562,6 +5562,23 @@ paths:
         name: mciId
         required: true
         type: string
+      - default: md
+        description: 'Report format: md or html'
+        enum:
+        - md
+        - html
+        in: query
+        name: format
+        type: string
+      - default: "false"
+        description: 'Download as file: true for file download, false for inline display
+          (only affects browsers/Swagger UI, not curl)'
+        enum:
+        - "true"
+        - "false"
+        in: query
+        name: download
+        type: string
       - description: Source infrastructure data from on-premise
         in: body
         name: onpremiseInfraModel
@@ -5569,10 +5586,19 @@ paths:
         schema:
           $ref: '#/definitions/controller.GenerateMigrationReportRequest'
       produces:
-      - text/plain
+      - text/markdown
+      - text/html
       responses:
         "200":
-          description: Markdown formatted migration report
+          description: Migration report in markdown or HTML format
+          headers:
+            Content-Disposition:
+              description: inline; filename=\"migration-report.md\" or \"migration-report.html\"
+                (or attachment when download=true)
+              type: string
+            Content-Type:
+              description: text/markdown; charset=utf-8 or text/html; charset=utf-8
+              type: string
           schema:
             type: string
         "400":
@@ -5591,16 +5617,26 @@ paths:
       consumes:
       - application/json
       description: Generate a comprehensive source infrastructure summary from on-premise
-        data in JSON or Markdown format
+        data in JSON, Markdown, or HTML format
       operationId: GenerateSourceInfraSummary
       parameters:
       - default: md
-        description: 'Summary format: json or md'
+        description: 'Summary format: json, md, or html'
         enum:
         - json
         - md
+        - html
         in: query
         name: format
+        type: string
+      - default: "false"
+        description: 'Download as file: true for file download, false for inline display
+          (only affects browsers/Swagger UI, not curl)'
+        enum:
+        - "true"
+        - "false"
+        in: query
+        name: download
         type: string
       - description: 'Custom request ID (NOTE: It will be used as a trace ID.)'
         in: header
@@ -5615,14 +5651,25 @@ paths:
       produces:
       - application/json
       - text/markdown
+      - text/html
       responses:
         "200":
           description: 'Different return types: json format returns SourceInfraSummary
-            object, md format returns markdown string'
+            object, md format returns markdown string, html format returns HTML string'
+          headers:
+            Content-Disposition:
+              description: inline; filename=\"source-summary.md\" or \"source-summary.html\"
+                (or attachment when download=true)
+              type: string
+            Content-Type:
+              description: text/markdown; charset=utf-8 or text/html; charset=utf-8
+              type: string
           schema:
             allOf:
             - $ref: '#/definitions/controller.JSONResult'
             - properties:
+                '[HTML]':
+                  type: string
                 '[JSON]':
                   $ref: '#/definitions/summary.SourceInfraSummary'
                 '[MARKDOWN]':
@@ -5643,8 +5690,8 @@ paths:
     get:
       consumes:
       - application/json
-      description: Generate a comprehensive target infrastructure summary in JSON
-        or Markdown format
+      description: Generate a comprehensive target infrastructure summary in JSON,
+        Markdown, or HTML format
       operationId: GenerateTargetInfraSummary
       parameters:
       - default: mig01
@@ -5660,12 +5707,22 @@ paths:
         required: true
         type: string
       - default: md
-        description: 'Summary format: json or md'
+        description: 'Summary format: json, md, or html'
         enum:
         - json
         - md
+        - html
         in: query
         name: format
+        type: string
+      - default: "false"
+        description: 'Download as file: true for file download, false for inline display
+          (only affects browsers/Swagger UI, not curl)'
+        enum:
+        - "true"
+        - "false"
+        in: query
+        name: download
         type: string
       - description: 'Custom request ID (NOTE: It will be used as a trace ID.)'
         in: header
@@ -5674,14 +5731,25 @@ paths:
       produces:
       - application/json
       - text/markdown
+      - text/html
       responses:
         "200":
           description: 'Different return types: json format returns TargetInfraSummary
-            object, md format returns markdown string'
+            object, md format returns markdown string, html format returns HTML string'
+          headers:
+            Content-Disposition:
+              description: inline; filename=\"target-summary.md\" or \"target-summary.html\"
+                (or attachment when download=true)
+              type: string
+            Content-Type:
+              description: text/markdown; charset=utf-8 or text/html; charset=utf-8
+              type: string
           schema:
             allOf:
             - $ref: '#/definitions/controller.JSONResult'
             - properties:
+                '[HTML]':
+                  type: string
                 '[JSON]':
                   $ref: '#/definitions/summary.TargetInfraSummary'
                 '[MARKDOWN]':

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,8 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yuin/goldmark v1.7.13 // indirect
+	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.12 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.12 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cloud-barista/cb-tumblebug v0.11.13 h1:KgNDnMiuBR9bo2VZbMasnUzrKIP/A/2CrhDG4cp+bWo=
 github.com/cloud-barista/cb-tumblebug v0.11.13/go.mod h1:rNsvfQxOyAhC4ZEeBb/zfajrFXU70D10wLTcRPiRhf0=
+github.com/cloud-barista/cb-tumblebug v0.11.15/go.mod h1:jxLBQMEqsYxIsOfgdhXC6KOwMg7Ldc3rvw1GAih3gFc=
 github.com/cloud-barista/cm-model v0.0.14 h1:WkfBZHRuzQmCxbvDNeuy+TQJQjZtjbLQ9gWB8XFffm0=
 github.com/cloud-barista/cm-model v0.0.14/go.mod h1:gSuMhQxD813KIdSvkp8uGptYOeyDik749sYcICZjhj8=
 github.com/cloud-barista/mc-terrarium v0.0.22 h1:64+7gHeqIRAGtW5TClujlKi1WnpvtsgLfu+2RsQdBQg=
@@ -191,6 +192,10 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
+github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/yunkon-kim/transx v0.0.1 h1:ifjv0VdxniRdwOU98fZBLr6k+hbAjSporE4GntLr1N4=
 github.com/yunkon-kim/transx v0.0.1/go.mod h1:S8Sp4FcqJMvseBnI5KhA4DX6v3D1nWhlbsYR9sG0i8E=
 go.etcd.io/etcd/api/v3 v3.5.12 h1:W4sw5ZoU2Juc9gBWuLk5U6fHfNVyY1WC5g9uiXZio/c=

--- a/pkg/api/rest/controller/summary.go
+++ b/pkg/api/rest/controller/summary.go
@@ -28,16 +28,20 @@ import (
 // GenerateTargetInfraSummary godoc
 // @ID GenerateTargetInfraSummary
 // @Summary Generate target infrastructure summary
-// @Description Generate a comprehensive target infrastructure summary in JSON or Markdown format
+// @Description Generate a comprehensive target infrastructure summary in JSON, Markdown, or HTML format
 // @Tags [Summary/Report] Infrastructure Analysis for Migration
 // @Accept  json
 // @Produce  json
 // @Produce  text/markdown
+// @Produce  text/html
 // @Param nsId path string true "Namespace ID" default(mig01)
 // @Param mciId path string true "Multi-Cloud Infrastructure (MCI) ID" default(mmci01)
-// @Param format query string false "Summary format: json or md" Enums(json,md) default(md)
+// @Param format query string false "Summary format: json, md, or html" Enums(json,md,html) default(md)
+// @Param download query string false "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)" Enums(true,false) default(false)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
-// @Success 200 {object} JSONResult{[MARKDOWN]=string,[JSON]=summary.TargetInfraSummary} "Different return types: json format returns TargetInfraSummary object, md format returns markdown string"
+// @Success 200 {object} JSONResult{[MARKDOWN]=string,[HTML]=string,[JSON]=summary.TargetInfraSummary} "Different return types: json format returns TargetInfraSummary object, md format returns markdown string, html format returns HTML string"
+// @Header 200 {string} Content-Disposition "inline; filename=\"target-summary.md\" or \"target-summary.html\" (or attachment when download=true)"
+// @Header 200 {string} Content-Type "text/markdown; charset=utf-8 or text/html; charset=utf-8"
 // @Failure 400 {object} model.Response
 // @Failure 404 {object} model.Response
 // @Failure 500 {object} model.Response
@@ -71,8 +75,22 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 	if format == "" {
 		format = "json" // default format
 	}
-	if format != "json" && format != "md" {
-		err := fmt.Errorf("invalid request, the format (format: %s) must be 'json' or 'md'", format)
+	if format != "json" && format != "md" && format != "html" {
+		err := fmt.Errorf("invalid request, the format (format: %s) must be 'json', 'md', or 'html'", format)
+		log.Warn().Msg(err.Error())
+		res := model.Response{
+			Success: false,
+			Text:    err.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	download := c.QueryParam("download")
+	if download == "" {
+		download = "false" // default: inline display
+	}
+	if download != "true" && download != "false" {
+		err := fmt.Errorf("invalid request, the download (download: %s) must be 'true' or 'false'", download)
 		log.Warn().Msg(err.Error())
 		res := model.Response{
 			Success: false,
@@ -82,7 +100,7 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 	}
 
 	// [Process]
-	log.Info().Msgf("Generating infrastructure summary (nsId: %s, mciId: %s, format: %s)", nsId, mciId, format)
+	log.Info().Msgf("Generating infrastructure summary (nsId: %s, mciId: %s, format: %s, download: %s)", nsId, mciId, format, download)
 
 	// Generate the infrastructure summary
 	infraSummary, err := summary.GenerateInfraSummary(nsId, mciId)
@@ -96,10 +114,39 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 	}
 
 	// [Output]
-	if format == "md" {
-		// Return markdown format
+	if format == "md" || format == "html" {
+		// Generate markdown summary
 		markdownSummary := summary.GenerateMarkdownSummary(infraSummary)
-		return c.String(http.StatusOK, markdownSummary)
+
+		var content []byte
+		var contentType string
+		var fileExtension string
+
+		if format == "html" {
+			// Convert markdown to HTML
+			content = summary.ConvertMarkdownToHTML([]byte(markdownSummary))
+			contentType = "text/html; charset=utf-8"
+			fileExtension = "html"
+		} else {
+			// Return as markdown
+			content = []byte(markdownSummary)
+			contentType = "text/markdown; charset=utf-8"
+			fileExtension = "md"
+		}
+
+		// Set Content-Disposition header based on download parameter
+		// - "inline": displays content in browser/Swagger UI (allows both viewing and downloading)
+		// - "attachment": forces file download in browser (content not displayed in Swagger UI response body)
+		filename := fmt.Sprintf("target-summary-%s-%s.%s", nsId, mciId, fileExtension)
+		dispositionType := "inline"
+		if download == "true" {
+			dispositionType = "attachment"
+		}
+		disposition := dispositionType + "; filename=\"" + filename + "\""
+		c.Response().Header().Set(echo.HeaderContentDisposition, disposition)
+
+		// Return with proper Content-Type
+		return c.Blob(http.StatusOK, contentType, content)
 	}
 
 	// Return JSON format (default)
@@ -114,15 +161,19 @@ type GenerateSourceInfraSummaryRequest struct {
 // GenerateSourceInfraSummary godoc
 // @ID GenerateSourceInfraSummary
 // @Summary Generate source infrastructure summary
-// @Description Generate a comprehensive source infrastructure summary from on-premise data in JSON or Markdown format
+// @Description Generate a comprehensive source infrastructure summary from on-premise data in JSON, Markdown, or HTML format
 // @Tags [Summary/Report] Infrastructure Analysis for Migration
 // @Accept  json
 // @Produce  json
 // @Produce  text/markdown
-// @Param format query string false "Summary format: json or md" Enums(json,md) default(md)
+// @Produce  text/html
+// @Param format query string false "Summary format: json, md, or html" Enums(json,md,html) default(md)
+// @Param download query string false "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)" Enums(true,false) default(false)
 // @Param X-Request-Id header string false "Custom request ID (NOTE: It will be used as a trace ID.)"
 // @Param Request body controller.GenerateSourceInfraSummaryRequest true "Source infrastructure data"
-// @Success 200 {object} JSONResult{[MARKDOWN]=string,[JSON]=summary.SourceInfraSummary} "Different return types: json format returns SourceInfraSummary object, md format returns markdown string"
+// @Success 200 {object} JSONResult{[MARKDOWN]=string,[HTML]=string,[JSON]=summary.SourceInfraSummary} "Different return types: json format returns SourceInfraSummary object, md format returns markdown string, html format returns HTML string"
+// @Header 200 {string} Content-Disposition "inline; filename=\"source-summary.md\" or \"source-summary.html\" (or attachment when download=true)"
+// @Header 200 {string} Content-Type "text/markdown; charset=utf-8 or text/html; charset=utf-8"
 // @Failure 400 {object} model.Response
 // @Failure 500 {object} model.Response
 // @Router /summary/source [post]
@@ -133,8 +184,22 @@ func GenerateSourceInfraSummary(c echo.Context) error {
 	if format == "" {
 		format = "json" // default format
 	}
-	if format != "json" && format != "md" {
-		err := fmt.Errorf("invalid request, the format (format: %s) must be 'json' or 'md'", format)
+	if format != "json" && format != "md" && format != "html" {
+		err := fmt.Errorf("invalid request, the format (format: %s) must be 'json', 'md', or 'html'", format)
+		log.Warn().Msg(err.Error())
+		res := model.Response{
+			Success: false,
+			Text:    err.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	download := c.QueryParam("download")
+	if download == "" {
+		download = "false" // default: inline display
+	}
+	if download != "true" && download != "false" {
+		err := fmt.Errorf("invalid request, the download (download: %s) must be 'true' or 'false'", download)
 		log.Warn().Msg(err.Error())
 		res := model.Response{
 			Success: false,
@@ -161,7 +226,7 @@ func GenerateSourceInfraSummary(c echo.Context) error {
 		infraName = fmt.Sprintf("infra-%d-servers", len(req.OnpremiseInfraModel.Servers))
 	}
 
-	log.Info().Msgf("Generating source infrastructure summary (infraName: %s, format: %s)", infraName, format)
+	log.Info().Msgf("Generating source infrastructure summary (infraName: %s, format: %s, download: %s)", infraName, format, download)
 
 	// Generate the source infrastructure summary
 	sourceSummary, err := summary.GenerateSourceInfraSummary(infraName, req.OnpremiseInfraModel)
@@ -175,10 +240,39 @@ func GenerateSourceInfraSummary(c echo.Context) error {
 	}
 
 	// [Output]
-	if format == "md" {
-		// Return markdown format
+	if format == "md" || format == "html" {
+		// Generate markdown summary
 		markdownSummary := summary.GenerateSourceMarkdownSummary(sourceSummary)
-		return c.String(http.StatusOK, markdownSummary)
+
+		var content []byte
+		var contentType string
+		var fileExtension string
+
+		if format == "html" {
+			// Convert markdown to HTML
+			content = summary.ConvertMarkdownToHTML([]byte(markdownSummary))
+			contentType = "text/html; charset=utf-8"
+			fileExtension = "html"
+		} else {
+			// Return as markdown
+			content = []byte(markdownSummary)
+			contentType = "text/markdown; charset=utf-8"
+			fileExtension = "md"
+		}
+
+		// Set Content-Disposition header based on download parameter
+		// - "inline": displays content in browser/Swagger UI (allows both viewing and downloading)
+		// - "attachment": forces file download in browser (content not displayed in Swagger UI response body)
+		filename := fmt.Sprintf("source-summary-%s.%s", infraName, fileExtension)
+		dispositionType := "inline"
+		if download == "true" {
+			dispositionType = "attachment"
+		}
+		disposition := dispositionType + "; filename=\"" + filename + "\""
+		c.Response().Header().Set(echo.HeaderContentDisposition, disposition)
+
+		// Return with proper Content-Type
+		return c.Blob(http.StatusOK, contentType, content)
 	}
 
 	// Return JSON format (default)

--- a/pkg/core/summary/html-converter.go
+++ b/pkg/core/summary/html-converter.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package summary provides infrastructure summary HTML generation
+package summary
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
+	emoji "github.com/yuin/goldmark-emoji"
+)
+
+// ConvertMarkdownToHTML converts markdown content to HTML
+// It uses goldmark library with the following configurations:
+// - Extensions: GFM (GitHub Flavored Markdown), Table, Strikethrough, Linkify, TaskList, Emoji
+// - Parser: AutoHeadingID enabled (automatic heading ID generation)
+// - Renderer: Unsafe mode (allow raw HTML), XHTML mode
+func ConvertMarkdownToHTML(md []byte) []byte {
+	var buf bytes.Buffer
+
+	// Configure goldmark with GitHub Flavored Markdown support
+	markdown := goldmark.New(
+		goldmark.WithExtensions(
+			extension.GFM,           // GitHub Flavored Markdown
+			extension.Table,         // Table support
+			extension.Strikethrough, // Strikethrough support
+			extension.Linkify,       // Auto-link URLs
+			extension.TaskList,      // Task list support
+			emoji.Emoji,             // Emoji support (:smile:, :tada:, etc.)
+		),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(), // Automatically assign IDs to headings
+		),
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(), // Allow raw HTML in markdown
+			html.WithXHTML(),  // Render as XHTML
+		),
+	)
+
+	// Convert markdown to HTML
+	if err := markdown.Convert(md, &buf); err != nil {
+		return []byte(fmt.Sprintf("<p>Error converting markdown to HTML: %v</p>", err))
+	}
+
+	// Wrap with complete HTML structure
+	htmlHeader := `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Infrastructure Summary</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        h1, h2, h3, h4, h5, h6 {
+            color: #2c3e50;
+            margin-top: 24px;
+            margin-bottom: 16px;
+            font-weight: 600;
+            line-height: 1.25;
+        }
+        h1 { font-size: 2em; border-bottom: 2px solid #eaecef; padding-bottom: 0.3em; }
+        h2 { font-size: 1.5em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
+        h3 { font-size: 1.25em; }
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 16px 0;
+            background-color: white;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        th, td {
+            border: 1px solid #dfe2e5;
+            padding: 12px;
+            text-align: left;
+        }
+        th {
+            background-color: #f6f8fa;
+            font-weight: 600;
+        }
+        tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+        code {
+            background-color: #f6f8fa;
+            border-radius: 3px;
+            padding: 2px 6px;
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 85%;
+        }
+        pre {
+            background-color: #f6f8fa;
+            border-radius: 6px;
+            padding: 16px;
+            overflow: auto;
+            line-height: 1.45;
+        }
+        pre code {
+            background-color: transparent;
+            padding: 0;
+        }
+        a {
+            color: #0366d6;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        hr {
+            border: 0;
+            border-top: 1px solid #eaecef;
+            margin: 24px 0;
+        }
+        blockquote {
+            border-left: 4px solid #dfe2e5;
+            padding: 0 16px;
+            color: #6a737d;
+            margin: 0;
+        }
+        ul, ol {
+            padding-left: 2em;
+            margin: 16px 0;
+        }
+        li {
+            margin: 4px 0;
+        }
+    </style>
+</head>
+<body>
+`
+	htmlFooter := `
+</body>
+</html>`
+
+	// Combine HTML parts
+	var result bytes.Buffer
+	result.WriteString(htmlHeader)
+	result.Write(buf.Bytes())
+	result.WriteString(htmlFooter)
+
+	return result.Bytes()
+}


### PR DESCRIPTION
- Add HTML output format to summary and report APIs (alongside existing JSON/MD formats)
- Implement markdown-to-HTML converter using goldmark with GFM, emoji, and table support
- Add flexible download control via query parameter (inline display vs file download)
- Set proper Content-Disposition headers based on format and download preference
- Include comprehensive GitHub-style CSS for professional HTML rendering