### PR TITLE
chore(api)!: update API naming from mci to infra

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -26,6 +26,7 @@ on:
       - "LICENSE"
       - "CODEOWNERS"
       - "deepdiffgo/**"
+      - "imdl/**"
       # - '.all-contributorsrc'
       # - 'assets/**'
       # - 'src/testclient/scripts/**'

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,6 +18,7 @@ on:
       - "src/testclient/scripts/**"
       - "docs/**"
       - "deepdiffgo/**"
+      - "imdl/**"
 
 jobs:
   # The job key (i.e., ID) is "build-source-code"

--- a/api/docs.go
+++ b/api/docs.go
@@ -538,7 +538,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/migration/ns/{nsId}/mci": {
+        "/migration/ns/{nsId}/infra": {
             "get": {
                 "description": "Get the migrated multi-cloud infrastructure (MCI)",
                 "consumes": [
@@ -621,8 +621,8 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Specify the information for the targeted mulci-cloud infrastructure (MCI)",
-                        "name": "mciInfo",
+                        "description": "Specify the information for the targeted multi-cloud infrastructure",
+                        "name": "infraInfo",
                         "in": "body",
                         "required": true,
                         "schema": {
@@ -658,7 +658,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/migration/ns/{nsId}/mci/{mciId}": {
+        "/migration/ns/{nsId}/infra/{infraId}": {
             "get": {
                 "description": "Get the migrated multi-cloud infrastructure (MCI)",
                 "consumes": [
@@ -684,8 +684,8 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "default": "my-infra101",
-                        "description": "Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
-                        "name": "mciId",
+                        "description": "Migrated Cloud Infrastructure ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
+                        "name": "infraId",
                         "in": "path",
                         "required": true
                     },
@@ -698,7 +698,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "The migrated multi-cloud infrastructure (MCI) information",
+                        "description": "The migrated multi-cloud infrastructure information",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-controller_MigrateInfraResponse"
                         }
@@ -742,8 +742,8 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "default": "my-infra101",
-                        "description": "Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
-                        "name": "mciId",
+                        "description": "Migrated Cloud Infrastructure ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
+                        "name": "infraId",
                         "in": "path",
                         "required": true
                     },
@@ -767,7 +767,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "The result of deleting the migrated multi-cloud infrastructure (MCI)",
+                        "description": "The result of deleting the migrated multi-cloud infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -787,7 +787,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/migration/ns/{nsId}/mciWithDefaults": {
+        "/migration/ns/{nsId}/infraWithDefaults": {
             "post": {
                 "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.",
                 "consumes": [
@@ -1615,7 +1615,7 @@ const docTemplate = `{
         },
         "/naming/alignment": {
             "post": {
-                "description": "When a parent/primary resource is renamed (e.g., VNet), this API updates all\nchild/dependent references in the model (e.g., SecurityGroup.VNetId, SubGroup.VNetId).\n\n**Supported resourceType values** (cb-tumblebug convention):\n- ` + "`" + `vNet` + "`" + ` : Rename VNet → propagates to SecurityGroup.VNetId, SubGroup.VNetId\n- ` + "`" + `subnet` + "`" + ` : Rename Subnet → propagates to SubGroup.SubnetId\n- ` + "`" + `sshKey` + "`" + ` : Rename SSH Key → propagates to SubGroup.SshKeyId\n- ` + "`" + `securityGroup` + "`" + ` : Rename SecurityGroup → propagates to SubGroup.SecurityGroupIds\n- ` + "`" + `mci` + "`" + ` : Rename MCI (no child propagation)\n\nAfter propagation, names are validated with NameSeed applied (pre-flight check).\nThe returned model uses **base names only** (NameSeed is applied at migration time).\n\nSee also: [API Guide: Align Names](https://github.com/cloud-barista/cm-beetle/blob/main/docs/api-guide-align-names.md)\n",
+                "description": "When a parent/primary resource is renamed (e.g., VNet), this API updates all\nchild/dependent references in the model (e.g., SecurityGroup.VNetId, SubGroup.VNetId).\n\n**Supported resourceType values** (cb-tumblebug convention):\n- ` + "`" + `vNet` + "`" + ` : Rename VNet → propagates to SecurityGroup.VNetId, SubGroup.VNetId\n- ` + "`" + `subnet` + "`" + ` : Rename Subnet → propagates to SubGroup.SubnetId\n- ` + "`" + `sshKey` + "`" + ` : Rename SSH Key → propagates to SubGroup.SshKeyId\n- ` + "`" + `securityGroup` + "`" + ` : Rename SecurityGroup → propagates to SubGroup.SecurityGroupIds\n- ` + "`" + `infra` + "`" + ` : Rename Infra (no child propagation)\n\nAfter propagation, names are validated with NameSeed applied (pre-flight check).\nThe returned model uses **base names only** (NameSeed is applied at migration time).\n\nSee also: [API Guide: Align Names](https://github.com/cloud-barista/cm-beetle/blob/main/docs/api-guide-align-names.md)\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -1634,7 +1634,7 @@ const docTemplate = `{
                             "subnet",
                             "securityGroup",
                             "sshKey",
-                            "mci"
+                            "infra"
                         ],
                         "type": "string",
                         "description": "Resource type to rename",
@@ -1662,7 +1662,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
+                            "$ref": "#/definitions/cloudmodel.RecommendedInfra"
                         }
                     },
                     {
@@ -1676,7 +1676,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Updated and validated model (base names)",
                         "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedVmInfra"
+                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedInfra"
                         }
                     },
                     "400": {
@@ -1690,7 +1690,7 @@ const docTemplate = `{
         },
         "/naming/validation": {
             "post": {
-                "description": "Validates that all internal references within a RecommendedVmInfra model\nare consistent and point to existing resources.\nNameSeed is NOT applied here; this validates the base names only.\n",
+                "description": "Validates that all internal references within a RecommendedInfra model\nare consistent and point to existing resources.\nNameSeed is NOT applied here; this validates the base names only.\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -1709,7 +1709,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
+                            "$ref": "#/definitions/cloudmodel.RecommendedInfra"
                         }
                     },
                     {
@@ -1773,9 +1773,9 @@ const docTemplate = `{
                 }
             }
         },
-        "/recommendation/containerInfra": {
+        "/recommendation/infra": {
             "post": {
-                "description": "[DEPRECATED] This endpoint is deprecated. Use /recommendation/k8sCluster and /recommendation/k8sNodeGroup instead.\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.",
+                "description": "Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.\n\n- See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256\n\n**[Required Parameters: ` + "`" + `desiredCsp` + "`" + `, ` + "`" + `desiredRegion` + "`" + `]** The desired cloud service provider and region for the recommended infrastructure.\n- if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.\n\n**[Optional Parameters: ` + "`" + `limit` + "`" + `]** Maximum number of recommended infrastructures to return (default: 3)\n\n**[Optional Parameters: ` + "`" + `minMatchRate` + "`" + `]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n**[Response Field: ` + "`" + `status` + "`" + `]** Candidate status based on the match rate threshold\n- **highly-matched**: Candidates meet or exceed the match rate threshold\n- **partially-matched**: Valid candidates below the match rate threshold\n\n**[Response Field: ` + "`" + `description` + "`" + `]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts\n- Example: \"Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable\"\n\n**[Optional] ` + "`" + `nameSeed` + "`" + `** is a base string used to prefix resource names (e.g., 'my' -\u003e 'my-vnet-01').\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -1785,12 +1785,11 @@ const docTemplate = `{
                 "tags": [
                     "[Recommendation] Infrastructure"
                 ],
-                "summary": "(Deprecated) Recommend an appropriate container infrastructure for cloud migration",
-                "operationId": "RecommendContainerInfra",
-                "deprecated": true,
+                "summary": "Recommend multiple VM infrastructure candidates for cloud migration",
+                "operationId": "RecommendVmInfraCandidates",
                 "parameters": [
                     {
-                        "description": "Specify the source container infrastructure",
+                        "description": "Specify the source infrastructure to be migrated",
                         "name": "UserInfra",
                         "in": "body",
                         "required": true,
@@ -1809,7 +1808,93 @@ const docTemplate = `{
                         "type": "string",
                         "default": "aws",
                         "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
+                        "name": "desiredCsp",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit (default: 3) the number of recommended infrastructures",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
+                        "name": "minMatchRate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully recommended infrastructure candidates",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/recommendation/infraWithDefaults": {
+            "post": {
+                "description": "Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration\n\n[Note] ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Infrastructure"
+                ],
+                "summary": "(To be updated) Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration",
+                "operationId": "RecommendVMInfraWithDefaults",
+                "parameters": [
+                    {
+                        "description": "Specify the source infrastructure to be migrated",
+                        "name": "UserInfra",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendInfraWithDefaultsRequest"
+                        }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "alibaba",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredCsp",
                         "in": "query"
                     },
                     {
@@ -1828,13 +1913,19 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Deprecated endpoint notice",
+                        "description": "The result of recommended infrastructure",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-controller_RecommendInfraWithDefaultsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
                     },
-                    "400": {
-                        "description": "Bad Request",
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -1984,154 +2075,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/recommendation/mci": {
-            "post": {
-                "description": "**(To be deprecated)** Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration\n\n[Note] ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Infrastructure"
-                ],
-                "summary": "**(To be deprecated)** Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration",
-                "operationId": "RecommendVMInfra",
-                "parameters": [
-                    {
-                        "description": "Specify the source infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredCsp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The result of recommended infrastructure",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-controller_RecommendVmInfraResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/recommendation/mciWithDefaults": {
-            "post": {
-                "description": "Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration\n\n[Note] ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Infrastructure"
-                ],
-                "summary": "(To be updated) Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration",
-                "operationId": "RecommendVMInfraWithDefaults",
-                "parameters": [
-                    {
-                        "description": "Specify the source infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraWithDefaultsRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredCsp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The result of recommended infrastructure",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-controller_RecommendVmInfraWithDefaultsResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
         "/recommendation/middleware/objectStorage": {
             "post": {
                 "description": "Recommend an appropriate object storage for cloud migration\n\n[Note] ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredCsp` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n[Warning] the recommended bucket name may be globally unique.\n- Beetle supports adding a suffix based on the existing bucket name to ensure uniqueness.\n- Suppose that the existing bucket name is unique enough.\n- Generate a suffix based on the existing bucket name.\n- e.g., \"my-bucket\" -\u003e SHA256 hash -\u003e base64 URL-safe encoding (6 bytes) -\u003e lowercase -\u003e \"my-bucket-{suffix}\"",
@@ -2206,6 +2149,80 @@ const docTemplate = `{
                 }
             }
         },
+        "/recommendation/resources/osImages": {
+            "post": {
+                "description": "Recommend an appropriate OS image for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Resources for VM infrastructure"
+                ],
+                "summary": "Recommend an appropriate OS image for cloud migration",
+                "operationId": "RecommendVmOsImages",
+                "parameters": [
+                    {
+                        "description": "Specify the your infrastructure to be migrated",
+                        "name": "UserInfra",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
+                        }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "alibaba",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredProvider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully recommended VM OS image(s)",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedOsImageList"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
         "/recommendation/resources/securityGroups": {
             "post": {
                 "description": "Recommend an appropriate security group for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
@@ -2227,7 +2244,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
                         }
                     },
                     {
@@ -2280,6 +2297,86 @@ const docTemplate = `{
                 }
             }
         },
+        "/recommendation/resources/specs": {
+            "post": {
+                "description": "Recommend an appropriate VM specification for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.\n- If ` + "`" + `targetMachineId` + "`" + ` is provided, only that specific machine will be processed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Resources for VM infrastructure"
+                ],
+                "summary": "Recommend an appropriate VM specification for cloud migration",
+                "operationId": "RecommendVmSpecs",
+                "parameters": [
+                    {
+                        "description": "Specify the your infrastructure to be migrated",
+                        "name": "UserInfra",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
+                        }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "alibaba",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredProvider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target Machine ID to focus recommendation on (optional)",
+                        "name": "targetMachineId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully recommended VM spec(s)",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedSpecList"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
         "/recommendation/resources/vNet": {
             "post": {
                 "description": "Recommend an appropriate virtual network for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
@@ -2301,7 +2398,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
                         }
                     },
                     {
@@ -2354,247 +2451,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/recommendation/resources/vmOsImages": {
-            "post": {
-                "description": "Recommend an appropriate OS image for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Resources for VM infrastructure"
-                ],
-                "summary": "Recommend an appropriate OS image for cloud migration",
-                "operationId": "RecommendVmOsImages",
-                "parameters": [
-                    {
-                        "description": "Specify the your infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully recommended VM OS image(s)",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedVmOsImageList"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request parameters",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error during recommendation",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/recommendation/resources/vmSpecs": {
-            "post": {
-                "description": "Recommend an appropriate VM specification for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.\n- If ` + "`" + `targetMachineId` + "`" + ` is provided, only that specific machine will be processed.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Resources for VM infrastructure"
-                ],
-                "summary": "Recommend an appropriate VM specification for cloud migration",
-                "operationId": "RecommendVmSpecs",
-                "parameters": [
-                    {
-                        "description": "Specify the your infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Target Machine ID to focus recommendation on (optional)",
-                        "name": "targetMachineId",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully recommended VM spec(s)",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedVmSpecList"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request parameters",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error during recommendation",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/recommendation/vmInfra": {
-            "post": {
-                "description": "Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.\n\n- See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256\n\n**[Required Parameters: ` + "`" + `desiredCsp` + "`" + `, ` + "`" + `desiredRegion` + "`" + `]** The desired cloud service provider and region for the recommended infrastructure.\n- if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.\n\n**[Optional Parameters: ` + "`" + `limit` + "`" + `]** Maximum number of recommended infrastructures to return (default: 3)\n\n**[Optional Parameters: ` + "`" + `minMatchRate` + "`" + `]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n**[Response Field: ` + "`" + `status` + "`" + `]** Candidate status based on the match rate threshold\n- **highly-matched**: Candidates meet or exceed the match rate threshold\n- **partially-matched**: Valid candidates below the match rate threshold\n\n**[Response Field: ` + "`" + `description` + "`" + `]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts\n- Example: \"Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable\"\n\n**[Optional] ` + "`" + `nameSeed` + "`" + `** is a base string used to prefix resource names (e.g., 'my' -\u003e 'my-vnet-01').\n",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Infrastructure"
-                ],
-                "summary": "Recommend multiple VM infrastructure candidates for cloud migration",
-                "operationId": "RecommendVmInfraCandidates",
-                "parameters": [
-                    {
-                        "description": "Specify the source infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredCsp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Limit (default: 3) the number of recommended infrastructures",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "number",
-                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
-                        "name": "minMatchRate",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully recommended infrastructure candidates",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedVmInfra"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request parameters",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error during recommendation",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/report/migration/ns/{nsId}/mci/{mciId}": {
+        "/report/migration/ns/{nsId}/infra/{infraId}": {
             "post": {
                 "description": "Generate a comprehensive migration report comparing source infrastructure with target cloud VMs, including resource mappings, network/security analysis, cost summary, and recommendations in Markdown or HTML format",
                 "consumes": [
@@ -2621,10 +2478,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "mci101",
-                        "example": "\"mci101\"",
-                        "description": "MCI ID",
-                        "name": "mciId",
+                        "default": "infra101",
+                        "example": "\"infra101\"",
+                        "description": "Infra ID",
+                        "name": "infraId",
                         "in": "path",
                         "required": true
                     },
@@ -2964,7 +2821,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/summary/target/ns/{nsId}/mci/{mciId}": {
+        "/summary/target/ns/{nsId}/infra/{infraId}": {
             "get": {
                 "description": "Generate a comprehensive target infrastructure summary in multiple formats based on 'format' query parameter:\n\n**Response Format by 'format' Parameter:**\n- ` + "`" + `format=md` + "`" + ` (default): Returns markdown string with Content-Type: text/markdown; charset=utf-8\n- ` + "`" + `format=html` + "`" + `: Returns HTML string with Content-Type: text/html; charset=utf-8\n- ` + "`" + `format=json` + "`" + `: Returns ApiResponse[TargetInfraSummary] with Content-Type: application/json\n\n**Note:** API documentation shows JSON schema for reference, but actual default response is markdown format.\n\n**Markdown example**: https://github.com/cloud-barista/cm-beetle/blob/main/cmd/test-cli/testresult/beetle-summary-target-aws.md\n\n**Download Behavior:**\n- ` + "`" + `download=false` + "`" + ` (default): Content displayed inline (viewable in browser/Swagger UI)\n- ` + "`" + `download=true` + "`" + `: Content downloaded as file (Content-Disposition: attachment)",
                 "consumes": [
@@ -4367,6 +4224,104 @@ const docTemplate = `{
                 "PlatformNA"
             ]
         },
+        "cloudmodel.RecommendedInfra": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "nameSeed": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetCloud": {
+                    "$ref": "#/definitions/cloudmodel.CloudProperty"
+                },
+                "targetInfra": {
+                    "$ref": "#/definitions/cloudmodel.InfraReq"
+                },
+                "targetOsImageList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.ImageInfo"
+                    }
+                },
+                "targetSecurityGroupList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
+                    }
+                },
+                "targetSpecList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.SpecInfo"
+                    }
+                },
+                "targetSshKey": {
+                    "$ref": "#/definitions/cloudmodel.SshKeyReq"
+                },
+                "targetVNet": {
+                    "$ref": "#/definitions/cloudmodel.VNetReq"
+                }
+            }
+        },
+        "cloudmodel.RecommendedInfraDynamic": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetInfra": {
+                    "$ref": "#/definitions/cloudmodel.InfraDynamicReq"
+                }
+            }
+        },
+        "cloudmodel.RecommendedOsImage": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "sourceServers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetOsImage": {
+                    "$ref": "#/definitions/cloudmodel.ImageInfo"
+                }
+            }
+        },
+        "cloudmodel.RecommendedOsImageList": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "recommendedOsImageList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.RecommendedOsImage"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "cloudmodel.RecommendedSecurityGroup": {
             "type": "object",
             "properties": {
@@ -4407,6 +4362,46 @@ const docTemplate = `{
                 }
             }
         },
+        "cloudmodel.RecommendedSpec": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "sourceServers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetSpec": {
+                    "$ref": "#/definitions/cloudmodel.SpecInfo"
+                }
+            }
+        },
+        "cloudmodel.RecommendedSpecList": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "recommendedSpecList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.RecommendedSpec"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "cloudmodel.RecommendedVNet": {
             "type": "object",
             "properties": {
@@ -4435,144 +4430,6 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/cloudmodel.RecommendedVNet"
                     }
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmInfra": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "nameSeed": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetCloud": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "targetSecurityGroupList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
-                    }
-                },
-                "targetSshKey": {
-                    "$ref": "#/definitions/cloudmodel.SshKeyReq"
-                },
-                "targetVNet": {
-                    "$ref": "#/definitions/cloudmodel.VNetReq"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraReq"
-                },
-                "targetVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.ImageInfo"
-                    }
-                },
-                "targetVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SpecInfo"
-                    }
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmInfraDynamic": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraDynamicReq"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmOsImage": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "sourceServers": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetVmOsImage": {
-                    "$ref": "#/definitions/cloudmodel.ImageInfo"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmOsImageList": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "recommendedVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmOsImage"
-                    }
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmSpec": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "sourceServers": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetVmSpec": {
-                    "$ref": "#/definitions/cloudmodel.SpecInfo"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmSpecList": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "recommendedVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmSpec"
-                    }
-                },
-                "status": {
-                    "type": "string"
                 }
             }
         },
@@ -5194,10 +5051,25 @@ const docTemplate = `{
                 "targetCloud": {
                     "$ref": "#/definitions/cloudmodel.CloudProperty"
                 },
+                "targetInfra": {
+                    "$ref": "#/definitions/cloudmodel.InfraReq"
+                },
+                "targetOsImageList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.ImageInfo"
+                    }
+                },
                 "targetSecurityGroupList": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
+                    }
+                },
+                "targetSpecList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.SpecInfo"
                     }
                 },
                 "targetSshKey": {
@@ -5205,21 +5077,6 @@ const docTemplate = `{
                 },
                 "targetVNet": {
                     "$ref": "#/definitions/cloudmodel.VNetReq"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraReq"
-                },
-                "targetVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.ImageInfo"
-                    }
-                },
-                "targetVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SpecInfo"
-                    }
                 }
             }
         },
@@ -5577,18 +5434,43 @@ const docTemplate = `{
         "controller.RecommendInfraRequest": {
             "type": "object",
             "properties": {
-                "desiredProvider": {
-                    "type": "string",
-                    "example": "aws"
+                "desiredCspAndRegionPair": {
+                    "$ref": "#/definitions/cloudmodel.CloudProperty"
                 },
-                "desiredRegion": {
+                "nameSeed": {
+                    "description": "Base string for resource name prefix (e.g., 'my' -\u003e 'my-vnet-01')",
                     "type": "string",
-                    "example": "ap-northeast-2"
+                    "example": "my"
                 },
-                "servers": {
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendInfraWithDefaultsRequest": {
+            "type": "object",
+            "properties": {
+                "desiredCspAndRegionPair": {
+                    "$ref": "#/definitions/cloudmodel.CloudProperty"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendInfraWithDefaultsResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "targetInfraList": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/recommendation.Kubernetes"
+                        "$ref": "#/definitions/cloudmodel.RecommendedInfraDynamic"
                     }
                 }
             }
@@ -5608,94 +5490,6 @@ const docTemplate = `{
                     "minItems": 1,
                     "items": {
                         "$ref": "#/definitions/controller.SourceObjectStorageProperty"
-                    }
-                }
-            }
-        },
-        "controller.RecommendVmInfraRequest": {
-            "type": "object",
-            "properties": {
-                "desiredCspAndRegionPair": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "nameSeed": {
-                    "description": "Base string for resource name prefix (e.g., 'my' -\u003e 'my-vnet-01')",
-                    "type": "string",
-                    "example": "my"
-                },
-                "onpremiseInfraModel": {
-                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
-                }
-            }
-        },
-        "controller.RecommendVmInfraResponse": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "nameSeed": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetCloud": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "targetSecurityGroupList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
-                    }
-                },
-                "targetSshKey": {
-                    "$ref": "#/definitions/cloudmodel.SshKeyReq"
-                },
-                "targetVNet": {
-                    "$ref": "#/definitions/cloudmodel.VNetReq"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraReq"
-                },
-                "targetVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.ImageInfo"
-                    }
-                },
-                "targetVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SpecInfo"
-                    }
-                }
-            }
-        },
-        "controller.RecommendVmInfraWithDefaultsRequest": {
-            "type": "object",
-            "properties": {
-                "desiredCspAndRegionPair": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "onpremiseInfraModel": {
-                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
-                }
-            }
-        },
-        "controller.RecommendVmInfraWithDefaultsResponse": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "targetVmInfraList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmInfraDynamic"
                     }
                 }
             }
@@ -5815,14 +5609,14 @@ const docTemplate = `{
                 }
             }
         },
-        "model.ApiResponse-array_cloudmodel_RecommendedVmInfra": {
+        "model.ApiResponse-array_cloudmodel_RecommendedInfra": {
             "type": "object",
             "properties": {
                 "data": {
                     "description": "Contains the actual response data (single object, list, or page)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
+                        "$ref": "#/definitions/cloudmodel.RecommendedInfra"
                     }
                 },
                 "error": {
@@ -5898,6 +5692,62 @@ const docTemplate = `{
                 }
             }
         },
+        "model.ApiResponse-cloudmodel_RecommendedInfra": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Contains the actual response data (single object, list, or page)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.RecommendedInfra"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "Error message for failed responses",
+                    "type": "string",
+                    "example": "Error message if failure"
+                },
+                "message": {
+                    "description": "Optional message for additional context",
+                    "type": "string",
+                    "example": "Operation successful"
+                },
+                "success": {
+                    "description": "Indicates whether the API call was successful",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
+        "model.ApiResponse-cloudmodel_RecommendedOsImageList": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Contains the actual response data (single object, list, or page)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.RecommendedOsImageList"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "Error message for failed responses",
+                    "type": "string",
+                    "example": "Error message if failure"
+                },
+                "message": {
+                    "description": "Optional message for additional context",
+                    "type": "string",
+                    "example": "Operation successful"
+                },
+                "success": {
+                    "description": "Indicates whether the API call was successful",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
         "model.ApiResponse-cloudmodel_RecommendedSecurityGroupList": {
             "type": "object",
             "properties": {
@@ -5926,6 +5776,34 @@ const docTemplate = `{
                 }
             }
         },
+        "model.ApiResponse-cloudmodel_RecommendedSpecList": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Contains the actual response data (single object, list, or page)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.RecommendedSpecList"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "Error message for failed responses",
+                    "type": "string",
+                    "example": "Error message if failure"
+                },
+                "message": {
+                    "description": "Optional message for additional context",
+                    "type": "string",
+                    "example": "Operation successful"
+                },
+                "success": {
+                    "description": "Indicates whether the API call was successful",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
         "model.ApiResponse-cloudmodel_RecommendedVNetList": {
             "type": "object",
             "properties": {
@@ -5934,90 +5812,6 @@ const docTemplate = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/cloudmodel.RecommendedVNetList"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-cloudmodel_RecommendedVmInfra": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-cloudmodel_RecommendedVmOsImageList": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmOsImageList"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-cloudmodel_RecommendedVmSpecList": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmSpecList"
                         }
                     ]
                 },
@@ -6150,42 +5944,14 @@ const docTemplate = `{
                 }
             }
         },
-        "model.ApiResponse-controller_RecommendVmInfraResponse": {
+        "model.ApiResponse-controller_RecommendInfraWithDefaultsResponse": {
             "type": "object",
             "properties": {
                 "data": {
                     "description": "Contains the actual response data (single object, list, or page)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/controller.RecommendVmInfraResponse"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-controller_RecommendVmInfraWithDefaultsResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/controller.RecommendVmInfraWithDefaultsResponse"
+                            "$ref": "#/definitions/controller.RecommendInfraWithDefaultsResponse"
                         }
                     ]
                 },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -532,7 +532,7 @@
                 }
             }
         },
-        "/migration/ns/{nsId}/mci": {
+        "/migration/ns/{nsId}/infra": {
             "get": {
                 "description": "Get the migrated multi-cloud infrastructure (MCI)",
                 "consumes": [
@@ -615,8 +615,8 @@
                         "required": true
                     },
                     {
-                        "description": "Specify the information for the targeted mulci-cloud infrastructure (MCI)",
-                        "name": "mciInfo",
+                        "description": "Specify the information for the targeted multi-cloud infrastructure",
+                        "name": "infraInfo",
                         "in": "body",
                         "required": true,
                         "schema": {
@@ -652,7 +652,7 @@
                 }
             }
         },
-        "/migration/ns/{nsId}/mci/{mciId}": {
+        "/migration/ns/{nsId}/infra/{infraId}": {
             "get": {
                 "description": "Get the migrated multi-cloud infrastructure (MCI)",
                 "consumes": [
@@ -678,8 +678,8 @@
                     {
                         "type": "string",
                         "default": "my-infra101",
-                        "description": "Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
-                        "name": "mciId",
+                        "description": "Migrated Cloud Infrastructure ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
+                        "name": "infraId",
                         "in": "path",
                         "required": true
                     },
@@ -692,7 +692,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "The migrated multi-cloud infrastructure (MCI) information",
+                        "description": "The migrated multi-cloud infrastructure information",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-controller_MigrateInfraResponse"
                         }
@@ -736,8 +736,8 @@
                     {
                         "type": "string",
                         "default": "my-infra101",
-                        "description": "Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
-                        "name": "mciId",
+                        "description": "Migrated Cloud Infrastructure ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')",
+                        "name": "infraId",
                         "in": "path",
                         "required": true
                     },
@@ -761,7 +761,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "The result of deleting the migrated multi-cloud infrastructure (MCI)",
+                        "description": "The result of deleting the migrated multi-cloud infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -781,7 +781,7 @@
                 }
             }
         },
-        "/migration/ns/{nsId}/mciWithDefaults": {
+        "/migration/ns/{nsId}/infraWithDefaults": {
             "post": {
                 "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.",
                 "consumes": [
@@ -1609,7 +1609,7 @@
         },
         "/naming/alignment": {
             "post": {
-                "description": "When a parent/primary resource is renamed (e.g., VNet), this API updates all\nchild/dependent references in the model (e.g., SecurityGroup.VNetId, SubGroup.VNetId).\n\n**Supported resourceType values** (cb-tumblebug convention):\n- `vNet` : Rename VNet → propagates to SecurityGroup.VNetId, SubGroup.VNetId\n- `subnet` : Rename Subnet → propagates to SubGroup.SubnetId\n- `sshKey` : Rename SSH Key → propagates to SubGroup.SshKeyId\n- `securityGroup` : Rename SecurityGroup → propagates to SubGroup.SecurityGroupIds\n- `mci` : Rename MCI (no child propagation)\n\nAfter propagation, names are validated with NameSeed applied (pre-flight check).\nThe returned model uses **base names only** (NameSeed is applied at migration time).\n\nSee also: [API Guide: Align Names](https://github.com/cloud-barista/cm-beetle/blob/main/docs/api-guide-align-names.md)\n",
+                "description": "When a parent/primary resource is renamed (e.g., VNet), this API updates all\nchild/dependent references in the model (e.g., SecurityGroup.VNetId, SubGroup.VNetId).\n\n**Supported resourceType values** (cb-tumblebug convention):\n- `vNet` : Rename VNet → propagates to SecurityGroup.VNetId, SubGroup.VNetId\n- `subnet` : Rename Subnet → propagates to SubGroup.SubnetId\n- `sshKey` : Rename SSH Key → propagates to SubGroup.SshKeyId\n- `securityGroup` : Rename SecurityGroup → propagates to SubGroup.SecurityGroupIds\n- `infra` : Rename Infra (no child propagation)\n\nAfter propagation, names are validated with NameSeed applied (pre-flight check).\nThe returned model uses **base names only** (NameSeed is applied at migration time).\n\nSee also: [API Guide: Align Names](https://github.com/cloud-barista/cm-beetle/blob/main/docs/api-guide-align-names.md)\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -1628,7 +1628,7 @@
                             "subnet",
                             "securityGroup",
                             "sshKey",
-                            "mci"
+                            "infra"
                         ],
                         "type": "string",
                         "description": "Resource type to rename",
@@ -1656,7 +1656,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
+                            "$ref": "#/definitions/cloudmodel.RecommendedInfra"
                         }
                     },
                     {
@@ -1670,7 +1670,7 @@
                     "200": {
                         "description": "Updated and validated model (base names)",
                         "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedVmInfra"
+                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedInfra"
                         }
                     },
                     "400": {
@@ -1684,7 +1684,7 @@
         },
         "/naming/validation": {
             "post": {
-                "description": "Validates that all internal references within a RecommendedVmInfra model\nare consistent and point to existing resources.\nNameSeed is NOT applied here; this validates the base names only.\n",
+                "description": "Validates that all internal references within a RecommendedInfra model\nare consistent and point to existing resources.\nNameSeed is NOT applied here; this validates the base names only.\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -1703,7 +1703,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
+                            "$ref": "#/definitions/cloudmodel.RecommendedInfra"
                         }
                     },
                     {
@@ -1767,9 +1767,9 @@
                 }
             }
         },
-        "/recommendation/containerInfra": {
+        "/recommendation/infra": {
             "post": {
-                "description": "[DEPRECATED] This endpoint is deprecated. Use /recommendation/k8sCluster and /recommendation/k8sNodeGroup instead.\n\n[Note] `desiredProvider` and `desiredRegion` are required.",
+                "description": "Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.\n\n- See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256\n\n**[Required Parameters: `desiredCsp`, `desiredRegion`]** The desired cloud service provider and region for the recommended infrastructure.\n- if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.\n\n**[Optional Parameters: `limit`]** Maximum number of recommended infrastructures to return (default: 3)\n\n**[Optional Parameters: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n**[Response Field: `status`]** Candidate status based on the match rate threshold\n- **highly-matched**: Candidates meet or exceed the match rate threshold\n- **partially-matched**: Valid candidates below the match rate threshold\n\n**[Response Field: `description`]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts\n- Example: \"Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable\"\n\n**[Optional] `nameSeed`** is a base string used to prefix resource names (e.g., 'my' -\u003e 'my-vnet-01').\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -1779,12 +1779,11 @@
                 "tags": [
                     "[Recommendation] Infrastructure"
                 ],
-                "summary": "(Deprecated) Recommend an appropriate container infrastructure for cloud migration",
-                "operationId": "RecommendContainerInfra",
-                "deprecated": true,
+                "summary": "Recommend multiple VM infrastructure candidates for cloud migration",
+                "operationId": "RecommendVmInfraCandidates",
                 "parameters": [
                     {
-                        "description": "Specify the source container infrastructure",
+                        "description": "Specify the source infrastructure to be migrated",
                         "name": "UserInfra",
                         "in": "body",
                         "required": true,
@@ -1803,7 +1802,93 @@
                         "type": "string",
                         "default": "aws",
                         "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
+                        "name": "desiredCsp",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit (default: 3) the number of recommended infrastructures",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
+                        "name": "minMatchRate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully recommended infrastructure candidates",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/recommendation/infraWithDefaults": {
+            "post": {
+                "description": "Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Infrastructure"
+                ],
+                "summary": "(To be updated) Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration",
+                "operationId": "RecommendVMInfraWithDefaults",
+                "parameters": [
+                    {
+                        "description": "Specify the source infrastructure to be migrated",
+                        "name": "UserInfra",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendInfraWithDefaultsRequest"
+                        }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "alibaba",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredCsp",
                         "in": "query"
                     },
                     {
@@ -1822,13 +1907,19 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Deprecated endpoint notice",
+                        "description": "The result of recommended infrastructure",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-controller_RecommendInfraWithDefaultsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
                     },
-                    "400": {
-                        "description": "Bad Request",
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -1978,154 +2069,6 @@
                 }
             }
         },
-        "/recommendation/mci": {
-            "post": {
-                "description": "**(To be deprecated)** Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Infrastructure"
-                ],
-                "summary": "**(To be deprecated)** Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration",
-                "operationId": "RecommendVMInfra",
-                "parameters": [
-                    {
-                        "description": "Specify the source infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredCsp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The result of recommended infrastructure",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-controller_RecommendVmInfraResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/recommendation/mciWithDefaults": {
-            "post": {
-                "description": "Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Infrastructure"
-                ],
-                "summary": "(To be updated) Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration",
-                "operationId": "RecommendVMInfraWithDefaults",
-                "parameters": [
-                    {
-                        "description": "Specify the source infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraWithDefaultsRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredCsp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The result of recommended infrastructure",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-controller_RecommendVmInfraWithDefaultsResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
         "/recommendation/middleware/objectStorage": {
             "post": {
                 "description": "Recommend an appropriate object storage for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n[Warning] the recommended bucket name may be globally unique.\n- Beetle supports adding a suffix based on the existing bucket name to ensure uniqueness.\n- Suppose that the existing bucket name is unique enough.\n- Generate a suffix based on the existing bucket name.\n- e.g., \"my-bucket\" -\u003e SHA256 hash -\u003e base64 URL-safe encoding (6 bytes) -\u003e lowercase -\u003e \"my-bucket-{suffix}\"",
@@ -2200,6 +2143,80 @@
                 }
             }
         },
+        "/recommendation/resources/osImages": {
+            "post": {
+                "description": "Recommend an appropriate OS image for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Resources for VM infrastructure"
+                ],
+                "summary": "Recommend an appropriate OS image for cloud migration",
+                "operationId": "RecommendVmOsImages",
+                "parameters": [
+                    {
+                        "description": "Specify the your infrastructure to be migrated",
+                        "name": "UserInfra",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
+                        }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "alibaba",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredProvider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully recommended VM OS image(s)",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedOsImageList"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
         "/recommendation/resources/securityGroups": {
             "post": {
                 "description": "Recommend an appropriate security group for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
@@ -2221,7 +2238,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
                         }
                     },
                     {
@@ -2274,6 +2291,86 @@
                 }
             }
         },
+        "/recommendation/resources/specs": {
+            "post": {
+                "description": "Recommend an appropriate VM specification for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.\n- If `targetMachineId` is provided, only that specific machine will be processed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Resources for VM infrastructure"
+                ],
+                "summary": "Recommend an appropriate VM specification for cloud migration",
+                "operationId": "RecommendVmSpecs",
+                "parameters": [
+                    {
+                        "description": "Specify the your infrastructure to be migrated",
+                        "name": "UserInfra",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
+                        }
+                    },
+                    {
+                        "enum": [
+                            "aws",
+                            "azure",
+                            "gcp",
+                            "alibaba",
+                            "ncp"
+                        ],
+                        "type": "string",
+                        "default": "aws",
+                        "description": "Provider (e.g., aws, azure, gcp)",
+                        "name": "desiredProvider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "ap-northeast-2",
+                        "description": "Region (e.g., ap-northeast-2)",
+                        "name": "desiredRegion",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target Machine ID to focus recommendation on (optional)",
+                        "name": "targetMachineId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully recommended VM spec(s)",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedSpecList"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
         "/recommendation/resources/vNet": {
             "post": {
                 "description": "Recommend an appropriate virtual network for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
@@ -2295,7 +2392,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
+                            "$ref": "#/definitions/controller.RecommendInfraRequest"
                         }
                     },
                     {
@@ -2348,247 +2445,7 @@
                 }
             }
         },
-        "/recommendation/resources/vmOsImages": {
-            "post": {
-                "description": "Recommend an appropriate OS image for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Resources for VM infrastructure"
-                ],
-                "summary": "Recommend an appropriate OS image for cloud migration",
-                "operationId": "RecommendVmOsImages",
-                "parameters": [
-                    {
-                        "description": "Specify the your infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully recommended VM OS image(s)",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedVmOsImageList"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request parameters",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error during recommendation",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/recommendation/resources/vmSpecs": {
-            "post": {
-                "description": "Recommend an appropriate VM specification for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.\n- If `targetMachineId` is provided, only that specific machine will be processed.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Resources for VM infrastructure"
-                ],
-                "summary": "Recommend an appropriate VM specification for cloud migration",
-                "operationId": "RecommendVmSpecs",
-                "parameters": [
-                    {
-                        "description": "Specify the your infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredProvider",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Target Machine ID to focus recommendation on (optional)",
-                        "name": "targetMachineId",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully recommended VM spec(s)",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-cloudmodel_RecommendedVmSpecList"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request parameters",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error during recommendation",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/recommendation/vmInfra": {
-            "post": {
-                "description": "Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.\n\n- See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256\n\n**[Required Parameters: `desiredCsp`, `desiredRegion`]** The desired cloud service provider and region for the recommended infrastructure.\n- if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.\n\n**[Optional Parameters: `limit`]** Maximum number of recommended infrastructures to return (default: 3)\n\n**[Optional Parameters: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n**[Response Field: `status`]** Candidate status based on the match rate threshold\n- **highly-matched**: Candidates meet or exceed the match rate threshold\n- **partially-matched**: Valid candidates below the match rate threshold\n\n**[Response Field: `description`]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts\n- Example: \"Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable\"\n\n**[Optional] `nameSeed`** is a base string used to prefix resource names (e.g., 'my' -\u003e 'my-vnet-01').\n",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Recommendation] Infrastructure"
-                ],
-                "summary": "Recommend multiple VM infrastructure candidates for cloud migration",
-                "operationId": "RecommendVmInfraCandidates",
-                "parameters": [
-                    {
-                        "description": "Specify the source infrastructure to be migrated",
-                        "name": "UserInfra",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controller.RecommendVmInfraRequest"
-                        }
-                    },
-                    {
-                        "enum": [
-                            "aws",
-                            "azure",
-                            "gcp",
-                            "alibaba",
-                            "ncp"
-                        ],
-                        "type": "string",
-                        "default": "aws",
-                        "description": "Provider (e.g., aws, azure, gcp)",
-                        "name": "desiredCsp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region (e.g., ap-northeast-2)",
-                        "name": "desiredRegion",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Limit (default: 3) the number of recommended infrastructures",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "number",
-                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
-                        "name": "minMatchRate",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
-                        "name": "X-Request-Id",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully recommended infrastructure candidates",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedVmInfra"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request parameters",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error during recommendation",
-                        "schema": {
-                            "$ref": "#/definitions/model.ApiResponse-any"
-                        }
-                    }
-                }
-            }
-        },
-        "/report/migration/ns/{nsId}/mci/{mciId}": {
+        "/report/migration/ns/{nsId}/infra/{infraId}": {
             "post": {
                 "description": "Generate a comprehensive migration report comparing source infrastructure with target cloud VMs, including resource mappings, network/security analysis, cost summary, and recommendations in Markdown or HTML format",
                 "consumes": [
@@ -2615,10 +2472,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "mci101",
-                        "example": "\"mci101\"",
-                        "description": "MCI ID",
-                        "name": "mciId",
+                        "default": "infra101",
+                        "example": "\"infra101\"",
+                        "description": "Infra ID",
+                        "name": "infraId",
                         "in": "path",
                         "required": true
                     },
@@ -2958,7 +2815,7 @@
                 }
             }
         },
-        "/summary/target/ns/{nsId}/mci/{mciId}": {
+        "/summary/target/ns/{nsId}/infra/{infraId}": {
             "get": {
                 "description": "Generate a comprehensive target infrastructure summary in multiple formats based on 'format' query parameter:\n\n**Response Format by 'format' Parameter:**\n- `format=md` (default): Returns markdown string with Content-Type: text/markdown; charset=utf-8\n- `format=html`: Returns HTML string with Content-Type: text/html; charset=utf-8\n- `format=json`: Returns ApiResponse[TargetInfraSummary] with Content-Type: application/json\n\n**Note:** API documentation shows JSON schema for reference, but actual default response is markdown format.\n\n**Markdown example**: https://github.com/cloud-barista/cm-beetle/blob/main/cmd/test-cli/testresult/beetle-summary-target-aws.md\n\n**Download Behavior:**\n- `download=false` (default): Content displayed inline (viewable in browser/Swagger UI)\n- `download=true`: Content downloaded as file (Content-Disposition: attachment)",
                 "consumes": [
@@ -4361,6 +4218,104 @@
                 "PlatformNA"
             ]
         },
+        "cloudmodel.RecommendedInfra": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "nameSeed": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetCloud": {
+                    "$ref": "#/definitions/cloudmodel.CloudProperty"
+                },
+                "targetInfra": {
+                    "$ref": "#/definitions/cloudmodel.InfraReq"
+                },
+                "targetOsImageList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.ImageInfo"
+                    }
+                },
+                "targetSecurityGroupList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
+                    }
+                },
+                "targetSpecList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.SpecInfo"
+                    }
+                },
+                "targetSshKey": {
+                    "$ref": "#/definitions/cloudmodel.SshKeyReq"
+                },
+                "targetVNet": {
+                    "$ref": "#/definitions/cloudmodel.VNetReq"
+                }
+            }
+        },
+        "cloudmodel.RecommendedInfraDynamic": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetInfra": {
+                    "$ref": "#/definitions/cloudmodel.InfraDynamicReq"
+                }
+            }
+        },
+        "cloudmodel.RecommendedOsImage": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "sourceServers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetOsImage": {
+                    "$ref": "#/definitions/cloudmodel.ImageInfo"
+                }
+            }
+        },
+        "cloudmodel.RecommendedOsImageList": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "recommendedOsImageList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.RecommendedOsImage"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "cloudmodel.RecommendedSecurityGroup": {
             "type": "object",
             "properties": {
@@ -4401,6 +4356,46 @@
                 }
             }
         },
+        "cloudmodel.RecommendedSpec": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "sourceServers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetSpec": {
+                    "$ref": "#/definitions/cloudmodel.SpecInfo"
+                }
+            }
+        },
+        "cloudmodel.RecommendedSpecList": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "recommendedSpecList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.RecommendedSpec"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "cloudmodel.RecommendedVNet": {
             "type": "object",
             "properties": {
@@ -4429,144 +4424,6 @@
                     "items": {
                         "$ref": "#/definitions/cloudmodel.RecommendedVNet"
                     }
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmInfra": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "nameSeed": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetCloud": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "targetSecurityGroupList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
-                    }
-                },
-                "targetSshKey": {
-                    "$ref": "#/definitions/cloudmodel.SshKeyReq"
-                },
-                "targetVNet": {
-                    "$ref": "#/definitions/cloudmodel.VNetReq"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraReq"
-                },
-                "targetVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.ImageInfo"
-                    }
-                },
-                "targetVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SpecInfo"
-                    }
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmInfraDynamic": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraDynamicReq"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmOsImage": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "sourceServers": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetVmOsImage": {
-                    "$ref": "#/definitions/cloudmodel.ImageInfo"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmOsImageList": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "recommendedVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmOsImage"
-                    }
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmSpec": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "sourceServers": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetVmSpec": {
-                    "$ref": "#/definitions/cloudmodel.SpecInfo"
-                }
-            }
-        },
-        "cloudmodel.RecommendedVmSpecList": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "recommendedVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmSpec"
-                    }
-                },
-                "status": {
-                    "type": "string"
                 }
             }
         },
@@ -5188,10 +5045,25 @@
                 "targetCloud": {
                     "$ref": "#/definitions/cloudmodel.CloudProperty"
                 },
+                "targetInfra": {
+                    "$ref": "#/definitions/cloudmodel.InfraReq"
+                },
+                "targetOsImageList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.ImageInfo"
+                    }
+                },
                 "targetSecurityGroupList": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
+                    }
+                },
+                "targetSpecList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.SpecInfo"
                     }
                 },
                 "targetSshKey": {
@@ -5199,21 +5071,6 @@
                 },
                 "targetVNet": {
                     "$ref": "#/definitions/cloudmodel.VNetReq"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraReq"
-                },
-                "targetVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.ImageInfo"
-                    }
-                },
-                "targetVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SpecInfo"
-                    }
                 }
             }
         },
@@ -5571,18 +5428,43 @@
         "controller.RecommendInfraRequest": {
             "type": "object",
             "properties": {
-                "desiredProvider": {
-                    "type": "string",
-                    "example": "aws"
+                "desiredCspAndRegionPair": {
+                    "$ref": "#/definitions/cloudmodel.CloudProperty"
                 },
-                "desiredRegion": {
+                "nameSeed": {
+                    "description": "Base string for resource name prefix (e.g., 'my' -\u003e 'my-vnet-01')",
                     "type": "string",
-                    "example": "ap-northeast-2"
+                    "example": "my"
                 },
-                "servers": {
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendInfraWithDefaultsRequest": {
+            "type": "object",
+            "properties": {
+                "desiredCspAndRegionPair": {
+                    "$ref": "#/definitions/cloudmodel.CloudProperty"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendInfraWithDefaultsResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "targetInfraList": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/recommendation.Kubernetes"
+                        "$ref": "#/definitions/cloudmodel.RecommendedInfraDynamic"
                     }
                 }
             }
@@ -5602,94 +5484,6 @@
                     "minItems": 1,
                     "items": {
                         "$ref": "#/definitions/controller.SourceObjectStorageProperty"
-                    }
-                }
-            }
-        },
-        "controller.RecommendVmInfraRequest": {
-            "type": "object",
-            "properties": {
-                "desiredCspAndRegionPair": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "nameSeed": {
-                    "description": "Base string for resource name prefix (e.g., 'my' -\u003e 'my-vnet-01')",
-                    "type": "string",
-                    "example": "my"
-                },
-                "onpremiseInfraModel": {
-                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
-                }
-            }
-        },
-        "controller.RecommendVmInfraResponse": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "nameSeed": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "targetCloud": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "targetSecurityGroupList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SecurityGroupReq"
-                    }
-                },
-                "targetSshKey": {
-                    "$ref": "#/definitions/cloudmodel.SshKeyReq"
-                },
-                "targetVNet": {
-                    "$ref": "#/definitions/cloudmodel.VNetReq"
-                },
-                "targetVmInfra": {
-                    "$ref": "#/definitions/cloudmodel.InfraReq"
-                },
-                "targetVmOsImageList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.ImageInfo"
-                    }
-                },
-                "targetVmSpecList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.SpecInfo"
-                    }
-                }
-            }
-        },
-        "controller.RecommendVmInfraWithDefaultsRequest": {
-            "type": "object",
-            "properties": {
-                "desiredCspAndRegionPair": {
-                    "$ref": "#/definitions/cloudmodel.CloudProperty"
-                },
-                "onpremiseInfraModel": {
-                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
-                }
-            }
-        },
-        "controller.RecommendVmInfraWithDefaultsResponse": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "targetVmInfraList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmInfraDynamic"
                     }
                 }
             }
@@ -5809,14 +5603,14 @@
                 }
             }
         },
-        "model.ApiResponse-array_cloudmodel_RecommendedVmInfra": {
+        "model.ApiResponse-array_cloudmodel_RecommendedInfra": {
             "type": "object",
             "properties": {
                 "data": {
                     "description": "Contains the actual response data (single object, list, or page)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
+                        "$ref": "#/definitions/cloudmodel.RecommendedInfra"
                     }
                 },
                 "error": {
@@ -5892,6 +5686,62 @@
                 }
             }
         },
+        "model.ApiResponse-cloudmodel_RecommendedInfra": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Contains the actual response data (single object, list, or page)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.RecommendedInfra"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "Error message for failed responses",
+                    "type": "string",
+                    "example": "Error message if failure"
+                },
+                "message": {
+                    "description": "Optional message for additional context",
+                    "type": "string",
+                    "example": "Operation successful"
+                },
+                "success": {
+                    "description": "Indicates whether the API call was successful",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
+        "model.ApiResponse-cloudmodel_RecommendedOsImageList": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Contains the actual response data (single object, list, or page)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.RecommendedOsImageList"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "Error message for failed responses",
+                    "type": "string",
+                    "example": "Error message if failure"
+                },
+                "message": {
+                    "description": "Optional message for additional context",
+                    "type": "string",
+                    "example": "Operation successful"
+                },
+                "success": {
+                    "description": "Indicates whether the API call was successful",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
         "model.ApiResponse-cloudmodel_RecommendedSecurityGroupList": {
             "type": "object",
             "properties": {
@@ -5920,6 +5770,34 @@
                 }
             }
         },
+        "model.ApiResponse-cloudmodel_RecommendedSpecList": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Contains the actual response data (single object, list, or page)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.RecommendedSpecList"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "Error message for failed responses",
+                    "type": "string",
+                    "example": "Error message if failure"
+                },
+                "message": {
+                    "description": "Optional message for additional context",
+                    "type": "string",
+                    "example": "Operation successful"
+                },
+                "success": {
+                    "description": "Indicates whether the API call was successful",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
         "model.ApiResponse-cloudmodel_RecommendedVNetList": {
             "type": "object",
             "properties": {
@@ -5928,90 +5806,6 @@
                     "allOf": [
                         {
                             "$ref": "#/definitions/cloudmodel.RecommendedVNetList"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-cloudmodel_RecommendedVmInfra": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmInfra"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-cloudmodel_RecommendedVmOsImageList": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmOsImageList"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-cloudmodel_RecommendedVmSpecList": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.RecommendedVmSpecList"
                         }
                     ]
                 },
@@ -6144,42 +5938,14 @@
                 }
             }
         },
-        "model.ApiResponse-controller_RecommendVmInfraResponse": {
+        "model.ApiResponse-controller_RecommendInfraWithDefaultsResponse": {
             "type": "object",
             "properties": {
                 "data": {
                     "description": "Contains the actual response data (single object, list, or page)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/controller.RecommendVmInfraResponse"
-                        }
-                    ]
-                },
-                "error": {
-                    "description": "Error message for failed responses",
-                    "type": "string",
-                    "example": "Error message if failure"
-                },
-                "message": {
-                    "description": "Optional message for additional context",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "success": {
-                    "description": "Indicates whether the API call was successful",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "model.ApiResponse-controller_RecommendVmInfraWithDefaultsResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Contains the actual response data (single object, list, or page)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/controller.RecommendVmInfraWithDefaultsResponse"
+                            "$ref": "#/definitions/controller.RecommendInfraWithDefaultsResponse"
                         }
                     ]
                 },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -970,6 +970,70 @@ definitions:
     - Linux_UNIX
     - Windows
     - PlatformNA
+  cloudmodel.RecommendedInfra:
+    properties:
+      description:
+        type: string
+      nameSeed:
+        type: string
+      status:
+        type: string
+      targetCloud:
+        $ref: '#/definitions/cloudmodel.CloudProperty'
+      targetInfra:
+        $ref: '#/definitions/cloudmodel.InfraReq'
+      targetOsImageList:
+        items:
+          $ref: '#/definitions/cloudmodel.ImageInfo'
+        type: array
+      targetSecurityGroupList:
+        items:
+          $ref: '#/definitions/cloudmodel.SecurityGroupReq'
+        type: array
+      targetSpecList:
+        items:
+          $ref: '#/definitions/cloudmodel.SpecInfo'
+        type: array
+      targetSshKey:
+        $ref: '#/definitions/cloudmodel.SshKeyReq'
+      targetVNet:
+        $ref: '#/definitions/cloudmodel.VNetReq'
+    type: object
+  cloudmodel.RecommendedInfraDynamic:
+    properties:
+      description:
+        type: string
+      status:
+        type: string
+      targetInfra:
+        $ref: '#/definitions/cloudmodel.InfraDynamicReq'
+    type: object
+  cloudmodel.RecommendedOsImage:
+    properties:
+      description:
+        type: string
+      sourceServers:
+        items:
+          type: string
+        type: array
+      status:
+        type: string
+      targetOsImage:
+        $ref: '#/definitions/cloudmodel.ImageInfo'
+    type: object
+  cloudmodel.RecommendedOsImageList:
+    properties:
+      count:
+        type: integer
+      description:
+        type: string
+      recommendedOsImageList:
+        items:
+          $ref: '#/definitions/cloudmodel.RecommendedOsImage'
+        type: array
+      status:
+        type: string
+    type: object
   cloudmodel.RecommendedSecurityGroup:
     properties:
       description:
@@ -996,6 +1060,32 @@ definitions:
           $ref: '#/definitions/cloudmodel.RecommendedSecurityGroup'
         type: array
     type: object
+  cloudmodel.RecommendedSpec:
+    properties:
+      description:
+        type: string
+      sourceServers:
+        items:
+          type: string
+        type: array
+      status:
+        type: string
+      targetSpec:
+        $ref: '#/definitions/cloudmodel.SpecInfo'
+    type: object
+  cloudmodel.RecommendedSpecList:
+    properties:
+      count:
+        type: integer
+      description:
+        type: string
+      recommendedSpecList:
+        items:
+          $ref: '#/definitions/cloudmodel.RecommendedSpec'
+        type: array
+      status:
+        type: string
+    type: object
   cloudmodel.RecommendedVNet:
     properties:
       description:
@@ -1015,96 +1105,6 @@ definitions:
         items:
           $ref: '#/definitions/cloudmodel.RecommendedVNet'
         type: array
-    type: object
-  cloudmodel.RecommendedVmInfra:
-    properties:
-      description:
-        type: string
-      nameSeed:
-        type: string
-      status:
-        type: string
-      targetCloud:
-        $ref: '#/definitions/cloudmodel.CloudProperty'
-      targetSecurityGroupList:
-        items:
-          $ref: '#/definitions/cloudmodel.SecurityGroupReq'
-        type: array
-      targetSshKey:
-        $ref: '#/definitions/cloudmodel.SshKeyReq'
-      targetVNet:
-        $ref: '#/definitions/cloudmodel.VNetReq'
-      targetVmInfra:
-        $ref: '#/definitions/cloudmodel.InfraReq'
-      targetVmOsImageList:
-        items:
-          $ref: '#/definitions/cloudmodel.ImageInfo'
-        type: array
-      targetVmSpecList:
-        items:
-          $ref: '#/definitions/cloudmodel.SpecInfo'
-        type: array
-    type: object
-  cloudmodel.RecommendedVmInfraDynamic:
-    properties:
-      description:
-        type: string
-      status:
-        type: string
-      targetVmInfra:
-        $ref: '#/definitions/cloudmodel.InfraDynamicReq'
-    type: object
-  cloudmodel.RecommendedVmOsImage:
-    properties:
-      description:
-        type: string
-      sourceServers:
-        items:
-          type: string
-        type: array
-      status:
-        type: string
-      targetVmOsImage:
-        $ref: '#/definitions/cloudmodel.ImageInfo'
-    type: object
-  cloudmodel.RecommendedVmOsImageList:
-    properties:
-      count:
-        type: integer
-      description:
-        type: string
-      recommendedVmOsImageList:
-        items:
-          $ref: '#/definitions/cloudmodel.RecommendedVmOsImage'
-        type: array
-      status:
-        type: string
-    type: object
-  cloudmodel.RecommendedVmSpec:
-    properties:
-      description:
-        type: string
-      sourceServers:
-        items:
-          type: string
-        type: array
-      status:
-        type: string
-      targetVmSpec:
-        $ref: '#/definitions/cloudmodel.SpecInfo'
-    type: object
-  cloudmodel.RecommendedVmSpecList:
-    properties:
-      count:
-        type: integer
-      description:
-        type: string
-      recommendedVmSpecList:
-        items:
-          $ref: '#/definitions/cloudmodel.RecommendedVmSpec'
-        type: array
-      status:
-        type: string
     type: object
   cloudmodel.RegionDetail:
     properties:
@@ -1544,24 +1544,24 @@ definitions:
         type: string
       targetCloud:
         $ref: '#/definitions/cloudmodel.CloudProperty'
+      targetInfra:
+        $ref: '#/definitions/cloudmodel.InfraReq'
+      targetOsImageList:
+        items:
+          $ref: '#/definitions/cloudmodel.ImageInfo'
+        type: array
       targetSecurityGroupList:
         items:
           $ref: '#/definitions/cloudmodel.SecurityGroupReq'
+        type: array
+      targetSpecList:
+        items:
+          $ref: '#/definitions/cloudmodel.SpecInfo'
         type: array
       targetSshKey:
         $ref: '#/definitions/cloudmodel.SshKeyReq'
       targetVNet:
         $ref: '#/definitions/cloudmodel.VNetReq'
-      targetVmInfra:
-        $ref: '#/definitions/cloudmodel.InfraReq'
-      targetVmOsImageList:
-        items:
-          $ref: '#/definitions/cloudmodel.ImageInfo'
-        type: array
-      targetVmSpecList:
-        items:
-          $ref: '#/definitions/cloudmodel.SpecInfo'
-        type: array
     type: object
   controller.MigrateInfraResponse:
     properties:
@@ -1862,15 +1862,31 @@ definitions:
     type: object
   controller.RecommendInfraRequest:
     properties:
-      desiredProvider:
-        example: aws
+      desiredCspAndRegionPair:
+        $ref: '#/definitions/cloudmodel.CloudProperty'
+      nameSeed:
+        description: Base string for resource name prefix (e.g., 'my' -> 'my-vnet-01')
+        example: my
         type: string
-      desiredRegion:
-        example: ap-northeast-2
+      onpremiseInfraModel:
+        $ref: '#/definitions/onpremisemodel.OnpremInfra'
+    type: object
+  controller.RecommendInfraWithDefaultsRequest:
+    properties:
+      desiredCspAndRegionPair:
+        $ref: '#/definitions/cloudmodel.CloudProperty'
+      onpremiseInfraModel:
+        $ref: '#/definitions/onpremisemodel.OnpremInfra'
+    type: object
+  controller.RecommendInfraWithDefaultsResponse:
+    properties:
+      count:
+        type: integer
+      description:
         type: string
-      servers:
+      targetInfraList:
         items:
-          $ref: '#/definitions/recommendation.Kubernetes'
+          $ref: '#/definitions/cloudmodel.RecommendedInfraDynamic'
         type: array
     type: object
   controller.RecommendObjectStorageRequest:
@@ -1885,64 +1901,6 @@ definitions:
     required:
     - desiredCloud
     - sourceObjectStorages
-    type: object
-  controller.RecommendVmInfraRequest:
-    properties:
-      desiredCspAndRegionPair:
-        $ref: '#/definitions/cloudmodel.CloudProperty'
-      nameSeed:
-        description: Base string for resource name prefix (e.g., 'my' -> 'my-vnet-01')
-        example: my
-        type: string
-      onpremiseInfraModel:
-        $ref: '#/definitions/onpremisemodel.OnpremInfra'
-    type: object
-  controller.RecommendVmInfraResponse:
-    properties:
-      description:
-        type: string
-      nameSeed:
-        type: string
-      status:
-        type: string
-      targetCloud:
-        $ref: '#/definitions/cloudmodel.CloudProperty'
-      targetSecurityGroupList:
-        items:
-          $ref: '#/definitions/cloudmodel.SecurityGroupReq'
-        type: array
-      targetSshKey:
-        $ref: '#/definitions/cloudmodel.SshKeyReq'
-      targetVNet:
-        $ref: '#/definitions/cloudmodel.VNetReq'
-      targetVmInfra:
-        $ref: '#/definitions/cloudmodel.InfraReq'
-      targetVmOsImageList:
-        items:
-          $ref: '#/definitions/cloudmodel.ImageInfo'
-        type: array
-      targetVmSpecList:
-        items:
-          $ref: '#/definitions/cloudmodel.SpecInfo'
-        type: array
-    type: object
-  controller.RecommendVmInfraWithDefaultsRequest:
-    properties:
-      desiredCspAndRegionPair:
-        $ref: '#/definitions/cloudmodel.CloudProperty'
-      onpremiseInfraModel:
-        $ref: '#/definitions/onpremisemodel.OnpremInfra'
-    type: object
-  controller.RecommendVmInfraWithDefaultsResponse:
-    properties:
-      count:
-        type: integer
-      description:
-        type: string
-      targetVmInfraList:
-        items:
-          $ref: '#/definitions/cloudmodel.RecommendedVmInfraDynamic'
-        type: array
     type: object
   controller.SourceObjectStorageProperty:
     properties:
@@ -2027,12 +1985,12 @@ definitions:
         example: true
         type: boolean
     type: object
-  model.ApiResponse-array_cloudmodel_RecommendedVmInfra:
+  model.ApiResponse-array_cloudmodel_RecommendedInfra:
     properties:
       data:
         description: Contains the actual response data (single object, list, or page)
         items:
-          $ref: '#/definitions/cloudmodel.RecommendedVmInfra'
+          $ref: '#/definitions/cloudmodel.RecommendedInfra'
         type: array
       error:
         description: Error message for failed responses
@@ -2085,6 +2043,44 @@ definitions:
         example: true
         type: boolean
     type: object
+  model.ApiResponse-cloudmodel_RecommendedInfra:
+    properties:
+      data:
+        allOf:
+        - $ref: '#/definitions/cloudmodel.RecommendedInfra'
+        description: Contains the actual response data (single object, list, or page)
+      error:
+        description: Error message for failed responses
+        example: Error message if failure
+        type: string
+      message:
+        description: Optional message for additional context
+        example: Operation successful
+        type: string
+      success:
+        description: Indicates whether the API call was successful
+        example: true
+        type: boolean
+    type: object
+  model.ApiResponse-cloudmodel_RecommendedOsImageList:
+    properties:
+      data:
+        allOf:
+        - $ref: '#/definitions/cloudmodel.RecommendedOsImageList'
+        description: Contains the actual response data (single object, list, or page)
+      error:
+        description: Error message for failed responses
+        example: Error message if failure
+        type: string
+      message:
+        description: Optional message for additional context
+        example: Operation successful
+        type: string
+      success:
+        description: Indicates whether the API call was successful
+        example: true
+        type: boolean
+    type: object
   model.ApiResponse-cloudmodel_RecommendedSecurityGroupList:
     properties:
       data:
@@ -2104,68 +2100,30 @@ definitions:
         example: true
         type: boolean
     type: object
+  model.ApiResponse-cloudmodel_RecommendedSpecList:
+    properties:
+      data:
+        allOf:
+        - $ref: '#/definitions/cloudmodel.RecommendedSpecList'
+        description: Contains the actual response data (single object, list, or page)
+      error:
+        description: Error message for failed responses
+        example: Error message if failure
+        type: string
+      message:
+        description: Optional message for additional context
+        example: Operation successful
+        type: string
+      success:
+        description: Indicates whether the API call was successful
+        example: true
+        type: boolean
+    type: object
   model.ApiResponse-cloudmodel_RecommendedVNetList:
     properties:
       data:
         allOf:
         - $ref: '#/definitions/cloudmodel.RecommendedVNetList'
-        description: Contains the actual response data (single object, list, or page)
-      error:
-        description: Error message for failed responses
-        example: Error message if failure
-        type: string
-      message:
-        description: Optional message for additional context
-        example: Operation successful
-        type: string
-      success:
-        description: Indicates whether the API call was successful
-        example: true
-        type: boolean
-    type: object
-  model.ApiResponse-cloudmodel_RecommendedVmInfra:
-    properties:
-      data:
-        allOf:
-        - $ref: '#/definitions/cloudmodel.RecommendedVmInfra'
-        description: Contains the actual response data (single object, list, or page)
-      error:
-        description: Error message for failed responses
-        example: Error message if failure
-        type: string
-      message:
-        description: Optional message for additional context
-        example: Operation successful
-        type: string
-      success:
-        description: Indicates whether the API call was successful
-        example: true
-        type: boolean
-    type: object
-  model.ApiResponse-cloudmodel_RecommendedVmOsImageList:
-    properties:
-      data:
-        allOf:
-        - $ref: '#/definitions/cloudmodel.RecommendedVmOsImageList'
-        description: Contains the actual response data (single object, list, or page)
-      error:
-        description: Error message for failed responses
-        example: Error message if failure
-        type: string
-      message:
-        description: Optional message for additional context
-        example: Operation successful
-        type: string
-      success:
-        description: Indicates whether the API call was successful
-        example: true
-        type: boolean
-    type: object
-  model.ApiResponse-cloudmodel_RecommendedVmSpecList:
-    properties:
-      data:
-        allOf:
-        - $ref: '#/definitions/cloudmodel.RecommendedVmSpecList'
         description: Contains the actual response data (single object, list, or page)
       error:
         description: Error message for failed responses
@@ -2256,30 +2214,11 @@ definitions:
         example: true
         type: boolean
     type: object
-  model.ApiResponse-controller_RecommendVmInfraResponse:
+  model.ApiResponse-controller_RecommendInfraWithDefaultsResponse:
     properties:
       data:
         allOf:
-        - $ref: '#/definitions/controller.RecommendVmInfraResponse'
-        description: Contains the actual response data (single object, list, or page)
-      error:
-        description: Error message for failed responses
-        example: Error message if failure
-        type: string
-      message:
-        description: Optional message for additional context
-        example: Operation successful
-        type: string
-      success:
-        description: Indicates whether the API call was successful
-        example: true
-        type: boolean
-    type: object
-  model.ApiResponse-controller_RecommendVmInfraWithDefaultsResponse:
-    properties:
-      data:
-        allOf:
-        - $ref: '#/definitions/controller.RecommendVmInfraWithDefaultsResponse'
+        - $ref: '#/definitions/controller.RecommendInfraWithDefaultsResponse'
         description: Contains the actual response data (single object, list, or page)
       error:
         description: Error message for failed responses
@@ -5300,7 +5239,7 @@ paths:
       summary: Check object storage (bucket) existence
       tags:
       - '[Migration] Managed middleware (preview)'
-  /migration/ns/{nsId}/mci:
+  /migration/ns/{nsId}/infra:
     get:
       consumes:
       - application/json
@@ -5355,10 +5294,9 @@ paths:
         name: nsId
         required: true
         type: string
-      - description: Specify the information for the targeted mulci-cloud infrastructure
-          (MCI)
+      - description: Specify the information for the targeted multi-cloud infrastructure
         in: body
-        name: mciInfo
+        name: infraInfo
         required: true
         schema:
           $ref: '#/definitions/controller.MigrateInfraRequest'
@@ -5386,7 +5324,7 @@ paths:
         defaults
       tags:
       - '[Migration] Infrastructure'
-  /migration/ns/{nsId}/mci/{mciId}:
+  /migration/ns/{nsId}/infra/{infraId}:
     delete:
       consumes:
       - application/json
@@ -5400,10 +5338,10 @@ paths:
         required: true
         type: string
       - default: my-infra101
-        description: Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned
-          by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')
+        description: Migrated Cloud Infrastructure ID (the actual ID returned by the
+          migration API; includes NameSeed prefix if used, e.g., 'my-infra101')
         in: path
-        name: mciId
+        name: infraId
         required: true
         type: string
       - default: terminate
@@ -5424,7 +5362,6 @@ paths:
       responses:
         "200":
           description: The result of deleting the migrated multi-cloud infrastructure
-            (MCI)
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
         "404":
@@ -5451,10 +5388,10 @@ paths:
         required: true
         type: string
       - default: my-infra101
-        description: Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned
-          by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')
+        description: Migrated Cloud Infrastructure ID (the actual ID returned by the
+          migration API; includes NameSeed prefix if used, e.g., 'my-infra101')
         in: path
-        name: mciId
+        name: infraId
         required: true
         type: string
       - description: Unique request ID (auto-generated if not provided). Used for
@@ -5466,7 +5403,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: The migrated multi-cloud infrastructure (MCI) information
+          description: The migrated multi-cloud infrastructure information
           schema:
             $ref: '#/definitions/model.ApiResponse-controller_MigrateInfraResponse'
         "404":
@@ -5480,7 +5417,7 @@ paths:
       summary: Get the migrated multi-cloud infrastructure (MCI)
       tags:
       - '[Migration] Infrastructure'
-  /migration/ns/{nsId}/mciWithDefaults:
+  /migration/ns/{nsId}/infraWithDefaults:
     post:
       consumes:
       - application/json
@@ -6053,7 +5990,7 @@ paths:
         - `subnet` : Rename Subnet → propagates to SubGroup.SubnetId
         - `sshKey` : Rename SSH Key → propagates to SubGroup.SshKeyId
         - `securityGroup` : Rename SecurityGroup → propagates to SubGroup.SecurityGroupIds
-        - `mci` : Rename MCI (no child propagation)
+        - `infra` : Rename Infra (no child propagation)
 
         After propagation, names are validated with NameSeed applied (pre-flight check).
         The returned model uses **base names only** (NameSeed is applied at migration time).
@@ -6067,7 +6004,7 @@ paths:
         - subnet
         - securityGroup
         - sshKey
-        - mci
+        - infra
         in: query
         name: resourceType
         required: true
@@ -6087,7 +6024,7 @@ paths:
         name: UserInfra
         required: true
         schema:
-          $ref: '#/definitions/cloudmodel.RecommendedVmInfra'
+          $ref: '#/definitions/cloudmodel.RecommendedInfra'
       - description: Unique request ID
         in: header
         name: X-Request-Id
@@ -6098,7 +6035,7 @@ paths:
         "200":
           description: Updated and validated model (base names)
           schema:
-            $ref: '#/definitions/model.ApiResponse-cloudmodel_RecommendedVmInfra'
+            $ref: '#/definitions/model.ApiResponse-cloudmodel_RecommendedInfra'
         "400":
           description: Invalid request or referential integrity failure
           schema:
@@ -6111,7 +6048,7 @@ paths:
       consumes:
       - application/json
       description: |
-        Validates that all internal references within a RecommendedVmInfra model
+        Validates that all internal references within a RecommendedInfra model
         are consistent and point to existing resources.
         NameSeed is NOT applied here; this validates the base names only.
       operationId: ValidateNames
@@ -6121,7 +6058,7 @@ paths:
         name: UserInfra
         required: true
         schema:
-          $ref: '#/definitions/cloudmodel.RecommendedVmInfra'
+          $ref: '#/definitions/cloudmodel.RecommendedInfra'
       - description: Unique request ID
         in: header
         name: X-Request-Id
@@ -6166,18 +6103,33 @@ paths:
       summary: Check Beetle is ready
       tags:
       - '[Admin] System management'
-  /recommendation/containerInfra:
+  /recommendation/infra:
     post:
       consumes:
       - application/json
-      deprecated: true
-      description: |-
-        [DEPRECATED] This endpoint is deprecated. Use /recommendation/k8sCluster and /recommendation/k8sNodeGroup instead.
+      description: |
+        Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.
 
-        [Note] `desiredProvider` and `desiredRegion` are required.
-      operationId: RecommendContainerInfra
+        - See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256
+
+        **[Required Parameters: `desiredCsp`, `desiredRegion`]** The desired cloud service provider and region for the recommended infrastructure.
+        - if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.
+
+        **[Optional Parameters: `limit`]** Maximum number of recommended infrastructures to return (default: 3)
+
+        **[Optional Parameters: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)
+
+        **[Response Field: `status`]** Candidate status based on the match rate threshold
+        - **highly-matched**: Candidates meet or exceed the match rate threshold
+        - **partially-matched**: Valid candidates below the match rate threshold
+
+        **[Response Field: `description`]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts
+        - Example: "Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable"
+
+        **[Optional] `nameSeed`** is a base string used to prefix resource names (e.g., 'my' -> 'my-vnet-01').
+      operationId: RecommendVmInfraCandidates
       parameters:
-      - description: Specify the source container infrastructure
+      - description: Specify the source infrastructure to be migrated
         in: body
         name: UserInfra
         required: true
@@ -6192,7 +6144,74 @@ paths:
         - alibaba
         - ncp
         in: query
-        name: desiredProvider
+        name: desiredCsp
+        type: string
+      - default: ap-northeast-2
+        description: Region (e.g., ap-northeast-2)
+        in: query
+        name: desiredRegion
+        type: string
+      - description: 'Limit (default: 3) the number of recommended infrastructures'
+        in: query
+        name: limit
+        type: integer
+      - description: 'Minimum match rate for highly-matched classification (default:
+          90.0, range: 0-100)'
+        in: query
+        name: minMatchRate
+        type: number
+      - description: Unique request ID (auto-generated if not provided). Used for
+          tracking request status and correlating logs.
+        in: header
+        name: X-Request-Id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully recommended infrastructure candidates
+          schema:
+            $ref: '#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "500":
+          description: Internal server error during recommendation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: Recommend multiple VM infrastructure candidates for cloud migration
+      tags:
+      - '[Recommendation] Infrastructure'
+  /recommendation/infraWithDefaults:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration
+
+        [Note] `desiredCsp` and `desiredRegion` are required.
+        - `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.
+
+        - If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.
+      operationId: RecommendVMInfraWithDefaults
+      parameters:
+      - description: Specify the source infrastructure to be migrated
+        in: body
+        name: UserInfra
+        required: true
+        schema:
+          $ref: '#/definitions/controller.RecommendInfraWithDefaultsRequest'
+      - default: aws
+        description: Provider (e.g., aws, azure, gcp)
+        enum:
+        - aws
+        - azure
+        - gcp
+        - alibaba
+        - ncp
+        in: query
+        name: desiredCsp
         type: string
       - default: ap-northeast-2
         description: Region (e.g., ap-northeast-2)
@@ -6208,15 +6227,19 @@ paths:
       - application/json
       responses:
         "200":
-          description: Deprecated endpoint notice
+          description: The result of recommended infrastructure
+          schema:
+            $ref: '#/definitions/model.ApiResponse-controller_RecommendInfraWithDefaultsResponse'
+        "404":
+          description: Not Found
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
-      summary: (Deprecated) Recommend an appropriate container infrastructure for
-        cloud migration
+      summary: (To be updated) Recommend an appropriate VM infrastructure (i.e., MCI,
+        multi-cloud infrastructure) with defaults for cloud migration
       tags:
       - '[Recommendation] Infrastructure'
   /recommendation/k8sControlPlane:
@@ -6322,124 +6345,6 @@ paths:
       summary: Recommend K8s worker node group configuration
       tags:
       - '[Recommendation] K8s Cluster (prototype)'
-  /recommendation/mci:
-    post:
-      consumes:
-      - application/json
-      description: |-
-        **(To be deprecated)** Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration
-
-        [Note] `desiredCsp` and `desiredRegion` are required.
-        - `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.
-      operationId: RecommendVMInfra
-      parameters:
-      - description: Specify the source infrastructure to be migrated
-        in: body
-        name: UserInfra
-        required: true
-        schema:
-          $ref: '#/definitions/controller.RecommendVmInfraRequest'
-      - default: aws
-        description: Provider (e.g., aws, azure, gcp)
-        enum:
-        - aws
-        - azure
-        - gcp
-        - alibaba
-        - ncp
-        in: query
-        name: desiredCsp
-        type: string
-      - default: ap-northeast-2
-        description: Region (e.g., ap-northeast-2)
-        in: query
-        name: desiredRegion
-        type: string
-      - description: Unique request ID (auto-generated if not provided). Used for
-          tracking request status and correlating logs.
-        in: header
-        name: X-Request-Id
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: The result of recommended infrastructure
-          schema:
-            $ref: '#/definitions/model.ApiResponse-controller_RecommendVmInfraResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-      summary: '**(To be deprecated)** Recommend an appropriate VM infrastructure
-        (i.e., MCI, multi-cloud infrastructure) for cloud migration'
-      tags:
-      - '[Recommendation] Infrastructure'
-  /recommendation/mciWithDefaults:
-    post:
-      consumes:
-      - application/json
-      description: |-
-        Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration
-
-        [Note] `desiredCsp` and `desiredRegion` are required.
-        - `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.
-      operationId: RecommendVMInfraWithDefaults
-      parameters:
-      - description: Specify the source infrastructure to be migrated
-        in: body
-        name: UserInfra
-        required: true
-        schema:
-          $ref: '#/definitions/controller.RecommendVmInfraWithDefaultsRequest'
-      - default: aws
-        description: Provider (e.g., aws, azure, gcp)
-        enum:
-        - aws
-        - azure
-        - gcp
-        - alibaba
-        - ncp
-        in: query
-        name: desiredCsp
-        type: string
-      - default: ap-northeast-2
-        description: Region (e.g., ap-northeast-2)
-        in: query
-        name: desiredRegion
-        type: string
-      - description: Unique request ID (auto-generated if not provided). Used for
-          tracking request status and correlating logs.
-        in: header
-        name: X-Request-Id
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: The result of recommended infrastructure
-          schema:
-            $ref: '#/definitions/model.ApiResponse-controller_RecommendVmInfraWithDefaultsResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-      summary: (To be updated) Recommend an appropriate VM infrastructure (i.e., MCI,
-        multi-cloud infrastructure) with defaults for cloud migration
-      tags:
-      - '[Recommendation] Infrastructure'
   /recommendation/middleware/objectStorage:
     post:
       consumes:
@@ -6504,6 +6409,64 @@ paths:
       summary: Recommend an object storage for cloud migration
       tags:
       - '[Recommendation] Managed middleware (preview)'
+  /recommendation/resources/osImages:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Recommend an appropriate OS image for cloud migration
+
+        [Note] `desiredProvider` and `desiredRegion` are required.
+        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
+
+        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
+      operationId: RecommendVmOsImages
+      parameters:
+      - description: Specify the your infrastructure to be migrated
+        in: body
+        name: UserInfra
+        required: true
+        schema:
+          $ref: '#/definitions/controller.RecommendInfraRequest'
+      - default: aws
+        description: Provider (e.g., aws, azure, gcp)
+        enum:
+        - aws
+        - azure
+        - gcp
+        - alibaba
+        - ncp
+        in: query
+        name: desiredProvider
+        type: string
+      - default: ap-northeast-2
+        description: Region (e.g., ap-northeast-2)
+        in: query
+        name: desiredRegion
+        type: string
+      - description: Unique request ID (auto-generated if not provided). Used for
+          tracking request status and correlating logs.
+        in: header
+        name: X-Request-Id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully recommended VM OS image(s)
+          schema:
+            $ref: '#/definitions/model.ApiResponse-cloudmodel_RecommendedOsImageList'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "500":
+          description: Internal server error during recommendation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: Recommend an appropriate OS image for cloud migration
+      tags:
+      - '[Recommendation] Resources for VM infrastructure'
   /recommendation/resources/securityGroups:
     post:
       consumes:
@@ -6522,7 +6485,7 @@ paths:
         name: UserInfra
         required: true
         schema:
-          $ref: '#/definitions/controller.RecommendVmInfraRequest'
+          $ref: '#/definitions/controller.RecommendInfraRequest'
       - default: aws
         description: Provider (e.g., aws, azure, gcp)
         enum:
@@ -6562,6 +6525,69 @@ paths:
       summary: Recommend an appropriate security group for cloud migration
       tags:
       - '[Recommendation] Resources for VM infrastructure'
+  /recommendation/resources/specs:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Recommend an appropriate VM specification for cloud migration
+
+        [Note] `desiredProvider` and `desiredRegion` are required.
+        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
+
+        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
+        - If `targetMachineId` is provided, only that specific machine will be processed.
+      operationId: RecommendVmSpecs
+      parameters:
+      - description: Specify the your infrastructure to be migrated
+        in: body
+        name: UserInfra
+        required: true
+        schema:
+          $ref: '#/definitions/controller.RecommendInfraRequest'
+      - default: aws
+        description: Provider (e.g., aws, azure, gcp)
+        enum:
+        - aws
+        - azure
+        - gcp
+        - alibaba
+        - ncp
+        in: query
+        name: desiredProvider
+        type: string
+      - default: ap-northeast-2
+        description: Region (e.g., ap-northeast-2)
+        in: query
+        name: desiredRegion
+        type: string
+      - description: Target Machine ID to focus recommendation on (optional)
+        in: query
+        name: targetMachineId
+        type: string
+      - description: Unique request ID (auto-generated if not provided). Used for
+          tracking request status and correlating logs.
+        in: header
+        name: X-Request-Id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully recommended VM spec(s)
+          schema:
+            $ref: '#/definitions/model.ApiResponse-cloudmodel_RecommendedSpecList'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "500":
+          description: Internal server error during recommendation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: Recommend an appropriate VM specification for cloud migration
+      tags:
+      - '[Recommendation] Resources for VM infrastructure'
   /recommendation/resources/vNet:
     post:
       consumes:
@@ -6580,7 +6606,7 @@ paths:
         name: UserInfra
         required: true
         schema:
-          $ref: '#/definitions/controller.RecommendVmInfraRequest'
+          $ref: '#/definitions/controller.RecommendInfraRequest'
       - default: aws
         description: Provider (e.g., aws, azure, gcp)
         enum:
@@ -6620,208 +6646,7 @@ paths:
       summary: Recommend an appropriate virtual network for cloud migration
       tags:
       - '[Recommendation] Resources for VM infrastructure'
-  /recommendation/resources/vmOsImages:
-    post:
-      consumes:
-      - application/json
-      description: |-
-        Recommend an appropriate OS image for cloud migration
-
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
-      operationId: RecommendVmOsImages
-      parameters:
-      - description: Specify the your infrastructure to be migrated
-        in: body
-        name: UserInfra
-        required: true
-        schema:
-          $ref: '#/definitions/controller.RecommendVmInfraRequest'
-      - default: aws
-        description: Provider (e.g., aws, azure, gcp)
-        enum:
-        - aws
-        - azure
-        - gcp
-        - alibaba
-        - ncp
-        in: query
-        name: desiredProvider
-        type: string
-      - default: ap-northeast-2
-        description: Region (e.g., ap-northeast-2)
-        in: query
-        name: desiredRegion
-        type: string
-      - description: Unique request ID (auto-generated if not provided). Used for
-          tracking request status and correlating logs.
-        in: header
-        name: X-Request-Id
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Successfully recommended VM OS image(s)
-          schema:
-            $ref: '#/definitions/model.ApiResponse-cloudmodel_RecommendedVmOsImageList'
-        "400":
-          description: Invalid request parameters
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-        "500":
-          description: Internal server error during recommendation
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-      summary: Recommend an appropriate OS image for cloud migration
-      tags:
-      - '[Recommendation] Resources for VM infrastructure'
-  /recommendation/resources/vmSpecs:
-    post:
-      consumes:
-      - application/json
-      description: |-
-        Recommend an appropriate VM specification for cloud migration
-
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
-        - If `targetMachineId` is provided, only that specific machine will be processed.
-      operationId: RecommendVmSpecs
-      parameters:
-      - description: Specify the your infrastructure to be migrated
-        in: body
-        name: UserInfra
-        required: true
-        schema:
-          $ref: '#/definitions/controller.RecommendVmInfraRequest'
-      - default: aws
-        description: Provider (e.g., aws, azure, gcp)
-        enum:
-        - aws
-        - azure
-        - gcp
-        - alibaba
-        - ncp
-        in: query
-        name: desiredProvider
-        type: string
-      - default: ap-northeast-2
-        description: Region (e.g., ap-northeast-2)
-        in: query
-        name: desiredRegion
-        type: string
-      - description: Target Machine ID to focus recommendation on (optional)
-        in: query
-        name: targetMachineId
-        type: string
-      - description: Unique request ID (auto-generated if not provided). Used for
-          tracking request status and correlating logs.
-        in: header
-        name: X-Request-Id
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Successfully recommended VM spec(s)
-          schema:
-            $ref: '#/definitions/model.ApiResponse-cloudmodel_RecommendedVmSpecList'
-        "400":
-          description: Invalid request parameters
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-        "500":
-          description: Internal server error during recommendation
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-      summary: Recommend an appropriate VM specification for cloud migration
-      tags:
-      - '[Recommendation] Resources for VM infrastructure'
-  /recommendation/vmInfra:
-    post:
-      consumes:
-      - application/json
-      description: |
-        Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.
-
-        - See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256
-
-        **[Required Parameters: `desiredCsp`, `desiredRegion`]** The desired cloud service provider and region for the recommended infrastructure.
-        - if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.
-
-        **[Optional Parameters: `limit`]** Maximum number of recommended infrastructures to return (default: 3)
-
-        **[Optional Parameters: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)
-
-        **[Response Field: `status`]** Candidate status based on the match rate threshold
-        - **highly-matched**: Candidates meet or exceed the match rate threshold
-        - **partially-matched**: Valid candidates below the match rate threshold
-
-        **[Response Field: `description`]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts
-        - Example: "Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable"
-
-        **[Optional] `nameSeed`** is a base string used to prefix resource names (e.g., 'my' -> 'my-vnet-01').
-      operationId: RecommendVmInfraCandidates
-      parameters:
-      - description: Specify the source infrastructure to be migrated
-        in: body
-        name: UserInfra
-        required: true
-        schema:
-          $ref: '#/definitions/controller.RecommendVmInfraRequest'
-      - default: aws
-        description: Provider (e.g., aws, azure, gcp)
-        enum:
-        - aws
-        - azure
-        - gcp
-        - alibaba
-        - ncp
-        in: query
-        name: desiredCsp
-        type: string
-      - default: ap-northeast-2
-        description: Region (e.g., ap-northeast-2)
-        in: query
-        name: desiredRegion
-        type: string
-      - description: 'Limit (default: 3) the number of recommended infrastructures'
-        in: query
-        name: limit
-        type: integer
-      - description: 'Minimum match rate for highly-matched classification (default:
-          90.0, range: 0-100)'
-        in: query
-        name: minMatchRate
-        type: number
-      - description: Unique request ID (auto-generated if not provided). Used for
-          tracking request status and correlating logs.
-        in: header
-        name: X-Request-Id
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Successfully recommended infrastructure candidates
-          schema:
-            $ref: '#/definitions/model.ApiResponse-array_cloudmodel_RecommendedVmInfra'
-        "400":
-          description: Invalid request parameters
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-        "500":
-          description: Internal server error during recommendation
-          schema:
-            $ref: '#/definitions/model.ApiResponse-any'
-      summary: Recommend multiple VM infrastructure candidates for cloud migration
-      tags:
-      - '[Recommendation] Infrastructure'
-  /report/migration/ns/{nsId}/mci/{mciId}:
+  /report/migration/ns/{nsId}/infra/{infraId}:
     post:
       consumes:
       - application/json
@@ -6837,11 +6662,11 @@ paths:
         name: nsId
         required: true
         type: string
-      - default: mci101
-        description: MCI ID
-        example: '"mci101"'
+      - default: infra101
+        description: Infra ID
+        example: '"infra101"'
         in: path
-        name: mciId
+        name: infraId
         required: true
         type: string
       - default: md
@@ -7132,7 +6957,7 @@ paths:
       summary: Generate source infrastructure summary
       tags:
       - '[Summary/Report] Infrastructure Analysis for Migration'
-  /summary/target/ns/{nsId}/mci/{mciId}:
+  /summary/target/ns/{nsId}/infra/{infraId}:
     get:
       consumes:
       - application/json

--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -31,15 +31,15 @@ Before testing CSP-Region pairs, the CLI performs:
 
 Each CSP-Region pair executes the following sequential operations:
 
-1. `POST /beetle/recommendation/vmInfra` - Infrastructure recommendation (returns multiple candidates, uses first one)
-2. `POST /beetle/migration/ns/{nsId}/mci` - Infrastructure migration
-3. `GET /beetle/migration/ns/{nsId}/mci` - List MCIs
-4. `GET /beetle/migration/ns/{nsId}/mci?option=id` - List MCI IDs
-5. `GET /beetle/migration/ns/{nsId}/mci/{mciId}` - Get specific MCI
+1. `POST /beetle/recommendation/infra` - Infrastructure recommendation (returns multiple candidates, uses first one)
+2. `POST /beetle/migration/ns/{nsId}/infra` - Infrastructure migration
+3. `GET /beetle/migration/ns/{nsId}/infra` - List infras
+4. `GET /beetle/migration/ns/{nsId}/infra?option=id` - List infra IDs
+5. `GET /beetle/migration/ns/{nsId}/infra/{infraId}` - Get specific infra
 6. **Remote Command Test** - SSH connectivity and accessibility check for migrated VMs
-7. **Target Infrastructure Summary**: `GET /beetle/summary/target/ns/{nsId}/mci/{mciId}` - Generate summary of migrated infrastructure
-8. **Migration Report**: `POST /beetle/report/migration/ns/{nsId}/mci/{mciId}` - Comprehensive migration analysis report
-9. `DELETE /beetle/migration/ns/{nsId}/mci/{mciId}?option=terminate` - Delete MCI
+7. **Target Infrastructure Summary**: `GET /beetle/summary/target/ns/{nsId}/infra/{infraId}` - Generate summary of migrated infrastructure
+8. **Migration Report**: `POST /beetle/report/migration/ns/{nsId}/infra/{infraId}` - Comprehensive migration analysis report
+9. `DELETE /beetle/migration/ns/{nsId}/infra/{infraId}?option=terminate` - Delete infra
 
 **Note**: If any test fails, remaining tests for that CSP-Region pair are skipped.
 
@@ -147,19 +147,19 @@ SOURCE INFRASTRUCTURE SUMMARY
 Testing CSP-Region Pair 1/5: AWS-Seoul
 ============================================================
 
---- Test 1: POST /beetle/recommendation/vmInfra ---
+--- Test 1: POST /beetle/recommendation/infra ---
 ✅ Test 1 passed (Duration: 541ms)
 
---- Test 2: POST /beetle/migration/ns/mig01/mci ---
+--- Test 2: POST /beetle/migration/ns/mig01/infra ---
 ✅ Test 2 passed (Duration: 37.999s)
 
---- Test 3: GET /beetle/migration/ns/mig01/mci ---
+--- Test 3: GET /beetle/migration/ns/mig01/infra ---
 ✅ Test 3 passed (Duration: 125ms)
 
---- Test 4: GET /beetle/migration/ns/mig01/mci?option=id ---
+--- Test 4: GET /beetle/migration/ns/mig01/infra?option=id ---
 ✅ Test 4 passed (Duration: 98ms)
 
---- Test 5: GET /beetle/migration/ns/mig01/mci/{mciId} ---
+--- Test 5: GET /beetle/migration/ns/mig01/infra/{infraId} ---
 ✅ Test 5 passed (Duration: 142ms)
 
 --- Test 6: Remote Command Accessibility Check ---
@@ -173,7 +173,7 @@ Testing CSP-Region Pair 1/5: AWS-Seoul
 --- Migration Report ---
 ✅ Migration report generated successfully
 
---- Test 7: DELETE /beetle/migration/ns/mig01/mci/{mciId} ---
+--- Test 7: DELETE /beetle/migration/ns/mig01/infra/{infraId} ---
 ✅ Test 7 passed (Duration: 25.3s)
 
 ============================================================
@@ -196,8 +196,8 @@ Individual Markdown reports are generated in `testresult/`:
 - `beetle-test-results-gcp.md` - GCP test results
 - `beetle-test-results-alibaba.md` - Alibaba Cloud test results
 - `beetle-test-results-ncp.md` - NCP test results
-- `target-infra-summary-{csp}-{mciId}.md` - Target infrastructure summaries (per CSP)
-- `migration-report-{csp}-{mciId}.md` - Migration reports (per CSP)
+- `target-infra-summary-{csp}-{infraId}.md` - Target infrastructure summaries (per CSP)
+- `migration-report-{csp}-{infraId}.md` - Migration reports (per CSP)
 
 ## Custom Configuration
 

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -45,8 +45,8 @@ type CSPTestReport struct {
 	BeetleURL              string
 	NamespaceID            string
 	OnpremiseInfraModel    onpremmodel.OnpremInfra
-	RecommendationRequest  controller.RecommendVmInfraRequest
-	RecommendationResponse *model.ApiResponse[[]cloudmodel.RecommendedVmInfra]
+	RecommendationRequest  controller.RecommendInfraRequest
+	RecommendationResponse *model.ApiResponse[[]cloudmodel.RecommendedInfra]
 	MigrationResponse      *controller.MigrateInfraResponse
 	ListMCIResponse        *cloudmodel.InfraInfoList
 	ListMCIIDsResponse     *cloudmodel.IdList
@@ -368,7 +368,7 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 	pairSkipped := 0
 
 	// Create RecommendVmInfraRequest for this CSP-Region pair
-	recommendRequest := controller.RecommendVmInfraRequest{
+	recommendRequest := controller.RecommendInfraRequest{
 		NameSeed: nameSeed,
 		DesiredCspAndRegionPair: cloudmodel.CloudProperty{
 			Csp:    cspPair.Csp,
@@ -392,7 +392,7 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 		TestResults:           make([]TestResults, 0),
 	}
 
-	var mciId string
+	var infraId string
 	var stopTesting bool
 
 	// Local helper to record results safely
@@ -414,7 +414,7 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 	}
 
 	/*
-	 * Test 1: POST /beetle/recommendation/vmInfra
+	 * Test 1: POST /beetle/recommendation/infra
 	 */
 	recommendationApiResponse, result1 := runRecommendationTest(client, config, cspPair.CloudProperty, recommendRequest, displayName)
 	recordResult(result1)
@@ -426,26 +426,26 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 		// Set tentative MCI ID from recommendation as a fallback for cleanup
 		if len(recommendationApiResponse.Data) > 0 {
 			// Predict the final name that Beetle will use after applying NameSeed
-			mciId = common.ComposeName(recommendationApiResponse.Data[0].TargetVmInfra.Name, nameSeed)
+			infraId = common.ComposeName(recommendationApiResponse.Data[0].TargetInfra.Name, nameSeed)
 		}
 	}
 
 	/*
-	 * Test 2: POST /beetle/migration/ns/{nsId}/mci
+	 * Test 2: POST /beetle/migration/ns/{nsId}/infra
 	 */
 	var result2 TestResults
 	if !stopTesting {
 		// Convert RecommendedVmInfra to MigrateInfraRequest
 		migrationRequest := controller.MigrateInfraRequest{
-			RecommendedVmInfra: recommendationApiResponse.Data[0],
+			RecommendedInfra: recommendationApiResponse.Data[0],
 		}
 		result2 = runMigrationTest(client, config, migrationRequest, displayName)
 		if structuredResponse, err := convertMapToMigrateInfraResponse(result2.Response); err == nil {
 			cspReport.MigrationResponse = structuredResponse
 			if structuredResponse.Id != "" {
-				mciId = structuredResponse.Id
+				infraId = structuredResponse.Id
 			} else if structuredResponse.Name != "" {
-				mciId = structuredResponse.Name
+				infraId = structuredResponse.Name
 			}
 		}
 		recordResult(result2)
@@ -455,7 +455,7 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 		}
 	} else {
 		result2 = TestResults{
-			TestName:     "Test 2: POST /beetle/migration/ns/{nsId}/mci",
+			TestName:     "Test 2: POST /beetle/migration/ns/{nsId}/infra",
 			StartTime:    time.Now(),
 			EndTime:      time.Now(),
 			Duration:     0,
@@ -465,17 +465,17 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 			Response:     map[string]interface{}{},
 			Error:        "Test skipped due to previous test failure",
 			ErrorMessage: "Test skipped due to previous test failure",
-			RequestURL:   fmt.Sprintf("%s/beetle/migration/ns/%s/mci", config.Beetle.Endpoint, config.Beetle.NamespaceID),
+			RequestURL:   fmt.Sprintf("%s/beetle/migration/ns/%s/infra", config.Beetle.Endpoint, config.Beetle.NamespaceID),
 		}
 		recordResult(result2)
 	}
 
 	/*
-	 * Test 3: GET /beetle/migration/ns/{nsId}/mci
+	 * Test 3: GET /beetle/migration/ns/{nsId}/infra
 	 */
 	var result3 TestResults
 	if !stopTesting {
-		result3 = runListMciTest(client, config, displayName)
+		result3 = runListInfraTest(client, config, displayName)
 		if result3.Success {
 			if structuredResponse, err := convertMapToInfraInfoList(result3.Response); err == nil {
 				cspReport.ListMCIResponse = structuredResponse
@@ -489,7 +489,7 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 		}
 	} else {
 		result3 = TestResults{
-			TestName:     "Test 3: GET /beetle/migration/ns/{nsId}/mci",
+			TestName:     "Test 3: GET /beetle/migration/ns/{nsId}/infra",
 			StartTime:    time.Now(),
 			EndTime:      time.Now(),
 			Duration:     0,
@@ -499,26 +499,26 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 			Response:     map[string]interface{}{},
 			Error:        "Test skipped due to previous test failure",
 			ErrorMessage: "Test skipped due to previous test failure",
-			RequestURL:   fmt.Sprintf("%s/beetle/migration/ns/%s/mci", config.Beetle.Endpoint, config.Beetle.NamespaceID),
+			RequestURL:   fmt.Sprintf("%s/beetle/migration/ns/%s/infra", config.Beetle.Endpoint, config.Beetle.NamespaceID),
 		}
 		recordResult(result3)
 	}
 
 	/*
-	 * Test 4: GET /beetle/migration/ns/{nsId}/mci?option=id
+	 * Test 4: GET /beetle/migration/ns/{nsId}/infra?option=id
 	 */
 	var result4 TestResults
 	if !stopTesting {
-		result4 = runListMciIdsTest(client, config, displayName)
+		result4 = runListInfraIdsTest(client, config, displayName)
 		if result4.Success {
 			if structuredResponse, err := convertMapToIdList(result4.Response); err == nil {
 				cspReport.ListMCIIDsResponse = structuredResponse
-				if mciId == "" && len(structuredResponse.IdList) > 0 {
+				if infraId == "" && len(structuredResponse.IdList) > 0 {
 					// Scoped identification: only pick an ID that contains the current nameSeed
 					// to prevent picking up another parallel test's MCI
 					for _, id := range structuredResponse.IdList {
 						if strings.Contains(id, nameSeed) {
-							mciId = id
+							infraId = id
 							break
 						}
 					}
@@ -531,7 +531,7 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 		}
 	} else {
 		result4 = TestResults{
-			TestName:     "Test 4: GET /beetle/migration/ns/{nsId}/mci?option=id",
+			TestName:     "Test 4: GET /beetle/migration/ns/{nsId}/infra?option=id",
 			StartTime:    time.Now(),
 			EndTime:      time.Now(),
 			Duration:     0,
@@ -541,16 +541,16 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 			Response:     map[string]interface{}{},
 			Error:        "Test skipped due to previous test failure",
 			ErrorMessage: "Test skipped due to previous test failure",
-			RequestURL:   fmt.Sprintf("%s/beetle/migration/ns/%s/mci?option=id", config.Beetle.Endpoint, config.Beetle.NamespaceID),
+			RequestURL:   fmt.Sprintf("%s/beetle/migration/ns/%s/infra?option=id", config.Beetle.Endpoint, config.Beetle.NamespaceID),
 		}
 		recordResult(result4)
 	}
 
 	/*
-	 * Test 5: GET /beetle/migration/ns/{nsId}/mci/{mciId}
+	 * Test 5: GET /beetle/migration/ns/{nsId}/infra/{infraId}
 	 */
-	if !stopTesting && mciId != "" {
-		result5, _ := runGetMciTest(client, config, mciId, displayName)
+	if !stopTesting && infraId != "" {
+		result5, _ := runGetInfraTest(client, config, infraId, displayName)
 		if structuredResponse, err := convertMapToVmInfraInfo(result5.Response); err == nil {
 			cspReport.GetMCIResponse = structuredResponse
 		}
@@ -566,7 +566,7 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 	 * Test 6: Remote Command Accessibility Check
 	 */
 	if !stopTesting {
-		result6 := runRemoteCommandTest(client, config, mciId, displayName)
+		result6 := runRemoteCommandTest(client, config, infraId, displayName)
 		recordResult(result6)
 		if !result6.Success {
 			stopTesting = true
@@ -578,8 +578,8 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 	/*
 	 * Test 7: Target Infrastructure Summary
 	 */
-	if mciId != "" {
-		resultTargetSummary := runTargetSummaryTest(client, config, mciId, cspPair.Csp, displayName)
+	if infraId != "" {
+		resultTargetSummary := runTargetSummaryTest(client, config, infraId, cspPair.Csp, displayName)
 		recordResult(resultTargetSummary)
 	} else {
 		recordResult(TestResults{
@@ -599,8 +599,8 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 	/*
 	 * Test 8: Migration Report
 	 */
-	if mciId != "" {
-		resultMigrationReport := runMigrationReportTest(client, config, onpremInfraModel, mciId, cspPair.Csp, displayName)
+	if infraId != "" {
+		resultMigrationReport := runMigrationReportTest(client, config, onpremInfraModel, infraId, cspPair.Csp, displayName)
 		recordResult(resultMigrationReport)
 	} else {
 		recordResult(TestResults{
@@ -618,11 +618,11 @@ func runTestCase(i int, cspPair TestCase, config TestConfig, onpremInfraModel on
 	}
 
 	/*
-	 * Test 9: DELETE /beetle/migration/ns/{nsId}/mci/{mciId} (CLEANUP)
+	 * Test 9: DELETE /beetle/migration/ns/{nsId}/infra/{infraId} (CLEANUP)
 	 * Ensure resource cleanup (Test 9) runs even on failure of Tests 1-8
 	 */
-	if mciId != "" {
-		result9, _ := runDeleteMciTest(client, config, mciId, displayName)
+	if infraId != "" {
+		result9, _ := runDeleteInfraTest(client, config, infraId, displayName)
 		if result9.Success {
 			cspReport.DeleteMCIResponse = result9.Response
 		}
@@ -730,16 +730,16 @@ func checkBeetleReadiness(client *resty.Client, beetleURL string) error {
 }
 
 // convertMapToRecommendVmInfraResponse converts interface{} to RecommendVmInfraResponse
-func convertMapToRecommendVmInfraResponse(responseMap interface{}) (*controller.RecommendVmInfraResponse, error) {
+func convertMapToRecommendVmInfraResponse(responseMap interface{}) (*controller.RecommendInfraResponse, error) {
 	jsonBytes, err := json.Marshal(responseMap)
 	if err != nil {
 		return nil, err
 	}
 
-	var apiResp model.ApiResponse[controller.RecommendVmInfraResponse]
+	var apiResp model.ApiResponse[controller.RecommendInfraResponse]
 	if err := json.Unmarshal(jsonBytes, &apiResp); err != nil {
 		// Fallback for direct unmarshal if not wrapped
-		var response controller.RecommendVmInfraResponse
+		var response controller.RecommendInfraResponse
 		if err := json.Unmarshal(jsonBytes, &response); err != nil {
 			return nil, err
 		}
@@ -829,15 +829,15 @@ func convertMapToVmInfraInfo(responseMap interface{}) (*cloudmodel.VmInfraInfo, 
 	return &apiResp.Data, nil
 }
 
-// runRecommendationTest performs Test 1: POST /beetle/recommendation/vmInfra
-func runRecommendationTest(client *resty.Client, config TestConfig, cspPair cloudmodel.CloudProperty, recommendRequest controller.RecommendVmInfraRequest, displayName string) (model.ApiResponse[[]cloudmodel.RecommendedVmInfra], TestResults) {
-	log.Info().Msg("\n--- Test 1: POST /beetle/recommendation/vmInfra ---")
+// runRecommendationTest performs Test 1: POST /beetle/recommendation/infra
+func runRecommendationTest(client *resty.Client, config TestConfig, cspPair cloudmodel.CloudProperty, recommendRequest controller.RecommendInfraRequest, displayName string) (model.ApiResponse[[]cloudmodel.RecommendedInfra], TestResults) {
+	log.Info().Msg("\n--- Test 1: POST /beetle/recommendation/infra ---")
 
 	// Wait before API call for stability with animation
 	animatedSleep(5*time.Second, "Waiting for a while for the previous task to be completed safely")
 
 	result := TestResults{
-		TestName:  fmt.Sprintf("POST /beetle/recommendation/vmInfra (%s)", displayName),
+		TestName:  fmt.Sprintf("POST /beetle/recommendation/infra (%s)", displayName),
 		StartTime: time.Now(),
 	}
 
@@ -845,14 +845,14 @@ func runRecommendationTest(client *resty.Client, config TestConfig, cspPair clou
 	limit := 2
 
 	// Log API call details
-	url := fmt.Sprintf("%s/beetle/recommendation/vmInfra?desiredCsp=%s&desiredRegion=%s&limit=%d", config.Beetle.Endpoint, cspPair.Csp, cspPair.Region, limit)
+	url := fmt.Sprintf("%s/beetle/recommendation/infra?desiredCsp=%s&desiredRegion=%s&limit=%d", config.Beetle.Endpoint, cspPair.Csp, cspPair.Region, limit)
 	log.Debug().Msgf("API Request URL: %s", url)
 
 	// Log request body
 	log.Debug().Msgf("API Request Body: %+v", recommendRequest)
 
 	// The new API returns multiple candidates using generic ApiResponse
-	var apiResponse model.ApiResponse[[]cloudmodel.RecommendedVmInfra]
+	var apiResponse model.ApiResponse[[]cloudmodel.RecommendedInfra]
 	err := common.ExecuteHttpRequest(
 		client,
 		"POST",
@@ -874,7 +874,7 @@ func runRecommendationTest(client *resty.Client, config TestConfig, cspPair clou
 		populateErrorInfo(&result, err, 0, url, recommendRequest)
 		fmt.Printf("❌ Test 1 failed: %s\n", result.ErrorMessage)
 		log.Error().Err(err).Str("url", url).Msg("Recommendation test failed")
-		return model.ApiResponse[[]cloudmodel.RecommendedVmInfra]{}, result
+		return model.ApiResponse[[]cloudmodel.RecommendedInfra]{}, result
 	}
 
 	// Check if we have at least one candidate
@@ -886,7 +886,7 @@ func runRecommendationTest(client *resty.Client, config TestConfig, cspPair clou
 		populateErrorInfo(&result, fmt.Errorf("%s", errMsg), 0, url, recommendRequest)
 		fmt.Printf("❌ Test 1 failed: %s\n", result.ErrorMessage)
 		log.Error().Str("url", url).Msg("No recommendation candidates found")
-		return model.ApiResponse[[]cloudmodel.RecommendedVmInfra]{}, result
+		return model.ApiResponse[[]cloudmodel.RecommendedInfra]{}, result
 	}
 
 	// Log number of candidates received
@@ -906,22 +906,22 @@ func runRecommendationTest(client *resty.Client, config TestConfig, cspPair clou
 	return apiResponse, result
 }
 
-// runMigrationTest performs Test 2: POST /beetle/migration/ns/{nsId}/mci
+// runMigrationTest performs Test 2: POST /beetle/migration/ns/{nsId}/infra
 func runMigrationTest(client *resty.Client, config TestConfig, migrationRequestBody controller.MigrateInfraRequest, displayName string) TestResults {
-	fmt.Printf("\n--- Test 2: POST /beetle/migration/ns/%s/mci ---\n", config.Beetle.NamespaceID)
+	fmt.Printf("\n--- Test 2: POST /beetle/migration/ns/%s/infra ---\n", config.Beetle.NamespaceID)
 
 	// Wait before API call for stability (migration needs more time) with spinner
 	animatedSleep(5*time.Second, "Waiting for a while for the previous task to be completed safely")
 
 	result := TestResults{
-		TestName:  fmt.Sprintf("POST /beetle/migration/ns/{nsId}/mci (%s)", displayName),
+		TestName:  fmt.Sprintf("POST /beetle/migration/ns/{nsId}/infra (%s)", displayName),
 		StartTime: time.Now(),
 	}
 
 	var apiResponse model.ApiResponse[controller.MigrateInfraResponse]
 
 	// Log API call details
-	url := fmt.Sprintf("%s/beetle/migration/ns/%s/mci", config.Beetle.Endpoint, config.Beetle.NamespaceID)
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/infra", config.Beetle.Endpoint, config.Beetle.NamespaceID)
 	log.Debug().Msgf("API Request URL: %s", url)
 
 	// Log request body
@@ -970,20 +970,20 @@ func runMigrationTest(client *resty.Client, config TestConfig, migrationRequestB
 	return result
 }
 
-// runListMciTest performs Test 3: GET /beetle/migration/ns/{nsId}/mci
-func runListMciTest(client *resty.Client, config TestConfig, displayName string) TestResults {
-	fmt.Printf("\n--- Test 3: GET /beetle/migration/ns/%s/mci ---\n", config.Beetle.NamespaceID)
+// runListInfraTest performs Test 3: GET /beetle/migration/ns/{nsId}/infra
+func runListInfraTest(client *resty.Client, config TestConfig, displayName string) TestResults {
+	fmt.Printf("\n--- Test 3: GET /beetle/migration/ns/%s/infra ---\n", config.Beetle.NamespaceID)
 
 	// Wait before API call for stability with animation
 	animatedSleep(5*time.Second, "Waiting for a while for the previous task to be completed safely")
 
 	result := TestResults{
-		TestName:  fmt.Sprintf("GET /beetle/migration/ns/{nsId}/mci (%s)", displayName),
+		TestName:  fmt.Sprintf("GET /beetle/migration/ns/{nsId}/infra (%s)", displayName),
 		StartTime: time.Now(),
 	}
 
 	// Log API call details
-	url := fmt.Sprintf("%s/beetle/migration/ns/%s/mci", config.Beetle.Endpoint, config.Beetle.NamespaceID)
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/infra", config.Beetle.Endpoint, config.Beetle.NamespaceID)
 	log.Debug().Msgf("API Request URL: %s", url)
 	log.Debug().Msg("API Request Body: none")
 
@@ -1026,20 +1026,20 @@ func runListMciTest(client *resty.Client, config TestConfig, displayName string)
 	return result
 }
 
-// runListMciIdsTest performs Test 4: GET /beetle/migration/ns/{nsId}/mci?option=id
-func runListMciIdsTest(client *resty.Client, config TestConfig, displayName string) TestResults {
-	fmt.Printf("\n--- Test 4: GET /beetle/migration/ns/%s/mci?option=id ---\n", config.Beetle.NamespaceID)
+// runListInfraIdsTest performs Test 4: GET /beetle/migration/ns/{nsId}/infra?option=id
+func runListInfraIdsTest(client *resty.Client, config TestConfig, displayName string) TestResults {
+	fmt.Printf("\n--- Test 4: GET /beetle/migration/ns/%s/infra?option=id ---\n", config.Beetle.NamespaceID)
 
 	// Wait before API call for stability with animation
 	animatedSleep(5*time.Second, "Waiting for a while for the previous task to be completed safely")
 
 	result := TestResults{
-		TestName:  fmt.Sprintf("GET /beetle/migration/ns/{nsId}/mci?option=id (%s)", displayName),
+		TestName:  fmt.Sprintf("GET /beetle/migration/ns/{nsId}/infra?option=id (%s)", displayName),
 		StartTime: time.Now(),
 	}
 
 	// Log API call details
-	url := fmt.Sprintf("%s/beetle/migration/ns/%s/mci?option=id", config.Beetle.Endpoint, config.Beetle.NamespaceID)
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/infra?option=id", config.Beetle.Endpoint, config.Beetle.NamespaceID)
 	log.Debug().Msgf("API Request URL: %s", url)
 	log.Debug().Msg("API Request Body: none")
 
@@ -1055,10 +1055,10 @@ func runListMciIdsTest(client *resty.Client, config TestConfig, displayName stri
 		&apiResponse,
 		0,
 	)
-	mciIdList := apiResponse.Data
+	infraIdList := apiResponse.Data
 
 	// Log response body
-	log.Debug().Msgf("API Response Body: %+v", mciIdList)
+	log.Debug().Msgf("API Response Body: %+v", infraIdList)
 
 	result.EndTime = time.Now()
 	result.Duration = result.EndTime.Sub(result.StartTime)
@@ -1082,30 +1082,30 @@ func runListMciIdsTest(client *resty.Client, config TestConfig, displayName stri
 	return result
 }
 
-// runGetMciTest performs Test 5: GET /beetle/migration/ns/{nsId}/mci/{mciId}
-func runGetMciTest(client *resty.Client, config TestConfig, mciId, displayName string) (TestResults, bool) {
-	if mciId == "" {
-		fmt.Println("⚠️  Test 5 skipped: No MCI ID available")
+// runGetInfraTest performs Test 5: GET /beetle/migration/ns/{nsId}/infra/{infraId}
+func runGetInfraTest(client *resty.Client, config TestConfig, infraId, displayName string) (TestResults, bool) {
+	if infraId == "" {
+		fmt.Println("⚠️  Test 5 skipped: No Infra ID available")
 		return TestResults{
-			TestName: fmt.Sprintf("GET /beetle/migration/ns/{nsId}/mci/{mciId} (%s)", displayName),
+			TestName: fmt.Sprintf("GET /beetle/migration/ns/{nsId}/infra/{infraId} (%s)", displayName),
 			Success:  false,
 			Skipped:  true,
-			Error:    "MCI ID not available from previous tests",
+			Error:    "Infra ID not available from previous tests",
 		}, false
 	}
 
-	fmt.Printf("\n--- Test 5: GET /beetle/migration/ns/%s/mci/%s ---\n", config.Beetle.NamespaceID, mciId)
+	fmt.Printf("\n--- Test 5: GET /beetle/migration/ns/%s/infra/%s ---\n", config.Beetle.NamespaceID, infraId)
 
 	// Wait before API call for stability with animation
 	animatedSleep(5*time.Second, "Waiting for a while for the previous task to be completed safely")
 
 	result := TestResults{
-		TestName:  fmt.Sprintf("GET /beetle/migration/ns/{nsId}/mci/{mciId} (%s)", displayName),
+		TestName:  fmt.Sprintf("GET /beetle/migration/ns/{nsId}/infra/{infraId} (%s)", displayName),
 		StartTime: time.Now(),
 	}
 
 	// Log API call details
-	url := fmt.Sprintf("%s/beetle/migration/ns/%s/mci/%s", config.Beetle.Endpoint, config.Beetle.NamespaceID, mciId)
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/infra/%s", config.Beetle.Endpoint, config.Beetle.NamespaceID, infraId)
 	log.Debug().Msgf("API Request URL: %s", url)
 	log.Debug().Msg("API Request Body: none")
 
@@ -1148,14 +1148,14 @@ func runGetMciTest(client *resty.Client, config TestConfig, mciId, displayName s
 	return result, true
 }
 
-// cleanupMci performs cleanup by deleting MCI when migration fails
-func cleanupMci(client *resty.Client, config TestConfig, mciId, displayName string) {
-	if mciId == "" {
-		log.Warn().Msg("Cleanup skipped: No MCI ID available")
+// cleanupInfra performs cleanup by deleting infra when migration fails
+func cleanupInfra(client *resty.Client, config TestConfig, infraId, displayName string) {
+	if infraId == "" {
+		log.Warn().Msg("Cleanup skipped: No Infra ID available")
 		return
 	}
 
-	log.Info().Str("mciId", mciId).Str("csp", displayName).Msg("Starting cleanup: Deleting failed MCI")
+	log.Info().Str("infraId", infraId).Str("csp", displayName).Msg("Starting cleanup: Deleting failed infra")
 
 	// Retry logic for internal cleanup
 	const maxCleanupRetries = 2
@@ -1163,12 +1163,12 @@ func cleanupMci(client *resty.Client, config TestConfig, mciId, displayName stri
 
 	for attempt := 1; attempt <= maxCleanupRetries; attempt++ {
 		if attempt > 1 {
-			log.Info().Str("mciId", mciId).Int("attempt", attempt).Msg("🔄 Retrying internal cleanup...")
+			log.Info().Str("infraId", infraId).Int("attempt", attempt).Msg("🔄 Retrying internal cleanup...")
 			time.Sleep(cleanupRetryDelay)
 		}
 
 		// Log API call details
-		url := fmt.Sprintf("%s/beetle/migration/ns/%s/mci/%s?option=terminate", config.Beetle.Endpoint, config.Beetle.NamespaceID, mciId)
+		url := fmt.Sprintf("%s/beetle/migration/ns/%s/infra/%s?option=terminate", config.Beetle.Endpoint, config.Beetle.NamespaceID, infraId)
 		log.Debug().Msgf("Cleanup API Request URL: %s", url)
 
 		var response map[string]interface{}
@@ -1182,13 +1182,13 @@ func cleanupMci(client *resty.Client, config TestConfig, mciId, displayName stri
 		log.Debug().Msgf("Cleanup Response Body: %+v", response)
 
 		if err == nil && resp.StatusCode() < 400 {
-			log.Info().Str("mciId", mciId).Str("csp", displayName).Msg("Cleanup completed: MCI successfully deleted")
+			log.Info().Str("infraId", infraId).Str("csp", displayName).Msg("Cleanup completed: Infra successfully deleted")
 			return
 		}
 
 		// If resource is already gone (404), consider cleanup successful
 		if resp != nil && resp.StatusCode() == http.StatusNotFound {
-			log.Info().Str("mciId", mciId).Str("csp", displayName).Msg("Cleanup skipped: MCI already deleted (404)")
+			log.Info().Str("infraId", infraId).Str("csp", displayName).Msg("Cleanup skipped: Infra already deleted (404)")
 			return
 		}
 
@@ -1196,36 +1196,36 @@ func cleanupMci(client *resty.Client, config TestConfig, mciId, displayName stri
 		if resp != nil {
 			statusCode = resp.StatusCode()
 		}
-		log.Warn().Err(err).Str("mciId", mciId).Int("statusCode", statusCode).Int("attempt", attempt).Msg("Cleanup attempt failed")
+		log.Warn().Err(err).Str("infraId", infraId).Int("statusCode", statusCode).Int("attempt", attempt).Msg("Cleanup attempt failed")
 	}
 
-	log.Error().Str("mciId", mciId).Msg("❌ Final cleanup attempt failed")
+	log.Error().Str("infraId", infraId).Msg("❌ Final cleanup attempt failed")
 }
 
-// runDeleteMciTest performs Test 7: DELETE /beetle/migration/ns/{nsId}/mci/{mciId}
-func runDeleteMciTest(client *resty.Client, config TestConfig, mciId, displayName string) (TestResults, bool) {
-	if mciId == "" {
-		fmt.Println("⚠️  Test 7 skipped: No MCI ID available")
+// runDeleteInfraTest performs Test 7: DELETE /beetle/migration/ns/{nsId}/infra/{infraId}
+func runDeleteInfraTest(client *resty.Client, config TestConfig, infraId, displayName string) (TestResults, bool) {
+	if infraId == "" {
+		fmt.Println("⚠️  Test 7 skipped: No Infra ID available")
 		return TestResults{
-			TestName: fmt.Sprintf("DELETE /beetle/migration/ns/{nsId}/mci/{mciId} (%s)", displayName),
+			TestName: fmt.Sprintf("DELETE /beetle/migration/ns/{nsId}/infra/{infraId} (%s)", displayName),
 			Success:  false,
 			Skipped:  true,
-			Error:    "MCI ID not available from previous tests",
+			Error:    "Infra ID not available from previous tests",
 		}, false
 	}
 
-	fmt.Printf("\n--- Test 7: DELETE /beetle/migration/ns/%s/mci/%s?option=terminate ---\n", config.Beetle.NamespaceID, mciId)
+	fmt.Printf("\n--- Test 7: DELETE /beetle/migration/ns/%s/infra/%s?option=terminate ---\n", config.Beetle.NamespaceID, infraId)
 
 	// Wait before API call for stability with animation
 	animatedSleep(30*time.Second, "Waiting for a while for the previous task to be completed safely")
 
 	result := TestResults{
-		TestName:  fmt.Sprintf("DELETE /beetle/migration/ns/{nsId}/mci/{mciId} (%s)", displayName),
+		TestName:  fmt.Sprintf("DELETE /beetle/migration/ns/{nsId}/infra/{infraId} (%s)", displayName),
 		StartTime: time.Now(),
 	}
 
 	// Log API call details
-	url := fmt.Sprintf("%s/beetle/migration/ns/%s/mci/%s?option=terminate", config.Beetle.Endpoint, config.Beetle.NamespaceID, mciId)
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/infra/%s?option=terminate", config.Beetle.Endpoint, config.Beetle.NamespaceID, infraId)
 	log.Debug().Msgf("API Request URL: %s", url)
 	log.Debug().Msg("API Request Body: none")
 
@@ -1239,7 +1239,7 @@ func runDeleteMciTest(client *resty.Client, config TestConfig, mciId, displayNam
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		if attempt > 1 {
-			log.Info().Str("mciId", mciId).Int("attempt", attempt).Int("maxRetries", maxRetries).Msg("🔄 Retrying MCI deletion...")
+			log.Info().Str("infraId", infraId).Int("attempt", attempt).Msg("🔄 Retrying infra deletion...")
 			animatedSleep(retryDelay, fmt.Sprintf("Waiting before retry attempt %d/%d", attempt, maxRetries))
 		}
 
@@ -1265,10 +1265,10 @@ func runDeleteMciTest(client *resty.Client, config TestConfig, mciId, displayNam
 			result.Response = response
 
 			if attempt > 1 {
-				log.Info().Str("mciId", mciId).Int("attempt", attempt).Msg("✅ MCI deletion succeeded after retry")
+				log.Info().Str("infraId", infraId).Int("attempt", attempt).Msg("✅ Infra deletion succeeded after retry")
 				fmt.Printf("✅ Test 7 passed (after %d attempt(s))\n", attempt)
 			} else {
-				log.Info().Str("mciId", mciId).Msg("✅ MCI deletion succeeded")
+				log.Info().Str("infraId", infraId).Msg("✅ Infra deletion succeeded")
 				fmt.Println("✅ Test 7 passed")
 			}
 			return result, true
@@ -1281,7 +1281,7 @@ func runDeleteMciTest(client *resty.Client, config TestConfig, mciId, displayNam
 
 		// If resource is already gone (404), no need to retry
 		if statusCode == http.StatusNotFound {
-			log.Info().Str("mciId", mciId).Msg("✅ MCI deletion skipped: Resource already deleted (404)")
+			log.Info().Str("infraId", infraId).Msg("✅ Infra deletion skipped: Resource already deleted (404)")
 			fmt.Println("✅ Test 7 passed (Resource already gone)")
 
 			result.EndTime = time.Now()
@@ -1293,9 +1293,9 @@ func runDeleteMciTest(client *resty.Client, config TestConfig, mciId, displayNam
 		}
 
 		if attempt < maxRetries {
-			log.Warn().Err(err).Str("mciId", mciId).Int("statusCode", statusCode).Int("attempt", attempt).Int("maxRetries", maxRetries).Msg("⚠️ MCI deletion attempt failed, will retry")
+			log.Warn().Err(err).Str("infraId", infraId).Int("statusCode", statusCode).Int("attempt", attempt).Int("maxRetries", maxRetries).Msg("⚠️ Infra deletion attempt failed, will retry")
 		} else {
-			log.Error().Err(err).Str("mciId", mciId).Int("statusCode", statusCode).Int("maxRetries", maxRetries).Msg("❌ MCI deletion failed after all retries")
+			log.Error().Err(err).Str("infraId", infraId).Int("statusCode", statusCode).Int("maxRetries", maxRetries).Msg("❌ Infra deletion failed after all retries")
 		}
 	}
 
@@ -1627,23 +1627,23 @@ func generateMarkdownContent(report *CSPTestReport) string {
 		var endpoint string
 		switch i {
 		case 0:
-			endpoint = "`POST /beetle/recommendation/vmInfra`"
+			endpoint = "`POST /beetle/recommendation/infra`"
 		case 1:
-			endpoint = fmt.Sprintf("`POST /beetle/migration/ns/%s/mci`", report.NamespaceID)
+			endpoint = fmt.Sprintf("`POST /beetle/migration/ns/%s/infra`", report.NamespaceID)
 		case 2:
-			endpoint = fmt.Sprintf("`GET /beetle/migration/ns/%s/mci`", report.NamespaceID)
+			endpoint = fmt.Sprintf("`GET /beetle/migration/ns/%s/infra`", report.NamespaceID)
 		case 3:
-			endpoint = fmt.Sprintf("`GET /beetle/migration/ns/%s/mci?option=id`", report.NamespaceID)
+			endpoint = fmt.Sprintf("`GET /beetle/migration/ns/%s/infra?option=id`", report.NamespaceID)
 		case 4:
-			endpoint = fmt.Sprintf("`GET /beetle/migration/ns/%s/mci/{{mciId}}`", report.NamespaceID)
+			endpoint = fmt.Sprintf("`GET /beetle/migration/ns/%s/infra/{{infraId}}`", report.NamespaceID)
 		case 5:
 			endpoint = "Remote Command Accessibility Check"
 		case 6:
-			endpoint = fmt.Sprintf("`GET /beetle/summary/target/ns/%s/mci/{{mciId}}`", report.NamespaceID)
+			endpoint = fmt.Sprintf("`GET /beetle/summary/target/ns/%s/infra/{{infraId}}`", report.NamespaceID)
 		case 7:
-			endpoint = fmt.Sprintf("`POST /beetle/report/migration/ns/%s/mci/{{mciId}}`", report.NamespaceID)
+			endpoint = fmt.Sprintf("`POST /beetle/report/migration/ns/%s/infra/{{infraId}}`", report.NamespaceID)
 		case 8:
-			endpoint = fmt.Sprintf("`DELETE /beetle/migration/ns/%s/mci/{{mciId}}`", report.NamespaceID)
+			endpoint = fmt.Sprintf("`DELETE /beetle/migration/ns/%s/infra/{{infraId}}`", report.NamespaceID)
 		default:
 			endpoint = ""
 		}
@@ -1706,7 +1706,7 @@ func generateMarkdownContent(report *CSPTestReport) string {
 
 	// API request information
 	sb.WriteString("#### 1.1 API Request Information\n\n")
-	sb.WriteString("- **API Endpoint**: `POST /beetle/recommendation/vmInfra`\n")
+	sb.WriteString("- **API Endpoint**: `POST /beetle/recommendation/infra`\n")
 	sb.WriteString("- **Purpose**: Get infrastructure recommendations for migration\n")
 	sb.WriteString("- **Required Parameters**: `desiredCsp` and `desiredRegion` in request body\n\n")
 
@@ -1757,7 +1757,7 @@ func generateMarkdownContent(report *CSPTestReport) string {
 
 	// API request information
 	sb.WriteString("#### 2.1 API Request Information\n\n")
-	sb.WriteString(fmt.Sprintf("- **API Endpoint**: `POST /beetle/migration/ns/%s/mci`\n", report.NamespaceID))
+	sb.WriteString(fmt.Sprintf("- **API Endpoint**: `POST /beetle/migration/ns/%s/infra`\n", report.NamespaceID))
 	sb.WriteString("- **Purpose**: Create and migrate infrastructure based on recommendation\n")
 	sb.WriteString(fmt.Sprintf("- **Namespace ID**: `%s`\n", report.NamespaceID))
 	sb.WriteString("- **Request Body**: Uses the response from the previous recommendation step\n\n")
@@ -1795,13 +1795,13 @@ func generateMarkdownContent(report *CSPTestReport) string {
 		}
 	}
 
-	// Test Case 3: List MCIs
-	sb.WriteString("### Test Case 3: Get a list of MCIs\n\n")
+	// Test Case 3: List Infras
+	sb.WriteString("### Test Case 3: Get a list of infras\n\n")
 
 	// API request information
 	sb.WriteString("#### 3.1 API Request Information\n\n")
-	sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/migration/ns/%s/mci`\n", report.NamespaceID))
-	sb.WriteString("- **Purpose**: Retrieve all Multi-Cloud Infrastructure instances\n")
+	sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/migration/ns/%s/infra`\n", report.NamespaceID))
+	sb.WriteString("- **Purpose**: Retrieve all migrated cloud infrastructure instances\n")
 	sb.WriteString(fmt.Sprintf("- **Namespace ID**: `%s`\n", report.NamespaceID))
 	sb.WriteString("- **Request Body**: None (GET request)\n\n")
 
@@ -1809,7 +1809,7 @@ func generateMarkdownContent(report *CSPTestReport) string {
 	sb.WriteString("#### 3.2 API Response Information\n\n")
 	if report.ListMCIResponse != nil {
 		sb.WriteString("- **Status**: ✅ **SUCCESS**\n")
-		sb.WriteString("- **Response**: MCI list retrieved successfully\n\n")
+		sb.WriteString("- **Response**: Infra list retrieved successfully\n\n")
 		sb.WriteString("**Response Body**:\n\n")
 		sb.WriteString("```json\n")
 		listJSON, _ := json.MarshalIndent(report.ListMCIResponse, "", "  ")
@@ -1820,7 +1820,7 @@ func generateMarkdownContent(report *CSPTestReport) string {
 		sb.WriteString("- **Error**: No response received\n\n")
 		// Add detailed error information if available
 		if len(report.TestResults) > 2 {
-			result := report.TestResults[2] // Third test is list MCIs
+			result := report.TestResults[2] // Third test is list infras
 			if result.ErrorMessage != "" {
 				sb.WriteString("**Error Message**:\n\n```\n")
 				sb.WriteString(result.ErrorMessage)
@@ -1832,13 +1832,13 @@ func generateMarkdownContent(report *CSPTestReport) string {
 		}
 	}
 
-	// Test Case 4: List MCI IDs
-	sb.WriteString("### Test Case 4: Get a list of MCI IDs\n\n")
+	// Test Case 4: List Infra IDs
+	sb.WriteString("### Test Case 4: Get a list of infra IDs\n\n")
 
 	// API request information
 	sb.WriteString("#### 4.1 API Request Information\n\n")
-	sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/migration/ns/%s/mci?option=id`\n", report.NamespaceID))
-	sb.WriteString("- **Purpose**: Retrieve MCI IDs only (lightweight response)\n")
+	sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/migration/ns/%s/infra?option=id`\n", report.NamespaceID))
+	sb.WriteString("- **Purpose**: Retrieve infra IDs only (lightweight response)\n")
 	sb.WriteString(fmt.Sprintf("- **Namespace ID**: `%s`\n", report.NamespaceID))
 	sb.WriteString("- **Query Parameter**: `option=id`\n")
 	sb.WriteString("- **Request Body**: None (GET request)\n\n")
@@ -1847,7 +1847,7 @@ func generateMarkdownContent(report *CSPTestReport) string {
 	sb.WriteString("#### 4.2 API Response Information\n\n")
 	if report.ListMCIIDsResponse != nil {
 		sb.WriteString("- **Status**: ✅ **SUCCESS**\n")
-		sb.WriteString("- **Response**: MCI IDs retrieved successfully\n\n")
+		sb.WriteString("- **Response**: Infra IDs retrieved successfully\n\n")
 		sb.WriteString("**Response Body**:\n\n")
 		sb.WriteString("```json\n")
 		idsJSON, _ := json.MarshalIndent(report.ListMCIIDsResponse, "", "  ")
@@ -1858,7 +1858,7 @@ func generateMarkdownContent(report *CSPTestReport) string {
 		sb.WriteString("- **Error**: No response received\n\n")
 		// Add detailed error information if available
 		if len(report.TestResults) > 3 {
-			result := report.TestResults[3] // Fourth test is list MCI IDs
+			result := report.TestResults[3] // Fourth test is list infra IDs
 			if result.ErrorMessage != "" {
 				sb.WriteString("**Error Message**:\n\n```\n")
 				sb.WriteString(result.ErrorMessage)
@@ -1872,20 +1872,20 @@ func generateMarkdownContent(report *CSPTestReport) string {
 
 	// Test Case 5: Get specific MCI (if available)
 	if report.GetMCIResponse != nil {
-		sb.WriteString("### Test Case 5: Get a specific MCI\n\n")
+		sb.WriteString("### Test Case 5: Get a specific infra\n\n")
 
 		// API request information
 		sb.WriteString("#### 5.1 API Request Information\n\n")
-		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/migration/ns/%s/mci/{{mciId}}`\n", report.NamespaceID))
-		sb.WriteString("- **Purpose**: Retrieve detailed information for a specific MCI\n")
+		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/migration/ns/%s/infra/{{infraId}}`\n", report.NamespaceID))
+		sb.WriteString("- **Purpose**: Retrieve detailed information for a specific infra\n")
 		sb.WriteString(fmt.Sprintf("- **Namespace ID**: `%s`\n", report.NamespaceID))
-		sb.WriteString("- **Path Parameter**: `{{mciId}}` - The specific MCI identifier\n")
+		sb.WriteString("- **Path Parameter**: `{{infraId}}` - The specific infra identifier\n")
 		sb.WriteString("- **Request Body**: None (GET request)\n\n")
 
 		// API response information
 		sb.WriteString("#### 5.2 API Response Information\n\n")
 		sb.WriteString("- **Status**: ✅ **SUCCESS**\n")
-		sb.WriteString("- **Response**: MCI details retrieved successfully\n\n")
+		sb.WriteString("- **Response**: Infra details retrieved successfully\n\n")
 		sb.WriteString("**Response Body**:\n\n")
 		sb.WriteString("<details>\n")
 		sb.WriteString("  <summary> <ins>Click to see the response body </ins> </summary>\n\n")
@@ -2117,10 +2117,10 @@ func generateMarkdownContent(report *CSPTestReport) string {
 
 		// API request information
 		sb.WriteString("#### 7.1 API Request Information\n\n")
-		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/summary/target/ns/%s/mci/{{mciId}}?format=md`\n", report.NamespaceID))
+		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `GET /beetle/summary/target/ns/%s/infra/{{infraId}}?format=md`\n", report.NamespaceID))
 		sb.WriteString("- **Purpose**: Get a summary of the migrated target infrastructure in Markdown format\n")
 		sb.WriteString(fmt.Sprintf("- **Namespace ID**: `%s`\n", report.NamespaceID))
-		sb.WriteString("- **Path Parameter**: `{{mciId}}` - The MCI identifier\n")
+		sb.WriteString("- **Path Parameter**: `{{infraId}}` - The infra identifier\n")
 		sb.WriteString("- **Query Parameter**: `format=md`\n\n")
 
 		// API response information
@@ -2152,10 +2152,10 @@ func generateMarkdownContent(report *CSPTestReport) string {
 
 		// API request information
 		sb.WriteString("#### 8.1 API Request Information\n\n")
-		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `POST /beetle/report/migration/ns/%s/mci/{{mciId}}`\n", report.NamespaceID))
+		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `POST /beetle/report/migration/ns/%s/infra/{{infraId}}`\n", report.NamespaceID))
 		sb.WriteString("- **Purpose**: Generate a comprehensive migration report matching source to target\n")
 		sb.WriteString(fmt.Sprintf("- **Namespace ID**: `%s`\n", report.NamespaceID))
-		sb.WriteString("- **Path Parameter**: `{{mciId}}` - The MCI identifier\n\n")
+		sb.WriteString("- **Path Parameter**: `{{infraId}}` - The infra identifier\n\n")
 
 		// API response information
 		sb.WriteString("#### 8.2 API Response Information\n\n")
@@ -2186,10 +2186,10 @@ func generateMarkdownContent(report *CSPTestReport) string {
 
 		// API request information
 		sb.WriteString("#### 9.1 API Request Information\n\n")
-		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `DELETE /beetle/migration/ns/%s/mci/{{mciId}}`\n", report.NamespaceID))
+		sb.WriteString(fmt.Sprintf("- **API Endpoint**: `DELETE /beetle/migration/ns/%s/infra/{{infraId}}`\n", report.NamespaceID))
 		sb.WriteString("- **Purpose**: Delete the migrated infrastructure and clean up resources\n")
 		sb.WriteString(fmt.Sprintf("- **Namespace ID**: `%s`\n", report.NamespaceID))
-		sb.WriteString("- **Path Parameter**: `{{mciId}}` - The MCI identifier to delete\n")
+		sb.WriteString("- **Path Parameter**: `{{infraId}}` - The infra identifier to delete\n")
 		sb.WriteString("- **Query Parameter**: `option=terminate` (terminates all resources)\n")
 		sb.WriteString("- **Request Body**: None (DELETE request)\n\n")
 
@@ -2350,10 +2350,10 @@ func runSourceSummaryTest(client *resty.Client, config TestConfig, onpremInfraMo
 	return result
 }
 
-// runTargetSummaryTest performs Target Summary: GET /beetle/summary/target/ns/{nsId}/mci/{mciId}
-func runTargetSummaryTest(client *resty.Client, config TestConfig, mciId, cspName, displayName string) TestResults {
+// runTargetSummaryTest performs Target Summary: GET /beetle/summary/target/ns/{nsId}/infra/{infraId}
+func runTargetSummaryTest(client *resty.Client, config TestConfig, infraId, cspName, displayName string) TestResults {
 	result := TestResults{
-		TestName:  "Target Summary: GET /beetle/summary/target/ns/{nsId}/mci/{mciId}",
+		TestName:  "Target Summary: GET /beetle/summary/target/ns/{nsId}/infra/{infraId}",
 		StartTime: time.Now(),
 	}
 
@@ -2364,8 +2364,8 @@ func runTargetSummaryTest(client *resty.Client, config TestConfig, mciId, cspNam
 	log.Info().Msgf("\n--- Target Infrastructure Summary for %s ---", displayName)
 
 	// Make API call with markdown format
-	url := fmt.Sprintf("%s/beetle/summary/target/ns/%s/mci/%s?format=md",
-		config.Beetle.Endpoint, config.Beetle.NamespaceID, mciId)
+	url := fmt.Sprintf("%s/beetle/summary/target/ns/%s/infra/%s?format=md",
+		config.Beetle.Endpoint, config.Beetle.NamespaceID, infraId)
 	result.RequestURL = url
 
 	resp, err := client.R().
@@ -2442,10 +2442,10 @@ func runTargetSummaryTest(client *resty.Client, config TestConfig, mciId, cspNam
 	return result
 }
 
-// runMigrationReportTest performs Migration Report: POST /beetle/report/migration/ns/{nsId}/mci/{mciId}
-func runMigrationReportTest(client *resty.Client, config TestConfig, onpremInfraModel onpremmodel.OnpremInfra, mciId, cspName, displayName string) TestResults {
+// runMigrationReportTest performs Migration Report: POST /beetle/report/migration/ns/{nsId}/infra/{infraId}
+func runMigrationReportTest(client *resty.Client, config TestConfig, onpremInfraModel onpremmodel.OnpremInfra, infraId, cspName, displayName string) TestResults {
 	result := TestResults{
-		TestName:  "Migration Report: POST /beetle/report/migration/ns/{nsId}/mci/{mciId}",
+		TestName:  "Migration Report: POST /beetle/report/migration/ns/{nsId}/infra/{infraId}",
 		StartTime: time.Now(),
 	}
 
@@ -2461,8 +2461,8 @@ func runMigrationReportTest(client *resty.Client, config TestConfig, onpremInfra
 	}
 
 	// Make API call
-	url := fmt.Sprintf("%s/beetle/report/migration/ns/%s/mci/%s",
-		config.Beetle.Endpoint, config.Beetle.NamespaceID, mciId)
+	url := fmt.Sprintf("%s/beetle/report/migration/ns/%s/infra/%s",
+		config.Beetle.Endpoint, config.Beetle.NamespaceID, infraId)
 	result.RequestURL = url
 
 	resp, err := client.R().
@@ -2541,7 +2541,7 @@ func runMigrationReportTest(client *resty.Client, config TestConfig, onpremInfra
 }
 
 // runRemoteCommandTest performs Test 6: Remote Command to check accessibility of migrated VM
-func runRemoteCommandTest(client *resty.Client, config TestConfig, mciId, displayName string) TestResults {
+func runRemoteCommandTest(client *resty.Client, config TestConfig, infraId, displayName string) TestResults {
 	log.Info().Msg("\n--- Test 6: Remote Command Accessibility Check ---")
 
 	// Wait before test for stability with animation
@@ -2563,7 +2563,7 @@ func runRemoteCommandTest(client *resty.Client, config TestConfig, mciId, displa
 
 	tbCli := tbclient.NewDefaultClient()
 	// tbSess := tbCli.NewSession() // or tbclient.NewSession()
-	accessInfo, err := tbCli.NewSession().ReadInfraAccessInfo(config.Beetle.NamespaceID, mciId, "accessinfo", "showSshKey")
+	accessInfo, err := tbCli.NewSession().ReadInfraAccessInfo(config.Beetle.NamespaceID, infraId, "accessinfo", "showSshKey")
 	if err != nil {
 		populateErrorInfo(&result, err, 0, "ReadMciAccessInfo", nil)
 		log.Error().Err(err).Msg("Failed to get MCI access info")

--- a/cmd/test-cli/testresult/beetle-report-mig-source-to-aws.md
+++ b/cmd/test-cli/testresult/beetle-report-mig-source-to-aws.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-04-28 13:57:37*
+*Report generated: 2026-04-29 11:19:44*
 
 ---
 
@@ -12,7 +12,7 @@ This report provides a comprehensive summary of the infrastructure migration fro
 
 **Target Region:** ap-northeast-2
 
-**Namespace:** mig01 | **MCI ID:** my01-infra101
+**Namespace:** mig01 | **Infra ID:** my01-infra101
 
 **Migration Status:** Completed
 
@@ -31,7 +31,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | t3a.large, t3a.xlarge, t3a.small |
+| 2 | **VM Spec** | 3 | ✅ Selected | t3a.small, t3a.large, t3a.xlarge |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my01-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my01-vnet-01) |
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-0dcffe4e7071b2746<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-027506f1a6f19e6cc<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-078e8d26eaed7b73a<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-051ac9230d0bef1c9<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-037f076d3e4a7e58c<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0c804300e25a9e689<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-01
 
-**CSP ID:** sg-075064850b7083c10 | **VNet:** my01-vnet-01 | **Rules:** 14
+**CSP ID:** sg-007b9eccfcda456c8 | **VNet:** my01-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-02
 
-**CSP ID:** sg-07e4e2b2ec9eaa901 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0fc813b405734c9e2 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-03
 
-**CSP ID:** sg-047b340892e067e68 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0e188003866e69890 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-04235032ae43d3e1c | 10.0.0.0/21 |
+| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-0700b9f9aa0f1f4ee | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0cd3c313e892c0e42 | 10.0.1.0/24 | my01-vnet-01 |
+| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-06ade1584a33bb44a | 10.0.1.0/24 | my01-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my01-sshkey-01 | tbd7obp0knprdfoa7dhv90 | 9e:d3:7e:6b:e0:d7:ca:8b:4a:0f:64:78:7f:fd:bd:92:6e:34:3c:01 | Used by all 3 VMs |
+| 1 | my01-sshkey-01 | tbd7ouhsp0bhc4mlvtc480 | b5:b9:09:d2:f0:15:a8:83:bc:d9:2b:89:9f:53:ef:cb:99:d4:0f:4b | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/testresult/beetle-summary-source.md
+++ b/cmd/test-cli/testresult/beetle-summary-source.md
@@ -1,6 +1,6 @@
 # Source Infrastructure Summary
 
-**Generated At:** 2026-04-28 13:56:02
+**Generated At:** 2026-04-29 11:17:52
 
 **Infrastructure Name:** infra-3-servers
 

--- a/cmd/test-cli/testresult/beetle-summary-target-aws.md
+++ b/cmd/test-cli/testresult/beetle-summary-target-aws.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-04-28 13:57:31
+**Generated At:** 2026-04-29 11:19:39
 
 **Namespace:** mig01
 
@@ -42,9 +42,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-0dcffe4e7071b2746 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 3.35.47.100<br>**Private IP:** 10.0.1.161<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-027506f1a6f19e6cc | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 3.36.100.61<br>**Private IP:** 10.0.1.178<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-078e8d26eaed7b73a | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.201.249.41<br>**Private IP:** 10.0.1.86<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-051ac9230d0bef1c9 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.79.76.8<br>**Private IP:** 10.0.1.54<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-037f076d3e4a7e58c | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 13.124.154.54<br>**Private IP:** 10.0.1.121<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0c804300e25a9e689 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.222.40<br>**Private IP:** 10.0.1.146<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-vnet-01 |
-| **CSP VNet ID** | vpc-04235032ae43d3e1c |
+| **CSP VNet ID** | vpc-0700b9f9aa0f1f4ee |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my01-subnet-01 | subnet-0cd3c313e892c0e42 | 10.0.1.0/24 | ap-northeast-2a |
+| my01-subnet-01 | subnet-06ade1584a33bb44a | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my01-sshkey-01 | tbd7obp0knprdfoa7dhv90 |  | 9e:d3:7e:6b:e0:d7:ca:8b:4a:0f:64:78:7f:fd:bd:92:6e:34:3c:01 |
+| my01-sshkey-01 | tbd7ouhsp0bhc4mlvtc480 |  | b5:b9:09:d2:f0:15:a8:83:bc:d9:2b:89:9f:53:ef:cb:99:d4:0f:4b |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-01 |
-| **CSP Security Group ID** | sg-075064850b7083c10 |
+| **CSP Security Group ID** | sg-007b9eccfcda456c8 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-02 |
-| **CSP Security Group ID** | sg-07e4e2b2ec9eaa901 |
+| **CSP Security Group ID** | sg-0fc813b405734c9e2 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-03 |
-| **CSP Security Group ID** | sg-047b340892e067e68 |
+| **CSP Security Group ID** | sg-0e188003866e69890 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/testresult/beetle-test-results-aws.md
+++ b/cmd/test-cli/testresult/beetle-test-results-aws.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.0+ (7f35add)
+- CM-Beetle: imdl/v0.1.1+ (7d0dc85)
 - cm-model: unknown
 - CB-Tumblebug: v0.12.9
 - CB-Spider: v0.12.17
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: April 28, 2026
-- Test Time: 22:56:02 KST
-- Test Execution: 2026-04-28 22:56:02 KST
+- Test Date: April 29, 2026
+- Test Time: 20:17:52 KST
+- Test Execution: 2026-04-29 20:17:52 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/vmInfra` | ✅ **PASS** | 2.568s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 45.739s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/mci` | ✅ **PASS** | 19ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/mci?option=id` | ✅ **PASS** | 8ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 18ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 4.875s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m3.137s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 18ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 8ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 31ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 6.986s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 5.861s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}` | ✅ **PASS** | 1m10.942s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 6.081s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.329s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m5.704s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 3m14.428126482s
+**Total Duration**: 3m29.439076047s
 
-*Test executed on April 28, 2026 at 22:56:02 KST (2026-04-28 22:56:02 KST) using CM-Beetle automated test CLI*
+*Test executed on April 29, 2026 at 20:17:52 KST (2026-04-29 20:17:52 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -69,7 +69,7 @@
 
 #### 1.1 API Request Information
 
-- **API Endpoint**: `POST /beetle/recommendation/vmInfra`
+- **API Endpoint**: `POST /beetle/recommendation/infra`
 - **Purpose**: Get infrastructure recommendations for migration
 - **Required Parameters**: `desiredCsp` and `desiredRegion` in request body
 
@@ -1953,7 +1953,7 @@
         "csp": "aws",
         "region": "ap-northeast-2"
       },
-      "targetVmInfra": {
+      "targetInfra": {
         "name": "infra101",
         "installMonAgent": "",
         "label": null,
@@ -2048,7 +2048,7 @@
         "publicKey": "",
         "privateKey": ""
       },
-      "targetVmSpecList": [
+      "targetSpecList": [
         {
           "id": "aws+ap-northeast-2+t3a.small",
           "uid": "d7k8jatq1uu3ogmrn28g",
@@ -2389,7 +2389,7 @@
           ]
         }
       ],
-      "targetVmOsImageList": [
+      "targetOsImageList": [
         {
           "resourceType": "image",
           "namespace": "system",
@@ -2844,7 +2844,7 @@
         "csp": "aws",
         "region": "ap-northeast-2"
       },
-      "targetVmInfra": {
+      "targetInfra": {
         "name": "infra101",
         "installMonAgent": "",
         "label": null,
@@ -2939,7 +2939,7 @@
         "publicKey": "",
         "privateKey": ""
       },
-      "targetVmSpecList": [
+      "targetSpecList": [
         {
           "id": "aws+ap-northeast-2+t3a.small",
           "uid": "d7k8jatq1uu3ogmrn28g",
@@ -3619,7 +3619,7 @@
           ]
         }
       ],
-      "targetVmOsImageList": [
+      "targetOsImageList": [
         {
           "resourceType": "image",
           "namespace": "system",
@@ -4076,7 +4076,7 @@
 
 #### 2.1 API Request Information
 
-- **API Endpoint**: `POST /beetle/migration/ns/mig01/mci`
+- **API Endpoint**: `POST /beetle/migration/ns/mig01/infra`
 - **Purpose**: Create and migrate infrastructure based on recommendation
 - **Namespace ID**: `mig01`
 - **Request Body**: Uses the response from the previous recommendation step
@@ -4095,7 +4095,7 @@
 {
   "resourceType": "infra",
   "id": "my01-infra101",
-  "uid": "tbd7obp24nprdfoa7dhvb0",
+  "uid": "tbd7ouhu90bhc4mlvtc4a0",
   "name": "my01-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -4123,7 +4123,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my01-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd7obp24nprdfoa7dhvb0"
+    "sys.uid": "tbd7ouhu90bhc4mlvtc4a0"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -4132,9 +4132,9 @@
     {
       "resourceType": "node",
       "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd7obp2cnprdfoa7dhvc0",
-      "cspResourceName": "tbd7obp2cnprdfoa7dhvc0",
-      "cspResourceId": "i-0dcffe4e7071b2746",
+      "uid": "tbd7ouhuh0bhc4mlvtc4b0",
+      "cspResourceName": "tbd7ouhuh0bhc4mlvtc4b0",
+      "cspResourceId": "i-051ac9230d0bef1c9",
       "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -4148,14 +4148,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-04-28 13:56:50",
+      "createdTime": "2026-04-29 11:18:44",
       "label": {
-        "Name": "tbd7obp2cnprdfoa7dhvc0",
+        "Name": "tbd7ouhuh0bhc4mlvtc4b0",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-04-28 13:56:50",
-        "sys.cspResourceId": "i-0dcffe4e7071b2746",
-        "sys.cspResourceName": "tbd7obp2cnprdfoa7dhvc0",
+        "sys.createdTime": "2026-04-29 11:18:44",
+        "sys.cspResourceId": "i-051ac9230d0bef1c9",
+        "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4b0",
         "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4164,7 +4164,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd7obp2cnprdfoa7dhvc0",
+        "sys.uid": "tbd7ouhuh0bhc4mlvtc4b0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4172,11 +4172,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.35.47.100",
+      "publicIP": "52.79.76.8",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.161",
-      "privateDNS": "ip-10-0-1-161.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.54",
+      "privateDNS": "ip-10-0-1-54.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 50,
       "RootDeviceName": "/dev/sda1",
@@ -4229,35 +4229,34 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-04235032ae43d3e1c",
+      "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0cd3c313e892c0e42",
-      "networkInterface": "eni-attach-0505ff5804e5fa2cf",
+      "cspSubnetId": "subnet-06ade1584a33bb44a",
+      "networkInterface": "eni-attach-0d621f1c321ad2915",
       "securityGroupIds": [
         "my01-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+      "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBO1X2cBHMcIxcJcNDmeGFMHt5GDaAip4jsZqAF/Xggrv2xg3F5gwP4hwKwZDjovY+IkSRou0asu3SRnQ2cvF1pI=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLE/Ej3Wy1xBhVWzSfTxBow7DBux1mqDIaQb+LBrt5mCrE0b349O66DyDspW/1r3wEIwV7t65hcET81FewZZFd4=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:l/Pj1FjM8s7Ig7M8rMy3gOWVuyTKQyMyLcgD5mFBIpM",
-        "firstUsedAt": "2026-04-28T13:57:00Z"
+        "fingerprint": "SHA256:2vbYD4q6rFgmOQ7xVsb2BZE97geg6sPseAnjGYc62ao",
+        "firstUsedAt": "2026-04-29T11:18:51Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-04-28T13:56:55Z",
-          "completedTime": "2026-04-28T13:57:01Z",
-          "elapsedTime": 6,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-161 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-04-29T11:18:50Z",
+          "completedTime": "2026-04-29T11:19:09Z",
+          "elapsedTime": 19,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -4271,7 +4270,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:32Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0fab2ad67d4f890df}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:22Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-09ef5bec592d4ab47}}"
         },
         {
           "key": "BootMode",
@@ -4283,7 +4282,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "0E987A53-48D0-4FDE-8DB7-B4C39AA5BE2F"
+          "value": "EF6244AC-C4EF-458B-823D-695B64CD0303"
         },
         {
           "key": "CpuOptions",
@@ -4315,7 +4314,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0dcffe4e7071b2746"
+          "value": "i-051ac9230d0bef1c9"
         },
         {
           "key": "InstanceType",
@@ -4323,11 +4322,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd7obp0knprdfoa7dhv90"
+          "value": "tbd7ouhsp0bhc4mlvtc480"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-04-28T13:56:31Z"
+          "value": "2026-04-29T11:18:21Z"
         },
         {
           "key": "MetadataOptions",
@@ -4339,7 +4338,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.35.47.100},Attachment:{AttachTime:2026-04-28T13:56:31Z,AttachmentId:eni-attach-0505ff5804e5fa2cf,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-075064850b7083c10,GroupName:tbd7obp0snprdfoa7dhv9g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:6d:c0:b9:44:57,NetworkInterfaceId:eni-04925ba38827ddd4f,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.161,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.35.47.100},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.161}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.79.76.8},Attachment:{AttachTime:2026-04-29T11:18:21Z,AttachmentId:eni-attach-0d621f1c321ad2915,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-007b9eccfcda456c8,GroupName:tbd7ouhsp0bhc4mlvtc48g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:09:9c:a7:28:ef,NetworkInterfaceId:eni-07daaeddf473649b8,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.54,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.79.76.8},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.54}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
         },
         {
           "key": "Placement",
@@ -4347,15 +4346,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-161.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-54.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.161"
+          "value": "10.0.1.54"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.35.47.100"
+          "value": "52.79.76.8"
         },
         {
           "key": "RootDeviceName",
@@ -4367,7 +4366,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-075064850b7083c10,GroupName:tbd7obp0snprdfoa7dhv9g}"
+          "value": "{GroupId:sg-007b9eccfcda456c8,GroupName:tbd7ouhsp0bhc4mlvtc48g}"
         },
         {
           "key": "SourceDestCheck",
@@ -4379,11 +4378,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0cd3c313e892c0e42"
+          "value": "subnet-06ade1584a33bb44a"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhvc0}"
+          "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4b0}"
         },
         {
           "key": "VirtualizationType",
@@ -4391,16 +4390,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-04235032ae43d3e1c"
+          "value": "vpc-0700b9f9aa0f1f4ee"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd7obp2cnprdfoa7dhve0",
-      "cspResourceName": "tbd7obp2cnprdfoa7dhve0",
-      "cspResourceId": "i-027506f1a6f19e6cc",
+      "uid": "tbd7ouhuh0bhc4mlvtc4d0",
+      "cspResourceName": "tbd7ouhuh0bhc4mlvtc4d0",
+      "cspResourceId": "i-037f076d3e4a7e58c",
       "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -4414,14 +4413,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-04-28 13:56:49",
+      "createdTime": "2026-04-29 11:18:43",
       "label": {
-        "Name": "tbd7obp2cnprdfoa7dhve0",
+        "Name": "tbd7ouhuh0bhc4mlvtc4d0",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-04-28 13:56:49",
-        "sys.cspResourceId": "i-027506f1a6f19e6cc",
-        "sys.cspResourceName": "tbd7obp2cnprdfoa7dhve0",
+        "sys.createdTime": "2026-04-29 11:18:43",
+        "sys.cspResourceId": "i-037f076d3e4a7e58c",
+        "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4d0",
         "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4430,7 +4429,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd7obp2cnprdfoa7dhve0",
+        "sys.uid": "tbd7ouhuh0bhc4mlvtc4d0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4438,11 +4437,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.36.100.61",
+      "publicIP": "13.124.154.54",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.178",
-      "privateDNS": "ip-10-0-1-178.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.121",
+      "privateDNS": "ip-10-0-1-121.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 50,
       "RootDeviceName": "/dev/sda1",
@@ -4495,35 +4494,34 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-04235032ae43d3e1c",
+      "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0cd3c313e892c0e42",
-      "networkInterface": "eni-attach-0f5a405fef64898dc",
+      "cspSubnetId": "subnet-06ade1584a33bb44a",
+      "networkInterface": "eni-attach-09a75af97298b6c82",
       "securityGroupIds": [
         "my01-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+      "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFHggPl/piWAmld8axHjEJmSw6iWHfOTnYeV811ivVf6NoBh+rsPg5FkeMro9d5lq7Rba/CaqMnNgHZeDiMlRD8=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGkC+QVXqwDPgvgWHtGtPa5nOhugMipVuKRLAgvloAPm2RMSgeg733qohcbxU4bOup2qSX+8wMj98AkZWXq2vP8=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:nRUyeoUpeodynxT1TRW5mkWNOEkwmE62HWAD/V8tk78",
-        "firstUsedAt": "2026-04-28T13:57:00Z"
+        "fingerprint": "SHA256:t3hLdX/IyMPxo/mUNpwAe+K0hwQUu33suJtRM+FWqK0",
+        "firstUsedAt": "2026-04-29T11:18:51Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-04-28T13:56:55Z",
-          "completedTime": "2026-04-28T13:57:01Z",
-          "elapsedTime": 6,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-178 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-04-29T11:18:50Z",
+          "completedTime": "2026-04-29T11:19:09Z",
+          "elapsedTime": 19,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -4537,7 +4535,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:29Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0b6c4287aee3c1a89}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:23Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0f50b3a6c65a66188}}"
         },
         {
           "key": "BootMode",
@@ -4549,7 +4547,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "8BE99295-0F90-49DC-BE21-36F5D8FFCF1B"
+          "value": "F4AE7EE5-732C-47DC-A541-DC1F2CD7314F"
         },
         {
           "key": "CpuOptions",
@@ -4581,7 +4579,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-027506f1a6f19e6cc"
+          "value": "i-037f076d3e4a7e58c"
         },
         {
           "key": "InstanceType",
@@ -4589,11 +4587,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd7obp0knprdfoa7dhv90"
+          "value": "tbd7ouhsp0bhc4mlvtc480"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-04-28T13:56:28Z"
+          "value": "2026-04-29T11:18:23Z"
         },
         {
           "key": "MetadataOptions",
@@ -4605,7 +4603,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.100.61},Attachment:{AttachTime:2026-04-28T13:56:28Z,AttachmentId:eni-attach-0f5a405fef64898dc,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-047b340892e067e68,GroupName:tbd7obp1knprdfoa7dhvag}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:01:c8:da:8c:e7,NetworkInterfaceId:eni-0c9619ab72657cf9c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.178,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.100.61},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.178}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.154.54},Attachment:{AttachTime:2026-04-29T11:18:23Z,AttachmentId:eni-attach-09a75af97298b6c82,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0e188003866e69890,GroupName:tbd7ouhtp0bhc4mlvtc49g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:8e:5e:34:3f:43,NetworkInterfaceId:eni-05ddf30ade1fda3c0,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.121,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.154.54},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.121}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
         },
         {
           "key": "Placement",
@@ -4613,15 +4611,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-178.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-121.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.178"
+          "value": "10.0.1.121"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.36.100.61"
+          "value": "13.124.154.54"
         },
         {
           "key": "RootDeviceName",
@@ -4633,7 +4631,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-047b340892e067e68,GroupName:tbd7obp1knprdfoa7dhvag}"
+          "value": "{GroupId:sg-0e188003866e69890,GroupName:tbd7ouhtp0bhc4mlvtc49g}"
         },
         {
           "key": "SourceDestCheck",
@@ -4645,11 +4643,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0cd3c313e892c0e42"
+          "value": "subnet-06ade1584a33bb44a"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhve0}"
+          "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4d0}"
         },
         {
           "key": "VirtualizationType",
@@ -4657,16 +4655,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-04235032ae43d3e1c"
+          "value": "vpc-0700b9f9aa0f1f4ee"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd7obp2cnprdfoa7dhvd0",
-      "cspResourceName": "tbd7obp2cnprdfoa7dhvd0",
-      "cspResourceId": "i-078e8d26eaed7b73a",
+      "uid": "tbd7ouhuh0bhc4mlvtc4c0",
+      "cspResourceName": "tbd7ouhuh0bhc4mlvtc4c0",
+      "cspResourceId": "i-0c804300e25a9e689",
       "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4680,14 +4678,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-04-28 13:56:47",
+      "createdTime": "2026-04-29 11:18:40",
       "label": {
-        "Name": "tbd7obp2cnprdfoa7dhvd0",
+        "Name": "tbd7ouhuh0bhc4mlvtc4c0",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-04-28 13:56:47",
-        "sys.cspResourceId": "i-078e8d26eaed7b73a",
-        "sys.cspResourceName": "tbd7obp2cnprdfoa7dhvd0",
+        "sys.createdTime": "2026-04-29 11:18:40",
+        "sys.cspResourceId": "i-0c804300e25a9e689",
+        "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4c0",
         "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4696,7 +4694,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd7obp2cnprdfoa7dhvd0",
+        "sys.uid": "tbd7ouhuh0bhc4mlvtc4c0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4704,11 +4702,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.201.249.41",
+      "publicIP": "43.203.222.40",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.86",
-      "privateDNS": "ip-10-0-1-86.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.146",
+      "privateDNS": "ip-10-0-1-146.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 50,
       "RootDeviceName": "/dev/sda1",
@@ -4761,22 +4759,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-04235032ae43d3e1c",
+      "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0cd3c313e892c0e42",
-      "networkInterface": "eni-attach-08462239ee43a94d6",
+      "cspSubnetId": "subnet-06ade1584a33bb44a",
+      "networkInterface": "eni-attach-074db64960d965a8b",
       "securityGroupIds": [
         "my01-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+      "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJWwlTZI5WBRhurwEJoTifemDZiNO1MqotFGn6VC4Qs5lruw7y9hT5iCmEP52A/SRfPug7XaEqzGfDkJyez8Y4s=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPQF1IZysPGHHT9k8h85k28UU53FlEv/P1jeUB7rBjUyqlsf0zcZ9BPWuQgMKDHPd6POiGOT9Q/P4Ukn+RlhxP8=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:LUHWnJdbGdaGKf4s9phDLh9izje2vxRPnunAUkDceV0",
-        "firstUsedAt": "2026-04-28T13:56:56Z"
+        "fingerprint": "SHA256:W49B55ZnQKo0VkNcLbPq6v83r3yGZ9MUxhpRaBtfUlo",
+        "firstUsedAt": "2026-04-29T11:18:50Z"
       },
       "commandStatus": [
         {
@@ -4784,11 +4782,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-04-28T13:56:55Z",
-          "completedTime": "2026-04-28T13:57:00Z",
-          "elapsedTime": 5,
+          "startedTime": "2026-04-29T11:18:50Z",
+          "completedTime": "2026-04-29T11:18:51Z",
+          "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-86 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-146 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4803,7 +4801,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:29Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-074af6b7f005c48fd}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:23Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0f87915239f0e2108}}"
         },
         {
           "key": "BootMode",
@@ -4815,7 +4813,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "62BFD880-DA15-41A6-ACE9-AD0A19794608"
+          "value": "97B683EF-2C32-44A9-B306-EA70446D8A51"
         },
         {
           "key": "CpuOptions",
@@ -4847,7 +4845,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-078e8d26eaed7b73a"
+          "value": "i-0c804300e25a9e689"
         },
         {
           "key": "InstanceType",
@@ -4855,11 +4853,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd7obp0knprdfoa7dhv90"
+          "value": "tbd7ouhsp0bhc4mlvtc480"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-04-28T13:56:29Z"
+          "value": "2026-04-29T11:18:22Z"
         },
         {
           "key": "MetadataOptions",
@@ -4871,7 +4869,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.249.41},Attachment:{AttachTime:2026-04-28T13:56:29Z,AttachmentId:eni-attach-08462239ee43a94d6,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-07e4e2b2ec9eaa901,GroupName:tbd7obp14nprdfoa7dhva0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:96:12:47:01:33,NetworkInterfaceId:eni-03997b3773398d964,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.86,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.249.41},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.86}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.222.40},Attachment:{AttachTime:2026-04-29T11:18:22Z,AttachmentId:eni-attach-074db64960d965a8b,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0fc813b405734c9e2,GroupName:tbd7ouht90bhc4mlvtc490}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:08:ed:d8:ed:11,NetworkInterfaceId:eni-0dcbc68d05016ee19,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.146,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.222.40},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.146}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
         },
         {
           "key": "Placement",
@@ -4879,15 +4877,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-86.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-146.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.86"
+          "value": "10.0.1.146"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.201.249.41"
+          "value": "43.203.222.40"
         },
         {
           "key": "RootDeviceName",
@@ -4899,7 +4897,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-07e4e2b2ec9eaa901,GroupName:tbd7obp14nprdfoa7dhva0}"
+          "value": "{GroupId:sg-0fc813b405734c9e2,GroupName:tbd7ouht90bhc4mlvtc490}"
         },
         {
           "key": "SourceDestCheck",
@@ -4911,11 +4909,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0cd3c313e892c0e42"
+          "value": "subnet-06ade1584a33bb44a"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhvd0}"
+          "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4c0}"
         },
         {
           "key": "VirtualizationType",
@@ -4923,7 +4921,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-04235032ae43d3e1c"
+          "value": "vpc-0700b9f9aa0f1f4ee"
         }
       ]
     }
@@ -4940,12 +4938,12 @@
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "43.201.249.41",
+        "nodeIp": "43.203.222.40",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-86 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-146 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4955,31 +4953,23 @@
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "3.35.47.100",
+        "nodeIp": "52.79.76.8",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-161 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       },
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "3.36.100.61",
+        "nodeIp": "13.124.154.54",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-178 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       }
     ]
@@ -4989,19 +4979,19 @@
 
 </details>
 
-### Test Case 3: Get a list of MCIs
+### Test Case 3: Get a list of infras
 
 #### 3.1 API Request Information
 
-- **API Endpoint**: `GET /beetle/migration/ns/mig01/mci`
-- **Purpose**: Retrieve all Multi-Cloud Infrastructure instances
+- **API Endpoint**: `GET /beetle/migration/ns/mig01/infra`
+- **Purpose**: Retrieve all migrated cloud infrastructure instances
 - **Namespace ID**: `mig01`
 - **Request Body**: None (GET request)
 
 #### 3.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Response**: MCI list retrieved successfully
+- **Response**: Infra list retrieved successfully
 
 **Response Body**:
 
@@ -5011,7 +5001,7 @@
     {
       "resourceType": "infra",
       "id": "my01-infra101",
-      "uid": "tbd7obp24nprdfoa7dhvb0",
+      "uid": "tbd7ouhu90bhc4mlvtc4a0",
       "name": "my01-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -5039,7 +5029,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my01-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd7obp24nprdfoa7dhvb0"
+        "sys.uid": "tbd7ouhu90bhc4mlvtc4a0"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5048,9 +5038,9 @@
         {
           "resourceType": "node",
           "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd7obp2cnprdfoa7dhvc0",
-          "cspResourceName": "tbd7obp2cnprdfoa7dhvc0",
-          "cspResourceId": "i-0dcffe4e7071b2746",
+          "uid": "tbd7ouhuh0bhc4mlvtc4b0",
+          "cspResourceName": "tbd7ouhuh0bhc4mlvtc4b0",
+          "cspResourceId": "i-051ac9230d0bef1c9",
           "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -5064,14 +5054,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-04-28 13:56:50",
+          "createdTime": "2026-04-29 11:18:44",
           "label": {
-            "Name": "tbd7obp2cnprdfoa7dhvc0",
+            "Name": "tbd7ouhuh0bhc4mlvtc4b0",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-04-28 13:56:50",
-            "sys.cspResourceId": "i-0dcffe4e7071b2746",
-            "sys.cspResourceName": "tbd7obp2cnprdfoa7dhvc0",
+            "sys.createdTime": "2026-04-29 11:18:44",
+            "sys.cspResourceId": "i-051ac9230d0bef1c9",
+            "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4b0",
             "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5080,7 +5070,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd7obp2cnprdfoa7dhvc0",
+            "sys.uid": "tbd7ouhuh0bhc4mlvtc4b0",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5088,11 +5078,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "3.35.47.100",
+          "publicIP": "52.79.76.8",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.161",
-          "privateDNS": "ip-10-0-1-161.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.54",
+          "privateDNS": "ip-10-0-1-54.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 50,
           "RootDeviceName": "/dev/sda1",
@@ -5145,35 +5135,34 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-04235032ae43d3e1c",
+          "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0cd3c313e892c0e42",
-          "networkInterface": "eni-attach-0505ff5804e5fa2cf",
+          "cspSubnetId": "subnet-06ade1584a33bb44a",
+          "networkInterface": "eni-attach-0d621f1c321ad2915",
           "securityGroupIds": [
             "my01-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+          "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBO1X2cBHMcIxcJcNDmeGFMHt5GDaAip4jsZqAF/Xggrv2xg3F5gwP4hwKwZDjovY+IkSRou0asu3SRnQ2cvF1pI=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLE/Ej3Wy1xBhVWzSfTxBow7DBux1mqDIaQb+LBrt5mCrE0b349O66DyDspW/1r3wEIwV7t65hcET81FewZZFd4=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:l/Pj1FjM8s7Ig7M8rMy3gOWVuyTKQyMyLcgD5mFBIpM",
-            "firstUsedAt": "2026-04-28T13:57:00Z"
+            "fingerprint": "SHA256:2vbYD4q6rFgmOQ7xVsb2BZE97geg6sPseAnjGYc62ao",
+            "firstUsedAt": "2026-04-29T11:18:51Z"
           },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-04-28T13:56:55Z",
-              "completedTime": "2026-04-28T13:57:01Z",
-              "elapsedTime": 6,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-161 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
+              "status": "Failed",
+              "startedTime": "2026-04-29T11:18:50Z",
+              "completedTime": "2026-04-29T11:19:09Z",
+              "elapsedTime": 19,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -5187,7 +5176,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:32Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0fab2ad67d4f890df}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:22Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-09ef5bec592d4ab47}}"
             },
             {
               "key": "BootMode",
@@ -5199,7 +5188,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "0E987A53-48D0-4FDE-8DB7-B4C39AA5BE2F"
+              "value": "EF6244AC-C4EF-458B-823D-695B64CD0303"
             },
             {
               "key": "CpuOptions",
@@ -5231,7 +5220,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0dcffe4e7071b2746"
+              "value": "i-051ac9230d0bef1c9"
             },
             {
               "key": "InstanceType",
@@ -5239,11 +5228,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd7obp0knprdfoa7dhv90"
+              "value": "tbd7ouhsp0bhc4mlvtc480"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-04-28T13:56:31Z"
+              "value": "2026-04-29T11:18:21Z"
             },
             {
               "key": "MetadataOptions",
@@ -5255,7 +5244,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.35.47.100},Attachment:{AttachTime:2026-04-28T13:56:31Z,AttachmentId:eni-attach-0505ff5804e5fa2cf,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-075064850b7083c10,GroupName:tbd7obp0snprdfoa7dhv9g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:6d:c0:b9:44:57,NetworkInterfaceId:eni-04925ba38827ddd4f,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.161,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.35.47.100},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.161}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.79.76.8},Attachment:{AttachTime:2026-04-29T11:18:21Z,AttachmentId:eni-attach-0d621f1c321ad2915,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-007b9eccfcda456c8,GroupName:tbd7ouhsp0bhc4mlvtc48g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:09:9c:a7:28:ef,NetworkInterfaceId:eni-07daaeddf473649b8,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.54,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.79.76.8},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.54}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
             },
             {
               "key": "Placement",
@@ -5263,15 +5252,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-161.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-54.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.161"
+              "value": "10.0.1.54"
             },
             {
               "key": "PublicIpAddress",
-              "value": "3.35.47.100"
+              "value": "52.79.76.8"
             },
             {
               "key": "RootDeviceName",
@@ -5283,7 +5272,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-075064850b7083c10,GroupName:tbd7obp0snprdfoa7dhv9g}"
+              "value": "{GroupId:sg-007b9eccfcda456c8,GroupName:tbd7ouhsp0bhc4mlvtc48g}"
             },
             {
               "key": "SourceDestCheck",
@@ -5295,11 +5284,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0cd3c313e892c0e42"
+              "value": "subnet-06ade1584a33bb44a"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhvc0}"
+              "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4b0}"
             },
             {
               "key": "VirtualizationType",
@@ -5307,16 +5296,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-04235032ae43d3e1c"
+              "value": "vpc-0700b9f9aa0f1f4ee"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd7obp2cnprdfoa7dhve0",
-          "cspResourceName": "tbd7obp2cnprdfoa7dhve0",
-          "cspResourceId": "i-027506f1a6f19e6cc",
+          "uid": "tbd7ouhuh0bhc4mlvtc4d0",
+          "cspResourceName": "tbd7ouhuh0bhc4mlvtc4d0",
+          "cspResourceId": "i-037f076d3e4a7e58c",
           "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5330,14 +5319,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-04-28 13:56:49",
+          "createdTime": "2026-04-29 11:18:43",
           "label": {
-            "Name": "tbd7obp2cnprdfoa7dhve0",
+            "Name": "tbd7ouhuh0bhc4mlvtc4d0",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-04-28 13:56:49",
-            "sys.cspResourceId": "i-027506f1a6f19e6cc",
-            "sys.cspResourceName": "tbd7obp2cnprdfoa7dhve0",
+            "sys.createdTime": "2026-04-29 11:18:43",
+            "sys.cspResourceId": "i-037f076d3e4a7e58c",
+            "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4d0",
             "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5346,7 +5335,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd7obp2cnprdfoa7dhve0",
+            "sys.uid": "tbd7ouhuh0bhc4mlvtc4d0",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5354,11 +5343,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "3.36.100.61",
+          "publicIP": "13.124.154.54",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.178",
-          "privateDNS": "ip-10-0-1-178.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.121",
+          "privateDNS": "ip-10-0-1-121.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 50,
           "RootDeviceName": "/dev/sda1",
@@ -5411,35 +5400,34 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-04235032ae43d3e1c",
+          "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0cd3c313e892c0e42",
-          "networkInterface": "eni-attach-0f5a405fef64898dc",
+          "cspSubnetId": "subnet-06ade1584a33bb44a",
+          "networkInterface": "eni-attach-09a75af97298b6c82",
           "securityGroupIds": [
             "my01-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+          "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFHggPl/piWAmld8axHjEJmSw6iWHfOTnYeV811ivVf6NoBh+rsPg5FkeMro9d5lq7Rba/CaqMnNgHZeDiMlRD8=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGkC+QVXqwDPgvgWHtGtPa5nOhugMipVuKRLAgvloAPm2RMSgeg733qohcbxU4bOup2qSX+8wMj98AkZWXq2vP8=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:nRUyeoUpeodynxT1TRW5mkWNOEkwmE62HWAD/V8tk78",
-            "firstUsedAt": "2026-04-28T13:57:00Z"
+            "fingerprint": "SHA256:t3hLdX/IyMPxo/mUNpwAe+K0hwQUu33suJtRM+FWqK0",
+            "firstUsedAt": "2026-04-29T11:18:51Z"
           },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-04-28T13:56:55Z",
-              "completedTime": "2026-04-28T13:57:01Z",
-              "elapsedTime": 6,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-178 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
+              "status": "Failed",
+              "startedTime": "2026-04-29T11:18:50Z",
+              "completedTime": "2026-04-29T11:19:09Z",
+              "elapsedTime": 19,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -5453,7 +5441,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:29Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0b6c4287aee3c1a89}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:23Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0f50b3a6c65a66188}}"
             },
             {
               "key": "BootMode",
@@ -5465,7 +5453,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "8BE99295-0F90-49DC-BE21-36F5D8FFCF1B"
+              "value": "F4AE7EE5-732C-47DC-A541-DC1F2CD7314F"
             },
             {
               "key": "CpuOptions",
@@ -5497,7 +5485,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-027506f1a6f19e6cc"
+              "value": "i-037f076d3e4a7e58c"
             },
             {
               "key": "InstanceType",
@@ -5505,11 +5493,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd7obp0knprdfoa7dhv90"
+              "value": "tbd7ouhsp0bhc4mlvtc480"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-04-28T13:56:28Z"
+              "value": "2026-04-29T11:18:23Z"
             },
             {
               "key": "MetadataOptions",
@@ -5521,7 +5509,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.100.61},Attachment:{AttachTime:2026-04-28T13:56:28Z,AttachmentId:eni-attach-0f5a405fef64898dc,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-047b340892e067e68,GroupName:tbd7obp1knprdfoa7dhvag}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:01:c8:da:8c:e7,NetworkInterfaceId:eni-0c9619ab72657cf9c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.178,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.100.61},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.178}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.154.54},Attachment:{AttachTime:2026-04-29T11:18:23Z,AttachmentId:eni-attach-09a75af97298b6c82,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0e188003866e69890,GroupName:tbd7ouhtp0bhc4mlvtc49g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:8e:5e:34:3f:43,NetworkInterfaceId:eni-05ddf30ade1fda3c0,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.121,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.154.54},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.121}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
             },
             {
               "key": "Placement",
@@ -5529,15 +5517,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-178.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-121.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.178"
+              "value": "10.0.1.121"
             },
             {
               "key": "PublicIpAddress",
-              "value": "3.36.100.61"
+              "value": "13.124.154.54"
             },
             {
               "key": "RootDeviceName",
@@ -5549,7 +5537,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-047b340892e067e68,GroupName:tbd7obp1knprdfoa7dhvag}"
+              "value": "{GroupId:sg-0e188003866e69890,GroupName:tbd7ouhtp0bhc4mlvtc49g}"
             },
             {
               "key": "SourceDestCheck",
@@ -5561,11 +5549,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0cd3c313e892c0e42"
+              "value": "subnet-06ade1584a33bb44a"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhve0}"
+              "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4d0}"
             },
             {
               "key": "VirtualizationType",
@@ -5573,16 +5561,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-04235032ae43d3e1c"
+              "value": "vpc-0700b9f9aa0f1f4ee"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd7obp2cnprdfoa7dhvd0",
-          "cspResourceName": "tbd7obp2cnprdfoa7dhvd0",
-          "cspResourceId": "i-078e8d26eaed7b73a",
+          "uid": "tbd7ouhuh0bhc4mlvtc4c0",
+          "cspResourceName": "tbd7ouhuh0bhc4mlvtc4c0",
+          "cspResourceId": "i-0c804300e25a9e689",
           "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5596,14 +5584,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-04-28 13:56:47",
+          "createdTime": "2026-04-29 11:18:40",
           "label": {
-            "Name": "tbd7obp2cnprdfoa7dhvd0",
+            "Name": "tbd7ouhuh0bhc4mlvtc4c0",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-04-28 13:56:47",
-            "sys.cspResourceId": "i-078e8d26eaed7b73a",
-            "sys.cspResourceName": "tbd7obp2cnprdfoa7dhvd0",
+            "sys.createdTime": "2026-04-29 11:18:40",
+            "sys.cspResourceId": "i-0c804300e25a9e689",
+            "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4c0",
             "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5612,7 +5600,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd7obp2cnprdfoa7dhvd0",
+            "sys.uid": "tbd7ouhuh0bhc4mlvtc4c0",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5620,11 +5608,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "43.201.249.41",
+          "publicIP": "43.203.222.40",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.86",
-          "privateDNS": "ip-10-0-1-86.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.146",
+          "privateDNS": "ip-10-0-1-146.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 50,
           "RootDeviceName": "/dev/sda1",
@@ -5677,22 +5665,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-04235032ae43d3e1c",
+          "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0cd3c313e892c0e42",
-          "networkInterface": "eni-attach-08462239ee43a94d6",
+          "cspSubnetId": "subnet-06ade1584a33bb44a",
+          "networkInterface": "eni-attach-074db64960d965a8b",
           "securityGroupIds": [
             "my01-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+          "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJWwlTZI5WBRhurwEJoTifemDZiNO1MqotFGn6VC4Qs5lruw7y9hT5iCmEP52A/SRfPug7XaEqzGfDkJyez8Y4s=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPQF1IZysPGHHT9k8h85k28UU53FlEv/P1jeUB7rBjUyqlsf0zcZ9BPWuQgMKDHPd6POiGOT9Q/P4Ukn+RlhxP8=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:LUHWnJdbGdaGKf4s9phDLh9izje2vxRPnunAUkDceV0",
-            "firstUsedAt": "2026-04-28T13:56:56Z"
+            "fingerprint": "SHA256:W49B55ZnQKo0VkNcLbPq6v83r3yGZ9MUxhpRaBtfUlo",
+            "firstUsedAt": "2026-04-29T11:18:50Z"
           },
           "commandStatus": [
             {
@@ -5700,11 +5688,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-04-28T13:56:55Z",
-              "completedTime": "2026-04-28T13:57:00Z",
-              "elapsedTime": 5,
+              "startedTime": "2026-04-29T11:18:50Z",
+              "completedTime": "2026-04-29T11:18:51Z",
+              "elapsedTime": 1,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-86 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-146 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5719,7 +5707,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:29Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-074af6b7f005c48fd}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:23Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0f87915239f0e2108}}"
             },
             {
               "key": "BootMode",
@@ -5731,7 +5719,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "62BFD880-DA15-41A6-ACE9-AD0A19794608"
+              "value": "97B683EF-2C32-44A9-B306-EA70446D8A51"
             },
             {
               "key": "CpuOptions",
@@ -5763,7 +5751,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-078e8d26eaed7b73a"
+              "value": "i-0c804300e25a9e689"
             },
             {
               "key": "InstanceType",
@@ -5771,11 +5759,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd7obp0knprdfoa7dhv90"
+              "value": "tbd7ouhsp0bhc4mlvtc480"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-04-28T13:56:29Z"
+              "value": "2026-04-29T11:18:22Z"
             },
             {
               "key": "MetadataOptions",
@@ -5787,7 +5775,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.249.41},Attachment:{AttachTime:2026-04-28T13:56:29Z,AttachmentId:eni-attach-08462239ee43a94d6,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-07e4e2b2ec9eaa901,GroupName:tbd7obp14nprdfoa7dhva0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:96:12:47:01:33,NetworkInterfaceId:eni-03997b3773398d964,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.86,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.249.41},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.86}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.222.40},Attachment:{AttachTime:2026-04-29T11:18:22Z,AttachmentId:eni-attach-074db64960d965a8b,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0fc813b405734c9e2,GroupName:tbd7ouht90bhc4mlvtc490}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:08:ed:d8:ed:11,NetworkInterfaceId:eni-0dcbc68d05016ee19,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.146,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.222.40},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.146}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
             },
             {
               "key": "Placement",
@@ -5795,15 +5783,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-86.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-146.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.86"
+              "value": "10.0.1.146"
             },
             {
               "key": "PublicIpAddress",
-              "value": "43.201.249.41"
+              "value": "43.203.222.40"
             },
             {
               "key": "RootDeviceName",
@@ -5815,7 +5803,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-07e4e2b2ec9eaa901,GroupName:tbd7obp14nprdfoa7dhva0}"
+              "value": "{GroupId:sg-0fc813b405734c9e2,GroupName:tbd7ouht90bhc4mlvtc490}"
             },
             {
               "key": "SourceDestCheck",
@@ -5827,11 +5815,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0cd3c313e892c0e42"
+              "value": "subnet-06ade1584a33bb44a"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhvd0}"
+              "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4c0}"
             },
             {
               "key": "VirtualizationType",
@@ -5839,7 +5827,7 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-04235032ae43d3e1c"
+              "value": "vpc-0700b9f9aa0f1f4ee"
             }
           ]
         }
@@ -5856,12 +5844,12 @@
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "43.201.249.41",
+            "nodeIp": "43.203.222.40",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-86 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-146 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5871,31 +5859,23 @@
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "3.35.47.100",
+            "nodeIp": "52.79.76.8",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {
-              "0": "Linux ip-10-0-1-161 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
+            "stdout": {},
+            "stderr": {},
             "err": null
           },
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "3.36.100.61",
+            "nodeIp": "13.124.154.54",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {
-              "0": "Linux ip-10-0-1-178 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
+            "stdout": {},
+            "stderr": {},
             "err": null
           }
         ]
@@ -5905,12 +5885,12 @@
 }
 ```
 
-### Test Case 4: Get a list of MCI IDs
+### Test Case 4: Get a list of infra IDs
 
 #### 4.1 API Request Information
 
-- **API Endpoint**: `GET /beetle/migration/ns/mig01/mci?option=id`
-- **Purpose**: Retrieve MCI IDs only (lightweight response)
+- **API Endpoint**: `GET /beetle/migration/ns/mig01/infra?option=id`
+- **Purpose**: Retrieve infra IDs only (lightweight response)
 - **Namespace ID**: `mig01`
 - **Query Parameter**: `option=id`
 - **Request Body**: None (GET request)
@@ -5918,7 +5898,7 @@
 #### 4.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Response**: MCI IDs retrieved successfully
+- **Response**: Infra IDs retrieved successfully
 
 **Response Body**:
 
@@ -5930,20 +5910,20 @@
 }
 ```
 
-### Test Case 5: Get a specific MCI
+### Test Case 5: Get a specific infra
 
 #### 5.1 API Request Information
 
-- **API Endpoint**: `GET /beetle/migration/ns/mig01/mci/{{mciId}}`
-- **Purpose**: Retrieve detailed information for a specific MCI
+- **API Endpoint**: `GET /beetle/migration/ns/mig01/infra/{{infraId}}`
+- **Purpose**: Retrieve detailed information for a specific infra
 - **Namespace ID**: `mig01`
-- **Path Parameter**: `{{mciId}}` - The specific MCI identifier
+- **Path Parameter**: `{{infraId}}` - The specific infra identifier
 - **Request Body**: None (GET request)
 
 #### 5.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Response**: MCI details retrieved successfully
+- **Response**: Infra details retrieved successfully
 
 **Response Body**:
 
@@ -5954,7 +5934,7 @@
 {
   "resourceType": "infra",
   "id": "my01-infra101",
-  "uid": "tbd7obp24nprdfoa7dhvb0",
+  "uid": "tbd7ouhu90bhc4mlvtc4a0",
   "name": "my01-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -5982,7 +5962,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my01-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd7obp24nprdfoa7dhvb0"
+    "sys.uid": "tbd7ouhu90bhc4mlvtc4a0"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -5991,9 +5971,9 @@
     {
       "resourceType": "node",
       "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd7obp2cnprdfoa7dhvc0",
-      "cspResourceName": "tbd7obp2cnprdfoa7dhvc0",
-      "cspResourceId": "i-0dcffe4e7071b2746",
+      "uid": "tbd7ouhuh0bhc4mlvtc4b0",
+      "cspResourceName": "tbd7ouhuh0bhc4mlvtc4b0",
+      "cspResourceId": "i-051ac9230d0bef1c9",
       "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -6007,14 +5987,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-04-28 13:56:50",
+      "createdTime": "2026-04-29 11:18:44",
       "label": {
-        "Name": "tbd7obp2cnprdfoa7dhvc0",
+        "Name": "tbd7ouhuh0bhc4mlvtc4b0",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-04-28 13:56:50",
-        "sys.cspResourceId": "i-0dcffe4e7071b2746",
-        "sys.cspResourceName": "tbd7obp2cnprdfoa7dhvc0",
+        "sys.createdTime": "2026-04-29 11:18:44",
+        "sys.cspResourceId": "i-051ac9230d0bef1c9",
+        "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4b0",
         "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6023,7 +6003,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd7obp2cnprdfoa7dhvc0",
+        "sys.uid": "tbd7ouhuh0bhc4mlvtc4b0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6031,11 +6011,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.35.47.100",
+      "publicIP": "52.79.76.8",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.161",
-      "privateDNS": "ip-10-0-1-161.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.54",
+      "privateDNS": "ip-10-0-1-54.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 50,
       "RootDeviceName": "/dev/sda1",
@@ -6088,35 +6068,34 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-04235032ae43d3e1c",
+      "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0cd3c313e892c0e42",
-      "networkInterface": "eni-attach-0505ff5804e5fa2cf",
+      "cspSubnetId": "subnet-06ade1584a33bb44a",
+      "networkInterface": "eni-attach-0d621f1c321ad2915",
       "securityGroupIds": [
         "my01-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+      "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBO1X2cBHMcIxcJcNDmeGFMHt5GDaAip4jsZqAF/Xggrv2xg3F5gwP4hwKwZDjovY+IkSRou0asu3SRnQ2cvF1pI=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLE/Ej3Wy1xBhVWzSfTxBow7DBux1mqDIaQb+LBrt5mCrE0b349O66DyDspW/1r3wEIwV7t65hcET81FewZZFd4=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:l/Pj1FjM8s7Ig7M8rMy3gOWVuyTKQyMyLcgD5mFBIpM",
-        "firstUsedAt": "2026-04-28T13:57:00Z"
+        "fingerprint": "SHA256:2vbYD4q6rFgmOQ7xVsb2BZE97geg6sPseAnjGYc62ao",
+        "firstUsedAt": "2026-04-29T11:18:51Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-04-28T13:56:55Z",
-          "completedTime": "2026-04-28T13:57:01Z",
-          "elapsedTime": 6,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-161 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-04-29T11:18:50Z",
+          "completedTime": "2026-04-29T11:19:09Z",
+          "elapsedTime": 19,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -6130,7 +6109,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:32Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0fab2ad67d4f890df}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:22Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-09ef5bec592d4ab47}}"
         },
         {
           "key": "BootMode",
@@ -6142,7 +6121,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "0E987A53-48D0-4FDE-8DB7-B4C39AA5BE2F"
+          "value": "EF6244AC-C4EF-458B-823D-695B64CD0303"
         },
         {
           "key": "CpuOptions",
@@ -6174,7 +6153,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0dcffe4e7071b2746"
+          "value": "i-051ac9230d0bef1c9"
         },
         {
           "key": "InstanceType",
@@ -6182,11 +6161,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd7obp0knprdfoa7dhv90"
+          "value": "tbd7ouhsp0bhc4mlvtc480"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-04-28T13:56:31Z"
+          "value": "2026-04-29T11:18:21Z"
         },
         {
           "key": "MetadataOptions",
@@ -6198,7 +6177,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.35.47.100},Attachment:{AttachTime:2026-04-28T13:56:31Z,AttachmentId:eni-attach-0505ff5804e5fa2cf,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-075064850b7083c10,GroupName:tbd7obp0snprdfoa7dhv9g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:6d:c0:b9:44:57,NetworkInterfaceId:eni-04925ba38827ddd4f,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.161,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.35.47.100},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.161}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.79.76.8},Attachment:{AttachTime:2026-04-29T11:18:21Z,AttachmentId:eni-attach-0d621f1c321ad2915,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-007b9eccfcda456c8,GroupName:tbd7ouhsp0bhc4mlvtc48g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:09:9c:a7:28:ef,NetworkInterfaceId:eni-07daaeddf473649b8,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.54,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.79.76.8},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.54}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
         },
         {
           "key": "Placement",
@@ -6206,15 +6185,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-161.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-54.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.161"
+          "value": "10.0.1.54"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.35.47.100"
+          "value": "52.79.76.8"
         },
         {
           "key": "RootDeviceName",
@@ -6226,7 +6205,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-075064850b7083c10,GroupName:tbd7obp0snprdfoa7dhv9g}"
+          "value": "{GroupId:sg-007b9eccfcda456c8,GroupName:tbd7ouhsp0bhc4mlvtc48g}"
         },
         {
           "key": "SourceDestCheck",
@@ -6238,11 +6217,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0cd3c313e892c0e42"
+          "value": "subnet-06ade1584a33bb44a"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhvc0}"
+          "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4b0}"
         },
         {
           "key": "VirtualizationType",
@@ -6250,16 +6229,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-04235032ae43d3e1c"
+          "value": "vpc-0700b9f9aa0f1f4ee"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd7obp2cnprdfoa7dhve0",
-      "cspResourceName": "tbd7obp2cnprdfoa7dhve0",
-      "cspResourceId": "i-027506f1a6f19e6cc",
+      "uid": "tbd7ouhuh0bhc4mlvtc4d0",
+      "cspResourceName": "tbd7ouhuh0bhc4mlvtc4d0",
+      "cspResourceId": "i-037f076d3e4a7e58c",
       "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6273,14 +6252,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-04-28 13:56:49",
+      "createdTime": "2026-04-29 11:18:43",
       "label": {
-        "Name": "tbd7obp2cnprdfoa7dhve0",
+        "Name": "tbd7ouhuh0bhc4mlvtc4d0",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-04-28 13:56:49",
-        "sys.cspResourceId": "i-027506f1a6f19e6cc",
-        "sys.cspResourceName": "tbd7obp2cnprdfoa7dhve0",
+        "sys.createdTime": "2026-04-29 11:18:43",
+        "sys.cspResourceId": "i-037f076d3e4a7e58c",
+        "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4d0",
         "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6289,7 +6268,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd7obp2cnprdfoa7dhve0",
+        "sys.uid": "tbd7ouhuh0bhc4mlvtc4d0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6297,11 +6276,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.36.100.61",
+      "publicIP": "13.124.154.54",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.178",
-      "privateDNS": "ip-10-0-1-178.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.121",
+      "privateDNS": "ip-10-0-1-121.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 50,
       "RootDeviceName": "/dev/sda1",
@@ -6354,35 +6333,34 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-04235032ae43d3e1c",
+      "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0cd3c313e892c0e42",
-      "networkInterface": "eni-attach-0f5a405fef64898dc",
+      "cspSubnetId": "subnet-06ade1584a33bb44a",
+      "networkInterface": "eni-attach-09a75af97298b6c82",
       "securityGroupIds": [
         "my01-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+      "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFHggPl/piWAmld8axHjEJmSw6iWHfOTnYeV811ivVf6NoBh+rsPg5FkeMro9d5lq7Rba/CaqMnNgHZeDiMlRD8=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGkC+QVXqwDPgvgWHtGtPa5nOhugMipVuKRLAgvloAPm2RMSgeg733qohcbxU4bOup2qSX+8wMj98AkZWXq2vP8=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:nRUyeoUpeodynxT1TRW5mkWNOEkwmE62HWAD/V8tk78",
-        "firstUsedAt": "2026-04-28T13:57:00Z"
+        "fingerprint": "SHA256:t3hLdX/IyMPxo/mUNpwAe+K0hwQUu33suJtRM+FWqK0",
+        "firstUsedAt": "2026-04-29T11:18:51Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-04-28T13:56:55Z",
-          "completedTime": "2026-04-28T13:57:01Z",
-          "elapsedTime": 6,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-178 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-04-29T11:18:50Z",
+          "completedTime": "2026-04-29T11:19:09Z",
+          "elapsedTime": 19,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -6396,7 +6374,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:29Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0b6c4287aee3c1a89}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:23Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0f50b3a6c65a66188}}"
         },
         {
           "key": "BootMode",
@@ -6408,7 +6386,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "8BE99295-0F90-49DC-BE21-36F5D8FFCF1B"
+          "value": "F4AE7EE5-732C-47DC-A541-DC1F2CD7314F"
         },
         {
           "key": "CpuOptions",
@@ -6440,7 +6418,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-027506f1a6f19e6cc"
+          "value": "i-037f076d3e4a7e58c"
         },
         {
           "key": "InstanceType",
@@ -6448,11 +6426,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd7obp0knprdfoa7dhv90"
+          "value": "tbd7ouhsp0bhc4mlvtc480"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-04-28T13:56:28Z"
+          "value": "2026-04-29T11:18:23Z"
         },
         {
           "key": "MetadataOptions",
@@ -6464,7 +6442,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.100.61},Attachment:{AttachTime:2026-04-28T13:56:28Z,AttachmentId:eni-attach-0f5a405fef64898dc,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-047b340892e067e68,GroupName:tbd7obp1knprdfoa7dhvag}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:01:c8:da:8c:e7,NetworkInterfaceId:eni-0c9619ab72657cf9c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.178,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.100.61},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.178}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.154.54},Attachment:{AttachTime:2026-04-29T11:18:23Z,AttachmentId:eni-attach-09a75af97298b6c82,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0e188003866e69890,GroupName:tbd7ouhtp0bhc4mlvtc49g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:8e:5e:34:3f:43,NetworkInterfaceId:eni-05ddf30ade1fda3c0,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.121,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.154.54},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.121}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
         },
         {
           "key": "Placement",
@@ -6472,15 +6450,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-178.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-121.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.178"
+          "value": "10.0.1.121"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.36.100.61"
+          "value": "13.124.154.54"
         },
         {
           "key": "RootDeviceName",
@@ -6492,7 +6470,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-047b340892e067e68,GroupName:tbd7obp1knprdfoa7dhvag}"
+          "value": "{GroupId:sg-0e188003866e69890,GroupName:tbd7ouhtp0bhc4mlvtc49g}"
         },
         {
           "key": "SourceDestCheck",
@@ -6504,11 +6482,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0cd3c313e892c0e42"
+          "value": "subnet-06ade1584a33bb44a"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhve0}"
+          "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4d0}"
         },
         {
           "key": "VirtualizationType",
@@ -6516,16 +6494,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-04235032ae43d3e1c"
+          "value": "vpc-0700b9f9aa0f1f4ee"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd7obp2cnprdfoa7dhvd0",
-      "cspResourceName": "tbd7obp2cnprdfoa7dhvd0",
-      "cspResourceId": "i-078e8d26eaed7b73a",
+      "uid": "tbd7ouhuh0bhc4mlvtc4c0",
+      "cspResourceName": "tbd7ouhuh0bhc4mlvtc4c0",
+      "cspResourceId": "i-0c804300e25a9e689",
       "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -6539,14 +6517,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-04-28 13:56:47",
+      "createdTime": "2026-04-29 11:18:40",
       "label": {
-        "Name": "tbd7obp2cnprdfoa7dhvd0",
+        "Name": "tbd7ouhuh0bhc4mlvtc4c0",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-04-28 13:56:47",
-        "sys.cspResourceId": "i-078e8d26eaed7b73a",
-        "sys.cspResourceName": "tbd7obp2cnprdfoa7dhvd0",
+        "sys.createdTime": "2026-04-29 11:18:40",
+        "sys.cspResourceId": "i-0c804300e25a9e689",
+        "sys.cspResourceName": "tbd7ouhuh0bhc4mlvtc4c0",
         "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6555,7 +6533,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd7obp2cnprdfoa7dhvd0",
+        "sys.uid": "tbd7ouhuh0bhc4mlvtc4c0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6563,11 +6541,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.201.249.41",
+      "publicIP": "43.203.222.40",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.86",
-      "privateDNS": "ip-10-0-1-86.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.146",
+      "privateDNS": "ip-10-0-1-146.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 50,
       "RootDeviceName": "/dev/sda1",
@@ -6620,22 +6598,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-04235032ae43d3e1c",
+      "cspVNetId": "vpc-0700b9f9aa0f1f4ee",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0cd3c313e892c0e42",
-      "networkInterface": "eni-attach-08462239ee43a94d6",
+      "cspSubnetId": "subnet-06ade1584a33bb44a",
+      "networkInterface": "eni-attach-074db64960d965a8b",
       "securityGroupIds": [
         "my01-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd7obp0knprdfoa7dhv90",
+      "cspSshKeyId": "tbd7ouhsp0bhc4mlvtc480",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJWwlTZI5WBRhurwEJoTifemDZiNO1MqotFGn6VC4Qs5lruw7y9hT5iCmEP52A/SRfPug7XaEqzGfDkJyez8Y4s=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPQF1IZysPGHHT9k8h85k28UU53FlEv/P1jeUB7rBjUyqlsf0zcZ9BPWuQgMKDHPd6POiGOT9Q/P4Ukn+RlhxP8=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:LUHWnJdbGdaGKf4s9phDLh9izje2vxRPnunAUkDceV0",
-        "firstUsedAt": "2026-04-28T13:56:56Z"
+        "fingerprint": "SHA256:W49B55ZnQKo0VkNcLbPq6v83r3yGZ9MUxhpRaBtfUlo",
+        "firstUsedAt": "2026-04-29T11:18:50Z"
       },
       "commandStatus": [
         {
@@ -6643,11 +6621,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-04-28T13:56:55Z",
-          "completedTime": "2026-04-28T13:57:00Z",
-          "elapsedTime": 5,
+          "startedTime": "2026-04-29T11:18:50Z",
+          "completedTime": "2026-04-29T11:18:51Z",
+          "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-86 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-146 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6662,7 +6640,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-28T13:56:29Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-074af6b7f005c48fd}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-04-29T11:18:23Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0f87915239f0e2108}}"
         },
         {
           "key": "BootMode",
@@ -6674,7 +6652,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "62BFD880-DA15-41A6-ACE9-AD0A19794608"
+          "value": "97B683EF-2C32-44A9-B306-EA70446D8A51"
         },
         {
           "key": "CpuOptions",
@@ -6706,7 +6684,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-078e8d26eaed7b73a"
+          "value": "i-0c804300e25a9e689"
         },
         {
           "key": "InstanceType",
@@ -6714,11 +6692,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd7obp0knprdfoa7dhv90"
+          "value": "tbd7ouhsp0bhc4mlvtc480"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-04-28T13:56:29Z"
+          "value": "2026-04-29T11:18:22Z"
         },
         {
           "key": "MetadataOptions",
@@ -6730,7 +6708,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.249.41},Attachment:{AttachTime:2026-04-28T13:56:29Z,AttachmentId:eni-attach-08462239ee43a94d6,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-07e4e2b2ec9eaa901,GroupName:tbd7obp14nprdfoa7dhva0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:96:12:47:01:33,NetworkInterfaceId:eni-03997b3773398d964,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.86,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.249.41},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.86}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0cd3c313e892c0e42,VpcId:vpc-04235032ae43d3e1c}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.222.40},Attachment:{AttachTime:2026-04-29T11:18:22Z,AttachmentId:eni-attach-074db64960d965a8b,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0fc813b405734c9e2,GroupName:tbd7ouht90bhc4mlvtc490}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:08:ed:d8:ed:11,NetworkInterfaceId:eni-0dcbc68d05016ee19,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.146,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.222.40},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.146}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-06ade1584a33bb44a,VpcId:vpc-0700b9f9aa0f1f4ee}"
         },
         {
           "key": "Placement",
@@ -6738,15 +6716,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-86.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-146.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.86"
+          "value": "10.0.1.146"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.201.249.41"
+          "value": "43.203.222.40"
         },
         {
           "key": "RootDeviceName",
@@ -6758,7 +6736,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-07e4e2b2ec9eaa901,GroupName:tbd7obp14nprdfoa7dhva0}"
+          "value": "{GroupId:sg-0fc813b405734c9e2,GroupName:tbd7ouht90bhc4mlvtc490}"
         },
         {
           "key": "SourceDestCheck",
@@ -6770,11 +6748,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0cd3c313e892c0e42"
+          "value": "subnet-06ade1584a33bb44a"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd7obp2cnprdfoa7dhvd0}"
+          "value": "{Key:Name,Value:tbd7ouhuh0bhc4mlvtc4c0}"
         },
         {
           "key": "VirtualizationType",
@@ -6782,7 +6760,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-04235032ae43d3e1c"
+          "value": "vpc-0700b9f9aa0f1f4ee"
         }
       ]
     }
@@ -6799,12 +6777,12 @@
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "43.201.249.41",
+        "nodeIp": "43.203.222.40",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-86 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-146 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6814,31 +6792,23 @@
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "3.35.47.100",
+        "nodeIp": "52.79.76.8",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-161 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       },
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "3.36.100.61",
+        "nodeIp": "13.124.154.54",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-178 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       }
     ]
@@ -6892,8 +6862,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux ip-10-0-1-161 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "3.35.47.100",
+      "output": "Linux ip-10-0-1-54 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "52.79.76.8",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -6904,8 +6874,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux ip-10-0-1-178 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "3.36.100.61",
+      "output": "Linux ip-10-0-1-121 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "13.124.154.54",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -6916,8 +6886,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux ip-10-0-1-86 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "43.201.249.41",
+      "output": "Linux ip-10-0-1-146 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "43.203.222.40",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -6933,10 +6903,10 @@
 
 #### 7.1 API Request Information
 
-- **API Endpoint**: `GET /beetle/summary/target/ns/mig01/mci/{{mciId}}?format=md`
+- **API Endpoint**: `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}?format=md`
 - **Purpose**: Get a summary of the migrated target infrastructure in Markdown format
 - **Namespace ID**: `mig01`
-- **Path Parameter**: `{{mciId}}` - The MCI identifier
+- **Path Parameter**: `{{infraId}}` - The infra identifier
 - **Query Parameter**: `format=md`
 
 #### 7.2 API Response Information
@@ -6947,7 +6917,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-04-28 13:57:31
+**Generated At:** 2026-04-29 11:19:39
 
 **Namespace:** mig01
 
@@ -6989,9 +6959,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-0dcffe4e7071b2746 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 3.35.47.100<br>**Private IP:** 10.0.1.161<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-027506f1a6f19e6cc | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 3.36.100.61<br>**Private IP:** 10.0.1.178<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-078e8d26eaed7b73a | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.201.249.41<br>**Private IP:** 10.0.1.86<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-051ac9230d0bef1c9 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.79.76.8<br>**Private IP:** 10.0.1.54<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-037f076d3e4a7e58c | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 13.124.154.54<br>**Private IP:** 10.0.1.121<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0c804300e25a9e689 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.222.40<br>**Private IP:** 10.0.1.146<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
 
 
 ## Network Resources
@@ -7003,7 +6973,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-vnet-01 |
-| **CSP VNet ID** | vpc-04235032ae43d3e1c |
+| **CSP VNet ID** | vpc-0700b9f9aa0f1f4ee |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -7012,7 +6982,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my01-subnet-01 | subnet-0cd3c313e892c0e42 | 10.0.1.0/24 | ap-northeast-2a |
+| my01-subnet-01 | subnet-06ade1584a33bb44a | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -7021,7 +6991,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my01-sshkey-01 | tbd7obp0knprdfoa7dhv90 |  | 9e:d3:7e:6b:e0:d7:ca:8b:4a:0f:64:78:7f:fd:bd:92:6e:34:3c:01 |
+| my01-sshkey-01 | tbd7ouhsp0bhc4mlvtc480 |  | b5:b9:09:d2:f0:15:a8:83:bc:d9:2b:89:9f:53:ef:cb:99:d4:0f:4b |
 
 ### Security Groups
 
@@ -7030,7 +7000,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-01 |
-| **CSP Security Group ID** | sg-075064850b7083c10 |
+| **CSP Security Group ID** | sg-007b9eccfcda456c8 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -7058,7 +7028,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-02 |
-| **CSP Security Group ID** | sg-07e4e2b2ec9eaa901 |
+| **CSP Security Group ID** | sg-0fc813b405734c9e2 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7091,7 +7061,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-03 |
-| **CSP Security Group ID** | sg-047b340892e067e68 |
+| **CSP Security Group ID** | sg-0e188003866e69890 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7151,10 +7121,10 @@
 
 #### 8.1 API Request Information
 
-- **API Endpoint**: `POST /beetle/report/migration/ns/mig01/mci/{{mciId}}`
+- **API Endpoint**: `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}`
 - **Purpose**: Generate a comprehensive migration report matching source to target
 - **Namespace ID**: `mig01`
-- **Path Parameter**: `{{mciId}}` - The MCI identifier
+- **Path Parameter**: `{{infraId}}` - The infra identifier
 
 #### 8.2 API Response Information
 
@@ -7166,7 +7136,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-04-28 13:57:37*
+*Report generated: 2026-04-29 11:19:44*
 
 ---
 
@@ -7176,7 +7146,7 @@ This report provides a comprehensive summary of the infrastructure migration fro
 
 **Target Region:** ap-northeast-2
 
-**Namespace:** mig01 | **MCI ID:** my01-infra101
+**Namespace:** mig01 | **Infra ID:** my01-infra101
 
 **Migration Status:** Completed
 
@@ -7195,7 +7165,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | t3a.large, t3a.xlarge, t3a.small |
+| 2 | **VM Spec** | 3 | ✅ Selected | t3a.small, t3a.large, t3a.xlarge |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my01-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my01-vnet-01) |
@@ -7210,9 +7180,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-0dcffe4e7071b2746<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-027506f1a6f19e6cc<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-078e8d26eaed7b73a<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-051ac9230d0bef1c9<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-037f076d3e4a7e58c<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0c804300e25a9e689<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7246,7 +7216,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-01
 
-**CSP ID:** sg-075064850b7083c10 | **VNet:** my01-vnet-01 | **Rules:** 14
+**CSP ID:** sg-007b9eccfcda456c8 | **VNet:** my01-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7274,7 +7244,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-02
 
-**CSP ID:** sg-07e4e2b2ec9eaa901 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0fc813b405734c9e2 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7307,7 +7277,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-03
 
-**CSP ID:** sg-047b340892e067e68 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0e188003866e69890 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7348,13 +7318,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-04235032ae43d3e1c | 10.0.0.0/21 |
+| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-0700b9f9aa0f1f4ee | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0cd3c313e892c0e42 | 10.0.1.0/24 | my01-vnet-01 |
+| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-06ade1584a33bb44a | 10.0.1.0/24 | my01-vnet-01 |
 
 ### Source Network Information
 
@@ -7396,7 +7366,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my01-sshkey-01 | tbd7obp0knprdfoa7dhv90 | 9e:d3:7e:6b:e0:d7:ca:8b:4a:0f:64:78:7f:fd:bd:92:6e:34:3c:01 | Used by all 3 VMs |
+| 1 | my01-sshkey-01 | tbd7ouhsp0bhc4mlvtc480 | b5:b9:09:d2:f0:15:a8:83:bc:d9:2b:89:9f:53:ef:cb:99:d4:0f:4b | Used by all 3 VMs |
 
 ---
 
@@ -7431,10 +7401,10 @@ Summary of key infrastructure resources created or configured in the target clou
 
 #### 9.1 API Request Information
 
-- **API Endpoint**: `DELETE /beetle/migration/ns/mig01/mci/{{mciId}}`
+- **API Endpoint**: `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}`
 - **Purpose**: Delete the migrated infrastructure and clean up resources
 - **Namespace ID**: `mig01`
-- **Path Parameter**: `{{mciId}}` - The MCI identifier to delete
+- **Path Parameter**: `{{infraId}}` - The infra identifier to delete
 - **Query Parameter**: `option=terminate` (terminates all resources)
 - **Request Body**: None (DELETE request)
 

--- a/docs/ai-context-for-us.md
+++ b/docs/ai-context-for-us.md
@@ -107,7 +107,7 @@ The proposed commit title/message is then reviewed and finalized by the contribu
 Need documentation for an API endpoint? Use the Copilot CLI tool:
 
 ```bash
-make api-guide API_PATH=/migration/ns/{nsId}/mci
+make api-guide API_PATH=/migration/ns/{nsId}/infra
 ```
 
 This uses GitHub Copilot CLI to read our Swagger specs and generate comprehensive guides with realistic examples.

--- a/docs/api-guide-align-names.md
+++ b/docs/api-guide-align-names.md
@@ -41,12 +41,12 @@ Set the `nameSeed` field in your request to distinguish resources across paralle
 
 ### Late Binding Workflow
 
-| Step                   | API                             | Naming Behavior                                                                                       |
-| ---------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| 1. Recommend           | `POST /recommendation/vm-infra` | Returns **base names** (e.g., `vnet-01`). <br>Pre-flight validates `seed + name` without applying it. |
-| 2. Align (optional)    | `POST /naming/alignment`        | Rename a resource and propagate to child references.                                                  |
-| 3. Validate (optional) | `POST /naming/validation`       | Verify internal reference consistency.                                                                |
-| 4. Migrate             | `POST /migration/.../mci`       | Applies `NameSeed` → `{seed}-{name}` and creates resources.                                           |
+| Step                   | API                          | Naming Behavior                                                                                       |
+| ---------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1. Recommend           | `POST /recommendation/infra` | Returns **base names** (e.g., `vnet-01`). <br>Pre-flight validates `seed + name` without applying it. |
+| 2. Align (optional)    | `POST /naming/alignment`     | Rename a resource and propagate to child references.                                                  |
+| 3. Validate (optional) | `POST /naming/validation`    | Verify internal reference consistency.                                                                |
+| 4. Migrate             | `POST /migration/.../infra`  | Applies `NameSeed` → `{seed}-{name}` and creates resources.                                           |
 
 ---
 

--- a/docs/api-migration-guide-tb-v0.12.9.md
+++ b/docs/api-migration-guide-tb-v0.12.9.md
@@ -1,0 +1,241 @@
+# API Migration Guide — CM-Beetle (TB v0.12.9 Alignment)
+
+> **AI-assisted**: Generated with [GitHub Copilot](https://github.com/features/copilot) in VS Code (Model: Claude Sonnet 4.6)
+
+This document describes all **breaking API changes** introduced by the TB v0.12.9 alignment,
+merged on **2026-04-29** (base commit `7d0dc85`).
+These changes apply to all builds and releases from that merge onward.
+
+> **This is a clean break.** Old paths and field names are removed immediately.
+> No backwards-compatibility shims or dual keys are provided.
+
+---
+
+## Summary of Changes
+
+The outdated vocabulary `mci / vmInfra / vmSpec / vmOsImage` has been replaced uniformly with
+`infra / infra / spec / osImage`, matching CB-Tumblebug v0.12.9 terminology.
+
+---
+
+## BC-1 — URL Path Changes
+
+| Old Path                                       | New Path                                           |
+| ---------------------------------------------- | -------------------------------------------------- |
+| `POST /migration/ns/{nsId}/mci`                | `POST /migration/ns/{nsId}/infra`                  |
+| `POST /migration/ns/{nsId}/mciWithDefaults`    | `POST /migration/ns/{nsId}/infraWithDefaults`      |
+| `GET /migration/ns/{nsId}/mci`                 | `GET /migration/ns/{nsId}/infra`                   |
+| `GET /migration/ns/{nsId}/mci/{mciId}`         | `GET /migration/ns/{nsId}/infra/{infraId}`         |
+| `DELETE /migration/ns/{nsId}/mci/{mciId}`      | `DELETE /migration/ns/{nsId}/infra/{infraId}`      |
+| `POST /recommendation/vmInfra`                 | `POST /recommendation/infra`                       |
+| `POST /recommendation/mciWithDefaults`         | `POST /recommendation/infraWithDefaults`           |
+| `GET /summary/target/ns/{nsId}/mci/{mciId}`    | `GET /summary/target/ns/{nsId}/infra/{infraId}`    |
+| `POST /report/migration/ns/{nsId}/mci/{mciId}` | `POST /report/migration/ns/{nsId}/infra/{infraId}` |
+| `/recommendation/resources/vmSpecs`            | `/recommendation/resources/specs`                  |
+| `/recommendation/resources/vmOsImages`         | `/recommendation/resources/osImages`               |
+
+**Client action required**: Update all request URLs in your client code.
+
+---
+
+## BC-2 — URL Path Parameter Changes
+
+| Old Parameter | New Parameter |
+| ------------- | ------------- |
+| `{mciId}`     | `{infraId}`   |
+
+**Client action required**: Rename the path parameter variable in your URL templates.
+
+---
+
+## BC-3 — JSON Response Field Changes
+
+| Old Field                    | New Field                |
+| ---------------------------- | ------------------------ |
+| `targetVmInfra`              | `targetInfra`            |
+| `targetVmInfraList`          | `targetInfraList`        |
+| `targetVmSpec`               | `targetSpec`             |
+| `targetVmSpecList`           | `targetSpecList`         |
+| `targetVmOsImage`            | `targetOsImage`          |
+| `targetVmOsImageList`        | `targetOsImageList`      |
+| `recommendedVmSpecList`      | `recommendedSpecList`    |
+| `recommendedVmOsImageList`   | `recommendedOsImageList` |
+| `recommendedVmInfraModel`    | `recommendedInfraModel`  |
+| `mciId` (in report metadata) | `infraId`                |
+
+**Client action required**: Update JSON deserialization mappings and struct tags.
+
+---
+
+## BC-4 — Swagger Schema Type Name Changes
+
+| Old Type                        | New Type                      |
+| ------------------------------- | ----------------------------- |
+| `RecommendedVmInfra`            | `RecommendedInfra`            |
+| `RecommendedVmInfraModel`       | `RecommendedInfraModel`       |
+| `RecommendedVmInfraDynamic`     | `RecommendedInfraDynamic`     |
+| `RecommendedVmInfraDynamicList` | `RecommendedInfraDynamicList` |
+| `RecommendedVmSpec`             | `RecommendedSpec`             |
+| `RecommendedVmSpecList`         | `RecommendedSpecList`         |
+| `RecommendedVmOsImage`          | `RecommendedOsImage`          |
+| `RecommendedVmOsImageList`      | `RecommendedOsImageList`      |
+
+**Client action required**: Regenerate any auto-generated SDK or type stubs from the updated Swagger spec.
+
+---
+
+## BC-5 — Naming Enum Value Change
+
+The `resourceType` enum used by the naming/alignment API has changed:
+
+| Old Value | New Value |
+| --------- | --------- |
+| `mci`     | `infra`   |
+
+**Client action required**: Update any `resourceType=mci` enum references to `resourceType=infra`.
+
+---
+
+## BC-6 — Removed Endpoints
+
+The following endpoint has been **removed entirely** (it was already deprecated):
+
+| Removed Endpoint                      | Replacement                                                         |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| `POST /recommendation/mci`            | Use `POST /recommendation/infra`                                    |
+| `POST /recommendation/containerInfra` | No direct replacement (K8s recommendation uses dedicated endpoints) |
+
+---
+
+## Before / After Examples
+
+### Migrate Infrastructure
+
+**Before (v0.4.x):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/migration/ns/mig01/mci \
+  -H "Content-Type: application/json" \
+  -d '{ "onpremiseInfraModel": { ... } }'
+```
+
+**After (this change):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/migration/ns/mig01/infra \
+  -H "Content-Type: application/json" \
+  -d '{ "onpremiseInfraModel": { ... } }'
+```
+
+---
+
+### Get Specific Infrastructure
+
+**Before (v0.4.x):**
+
+```bash
+curl http://localhost:8056/beetle/migration/ns/mig01/mci/infra01
+```
+
+**After (this change):**
+
+```bash
+curl http://localhost:8056/beetle/migration/ns/mig01/infra/infra01
+```
+
+---
+
+### Recommend VM Infrastructure
+
+**Before (v0.4.x):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/recommendation/vmInfra \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+```
+
+**After (this change):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/recommendation/infra \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+```
+
+---
+
+### Target Infrastructure Summary
+
+**Before (v0.4.x):**
+
+```bash
+curl "http://localhost:8056/beetle/summary/target/ns/mig01/mci/infra01?format=md"
+```
+
+**After (this change):**
+
+```bash
+curl "http://localhost:8056/beetle/summary/target/ns/mig01/infra/infra01?format=md"
+```
+
+---
+
+### Migration Report
+
+**Before (v0.4.x):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/report/migration/ns/mig01/mci/infra01 \
+  -H "Content-Type: application/json" \
+  -d '{ "onpremiseInfraModel": { ... } }'
+```
+
+**After (this change):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/report/migration/ns/mig01/infra/infra01 \
+  -H "Content-Type: application/json" \
+  -d '{ "onpremiseInfraModel": { ... } }'
+```
+
+---
+
+### Recommend VM Specs
+
+**Before (v0.4.x):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/recommendation/resources/vmSpecs \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+```
+
+**After (this change):**
+
+```bash
+curl -X POST http://localhost:8056/beetle/recommendation/resources/specs \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+```
+
+---
+
+## Deprecation and Sunset Policy
+
+This is a **clean break** change. Old paths are removed immediately with no redirect:
+
+- No 307 redirects are provided for old paths.
+- Requests to old paths will return `404 Not Found`.
+- Clients must update to new paths before pulling builds from commit `7d0dc85` or later.
+
+---
+
+## Checklist for Client Upgrade
+
+- [ ] Update all API request URLs (`/mci` → `/infra`, `/vmInfra` → `/infra`, etc.)
+- [ ] Update path parameter names (`{mciId}` → `{infraId}`)
+- [ ] Update JSON response field mappings (see BC-3)
+- [ ] Regenerate SDK stubs from the new Swagger spec (see BC-4)
+- [ ] Update `resourceType=mci` enum to `resourceType=infra` (see BC-5)
+- [ ] Remove calls to `POST /recommendation/mci` and `POST /recommendation/containerInfra` (see BC-6)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ go 1.26.2
 
 require (
 	github.com/cloud-barista/cb-tumblebug v0.12.9
-	github.com/cloud-barista/cm-beetle/imdl v0.1.1
+	github.com/cloud-barista/cm-beetle/imdl v0.1.2
 	github.com/cloud-barista/cm-beetle/transx v0.1.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-playground/validator/v10 v10.30.2

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/cloud-barista/cb-tumblebug v0.12.9 h1:d1m2sdmVAw9u1bXL920aRKs5UBTx5G8
 github.com/cloud-barista/cb-tumblebug v0.12.9/go.mod h1:MUMXO9BWx5AJpZl/yapk5W44EIG5Po19hgnE1Rt/g5k=
 github.com/cloud-barista/cm-beetle/imdl v0.1.1 h1:0YqkjBTq7Mgo7sHf2PcIf8VYSPrwhYcHX1kBl+o5TIM=
 github.com/cloud-barista/cm-beetle/imdl v0.1.1/go.mod h1:RfpzPB67XRW5TDGs5f4Cv/W/zJ3c+eU8eV291oj+ns0=
+github.com/cloud-barista/cm-beetle/imdl v0.1.2 h1:uTEw4VF6T1ZjJ2+3TigO8FxX44Fs21/F24+tPmPNG6o=
+github.com/cloud-barista/cm-beetle/imdl v0.1.2/go.mod h1:RfpzPB67XRW5TDGs5f4Cv/W/zJ3c+eU8eV291oj+ns0=
 github.com/cloud-barista/cm-beetle/transx v0.1.0 h1:DVQSslEnaVGjuJ+VtIq/2Rr/E7hjsvFja4Gy4kzhUpE=
 github.com/cloud-barista/cm-beetle/transx v0.1.0/go.mod h1:lEgonyJmSY6L7cBLNS1YItx7Pw1nN48j6y9pquBHyDQ=
 github.com/cloud-barista/mc-terrarium v0.1.4 h1:w60hp6lEquL41/f1L08E9qchm7qL9hfiyr3AXASZIdI=

--- a/pkg/api/rest/controller/migration.go
+++ b/pkg/api/rest/controller/migration.go
@@ -54,7 +54,7 @@ type MigrateInfraWithDefaultsResponse struct {
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
 // @Success 201 {object} model.ApiResponse[MigrateInfraWithDefaultsResponse] "Successfully migrated to the multi-cloud infrastructure"
 // @Failure 500 {object} model.ApiResponse[any]
-// @Router /migration/ns/{nsId}/mciWithDefaults [post]
+// @Router /migration/ns/{nsId}/infraWithDefaults [post]
 func MigrateInfraWithDefaults(c echo.Context) error {
 
 	// [Input]
@@ -93,7 +93,7 @@ func MigrateInfraWithDefaults(c echo.Context) error {
 // TODO: Check and dev the request and response bodies for the following API
 
 type MigrateInfraRequest struct {
-	cloudmodel.RecommendedVmInfra
+	cloudmodel.RecommendedInfra
 }
 
 type MigrateInfraResponse struct {
@@ -108,12 +108,12 @@ type MigrateInfraResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(mig01)
-// @Param mciInfo body MigrateInfraRequest true "Specify the information for the targeted mulci-cloud infrastructure (MCI)"
+// @Param infraInfo body MigrateInfraRequest true "Specify the information for the targeted multi-cloud infrastructure"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
 // @Success 201 {object} model.ApiResponse[MigrateInfraResponse] "Successfully migrated to the multi-cloud infrastructure"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
-// @Router /migration/ns/{nsId}/mci [post]
+// @Router /migration/ns/{nsId}/infra [post]
 func MigrateInfra(c echo.Context) error {
 
 	// [Input]
@@ -131,11 +131,11 @@ func MigrateInfra(c echo.Context) error {
 	}
 
 	// log.Debug().Msgf("req: %+v", req)
-	log.Debug().Msgf("req.RecommendedVmInfra: %+v", req.RecommendedVmInfra)
+	log.Debug().Msgf("req.RecommendedVmInfra: %+v", req.RecommendedInfra)
 
 	// [Process]
 	// Apply NameSeed (Late Binding) before migration
-	infraToMigrate := common.ApplyNameSeed(req.RecommendedVmInfra)
+	infraToMigrate := common.ApplyNameSeed(req.RecommendedInfra)
 
 	// Validate names and referential integrity
 	if ok, detail := common.ValidateComposedNames(infraToMigrate); !ok {
@@ -171,7 +171,7 @@ func MigrateInfra(c echo.Context) error {
 // @Success 200 {object} model.ApiResponse[cloudmodel.IdList] "The ID list of The migrated multi-cloud infrastructure (Infra)"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
-// @Router /migration/ns/{nsId}/mci [get]
+// @Router /migration/ns/{nsId}/infra [get]
 func ListInfra(c echo.Context) error {
 
 	// [Input]
@@ -219,12 +219,12 @@ func ListInfra(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(mig01)
-// @Param mciId path string true "Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')" default(my-infra101)
+// @Param infraId path string true "Migrated Cloud Infrastructure ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')" default(my-infra101)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[MigrateInfraResponse] "The migrated multi-cloud infrastructure (MCI) information"
+// @Success 200 {object} model.ApiResponse[MigrateInfraResponse] "The migrated multi-cloud infrastructure information"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
-// @Router /migration/ns/{nsId}/mci/{mciId} [get]
+// @Router /migration/ns/{nsId}/infra/{infraId} [get]
 func GetInfra(c echo.Context) error {
 
 	// [Input]
@@ -236,15 +236,15 @@ func GetInfra(c echo.Context) error {
 	}
 	// nsId := common.DefaultNamespaceId
 
-	mciId := c.Param("mciId")
-	if mciId == "" {
-		err := fmt.Errorf("invalid request, the multi-cloud infrastructure ID (mciId: %s) is required", mciId)
+	infraId := c.Param("infraId")
+	if infraId == "" {
+		err := fmt.Errorf("invalid request, the cloud infrastructure ID (infraId: %s) is required", infraId)
 		log.Warn().Msg(err.Error())
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse(err.Error()))
 	}
 
 	// [Process]
-	vmInfraInfo, err := migration.GetVMInfra(nsId, mciId)
+	vmInfraInfo, err := migration.GetVMInfra(nsId, infraId)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to get the migrated multi-cloud infrastructure")
 
@@ -267,13 +267,13 @@ func GetInfra(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(mig01)
-// @Param mciId path string true "Migrated Multi-Cloud Infrastructure (MCI) ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')" default(my-infra101)
+// @Param infraId path string true "Migrated Cloud Infrastructure ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')" default(my-infra101)
 // @Param option query string false "Option for deletion" Enums(terminate,force) default(terminate)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[any] "The result of deleting the migrated multi-cloud infrastructure (MCI)"
+// @Success 200 {object} model.ApiResponse[any] "The result of deleting the migrated multi-cloud infrastructure"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
-// @Router /migration/ns/{nsId}/mci/{mciId} [delete]
+// @Router /migration/ns/{nsId}/infra/{infraId} [delete]
 func DeleteInfra(c echo.Context) error {
 
 	// [Input]
@@ -285,9 +285,9 @@ func DeleteInfra(c echo.Context) error {
 	}
 	// nsId := common.DefaultNamespaceId
 
-	mciId := c.Param("mciId")
-	if mciId == "" {
-		err := fmt.Errorf("invalid request, the multi-cloud infrastructure ID (mciId: %s) is required", mciId)
+	infraId := c.Param("infraId")
+	if infraId == "" {
+		err := fmt.Errorf("invalid request, the cloud infrastructure ID (infraId: %s) is required", infraId)
 		log.Warn().Msg(err.Error())
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse(err.Error()))
 	}
@@ -300,7 +300,7 @@ func DeleteInfra(c echo.Context) error {
 	}
 
 	// [Process]
-	retMsg, err := migration.DeleteVMInfra(nsId, mciId, option)
+	retMsg, err := migration.DeleteVMInfra(nsId, infraId, option)
 
 	if err != nil {
 		log.Error().Err(err).Msg("failed to delete the migrated multi-cloud infrastructure")

--- a/pkg/api/rest/controller/naming.go
+++ b/pkg/api/rest/controller/naming.go
@@ -35,7 +35,7 @@ import (
 // @Description - `subnet` : Rename Subnet → propagates to SubGroup.SubnetId
 // @Description - `sshKey` : Rename SSH Key → propagates to SubGroup.SshKeyId
 // @Description - `securityGroup` : Rename SecurityGroup → propagates to SubGroup.SecurityGroupIds
-// @Description - `mci` : Rename MCI (no child propagation)
+// @Description - `infra` : Rename Infra (no child propagation)
 // @Description
 // @Description After propagation, names are validated with NameSeed applied (pre-flight check).
 // @Description The returned model uses **base names only** (NameSeed is applied at migration time).
@@ -45,12 +45,12 @@ import (
 // @Tags [Infrastructure] Resource Naming
 // @Accept  json
 // @Produce  json
-// @Param resourceType query string true "Resource type to rename" Enums(vNet,subnet,securityGroup,sshKey,mci)
+// @Param resourceType query string true "Resource type to rename" Enums(vNet,subnet,securityGroup,sshKey,infra)
 // @Param oldName query string true "Current name of the resource (before change)"
 // @Param newName query string true "New name of the resource (after change)"
-// @Param UserInfra body cloudmodel.RecommendedVmInfra true "The recommendation model to update"
+// @Param UserInfra body cloudmodel.RecommendedInfra true "The recommendation model to update"
 // @Param X-Request-Id header string false "Unique request ID"
-// @Success 200 {object} model.ApiResponse[cloudmodel.RecommendedVmInfra] "Updated and validated model (base names)"
+// @Success 200 {object} model.ApiResponse[cloudmodel.RecommendedInfra] "Updated and validated model (base names)"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request or referential integrity failure"
 // @Router /naming/alignment [post]
 func AlignNames(c echo.Context) error {
@@ -62,7 +62,7 @@ func AlignNames(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("query params 'resourceType', 'oldName', and 'newName' are all required"))
 	}
 
-	req := &cloudmodel.RecommendedVmInfra{}
+	req := &cloudmodel.RecommendedInfra{}
 	if err := c.Bind(req); err != nil {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request body format"))
 	}
@@ -85,20 +85,20 @@ func AlignNames(c echo.Context) error {
 // ValidateNames godoc
 // @ID ValidateNames
 // @Summary Validate resource names and referential integrity
-// @Description Validates that all internal references within a RecommendedVmInfra model
+// @Description Validates that all internal references within a RecommendedInfra model
 // @Description are consistent and point to existing resources.
 // @Description NameSeed is NOT applied here; this validates the base names only.
 // @Description
 // @Tags [Infrastructure] Resource Naming
 // @Accept  json
 // @Produce  json
-// @Param UserInfra body cloudmodel.RecommendedVmInfra true "The recommendation model to validate"
+// @Param UserInfra body cloudmodel.RecommendedInfra true "The recommendation model to validate"
 // @Param X-Request-Id header string false "Unique request ID"
 // @Success 200 {object} model.ApiResponse[any] "Naming and referential integrity are valid"
 // @Failure 400 {object} model.ApiResponse[any] "Referential integrity validation failure"
 // @Router /naming/validation [post]
 func ValidateNames(c echo.Context) error {
-	req := &cloudmodel.RecommendedVmInfra{}
+	req := &cloudmodel.RecommendedInfra{}
 	if err := c.Bind(req); err != nil {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
 	}

--- a/pkg/api/rest/controller/recommendation-resource.go
+++ b/pkg/api/rest/controller/recommendation-resource.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
-	"github.com/cloud-barista/cm-beetle/pkg/core/recommendation"
 	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
 	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
+	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
+	"github.com/cloud-barista/cm-beetle/pkg/core/recommendation"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -38,7 +38,7 @@ import (
 // @Tags [Recommendation] Resources for VM infrastructure
 // @Accept json
 // @Produce	json
-// @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
+// @Param UserInfra body RecommendInfraRequest true "Specify the your infrastructure to be migrated"
 // @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
@@ -49,7 +49,7 @@ import (
 func RecommendVNet(c echo.Context) error {
 
 	// [Input]
-	var req RecommendVmInfraRequest
+	var req RecommendInfraRequest
 	if err := c.Bind(&req); err != nil {
 		log.Warn().Err(err).Msg("failed to bind request body")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
@@ -109,7 +109,7 @@ func RecommendVNet(c echo.Context) error {
 // @Tags [Recommendation] Resources for VM infrastructure
 // @Accept  json
 // @Produce  json
-// @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
+// @Param UserInfra body RecommendInfraRequest true "Specify the your infrastructure to be migrated"
 // @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
@@ -120,7 +120,7 @@ func RecommendVNet(c echo.Context) error {
 func RecommendSecurityGroups(c echo.Context) error {
 
 	// [Input]
-	var req RecommendVmInfraRequest
+	var req RecommendInfraRequest
 	if err := c.Bind(&req); err != nil {
 		log.Warn().Err(err).Msg("failed to bind request body")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
@@ -156,7 +156,7 @@ func RecommendSecurityGroups(c echo.Context) error {
 }
 
 type RecommendVmSpecResponse struct {
-	cloudmodel.RecommendedVmSpecList
+	cloudmodel.RecommendedSpecList
 }
 
 // RecommendVmSpecs godoc
@@ -172,19 +172,19 @@ type RecommendVmSpecResponse struct {
 // @Tags [Recommendation] Resources for VM infrastructure
 // @Accept  json
 // @Produce  json
-// @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
+// @Param UserInfra body RecommendInfraRequest true "Specify the your infrastructure to be migrated"
 // @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param targetMachineId query string false "Target Machine ID to focus recommendation on (optional)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[cloudmodel.RecommendedVmSpecList] "Successfully recommended VM spec(s)"
+// @Success 200 {object} model.ApiResponse[cloudmodel.RecommendedSpecList] "Successfully recommended VM spec(s)"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during recommendation"
-// @Router /recommendation/resources/vmSpecs [post]
+// @Router /recommendation/resources/specs [post]
 func RecommendVmSpecs(c echo.Context) error {
 
 	// [Input]
-	var req RecommendVmInfraRequest
+	var req RecommendInfraRequest
 	if err := c.Bind(&req); err != nil {
 		log.Warn().Err(err).Msg("failed to bind request body")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
@@ -237,7 +237,7 @@ func RecommendVmSpecs(c echo.Context) error {
 	}
 
 	// [Process]
-	recommendedVmSpecList := cloudmodel.RecommendedVmSpecList{}
+	recommendedVmSpecList := cloudmodel.RecommendedSpecList{}
 	for i, server := range serversToProcess {
 
 		specsLimit := recommendation.GetDefaultSpecsLimit()
@@ -248,26 +248,26 @@ func RecommendVmSpecs(c echo.Context) error {
 		if err != nil {
 			log.Error().Err(err).Msg("failed to recommend VM specs")
 
-			temp := cloudmodel.RecommendedVmSpec{
+			temp := cloudmodel.RecommendedSpec{
 				SourceServers: []string{server.MachineId}, // Set MachineId to identify the source server
 				Description:   fmt.Sprintf("failed to recommend VM specs for server %d: %s", i+1, server.MachineId),
 				Status:        string(recommendation.NothingRecommended),
-				TargetVmSpec:  cloudmodel.SpecInfo{},
+				TargetSpec:    cloudmodel.SpecInfo{},
 			}
-			recommendedVmSpecList.RecommendedVmSpecList = append(recommendedVmSpecList.RecommendedVmSpecList, temp)
+			recommendedVmSpecList.RecommendedSpecList = append(recommendedVmSpecList.RecommendedSpecList, temp)
 			continue
 		}
 		log.Trace().Msgf("specList: %v, count: %d", specList, count)
 		if count == 0 {
 			log.Warn().Msgf("no VM specs recommended for server: %s", server.MachineId)
 
-			temp := cloudmodel.RecommendedVmSpec{
+			temp := cloudmodel.RecommendedSpec{
 				SourceServers: []string{server.MachineId}, // Set MachineId to identify the source server
 				Description:   fmt.Sprintf("no VM specs recommended for server %d: %s", i+1, server.MachineId),
 				Status:        string(recommendation.NothingRecommended),
-				TargetVmSpec:  cloudmodel.SpecInfo{},
+				TargetSpec:    cloudmodel.SpecInfo{},
 			}
-			recommendedVmSpecList.RecommendedVmSpecList = append(recommendedVmSpecList.RecommendedVmSpecList, temp)
+			recommendedVmSpecList.RecommendedSpecList = append(recommendedVmSpecList.RecommendedSpecList, temp)
 			continue
 		}
 
@@ -276,8 +276,8 @@ func RecommendVmSpecs(c echo.Context) error {
 			// Check if the spec already exists in the list
 			exists := false
 			idx := -1
-			for i, existingSpec := range recommendedVmSpecList.RecommendedVmSpecList {
-				if existingSpec.TargetVmSpec.Id == spec.Id {
+			for i, existingSpec := range recommendedVmSpecList.RecommendedSpecList {
+				if existingSpec.TargetSpec.Id == spec.Id {
 					exists = true
 					idx = i
 					break
@@ -287,31 +287,31 @@ func RecommendVmSpecs(c echo.Context) error {
 			// If the spec already exists, append the server to the existing list
 			// Otherwise, create a new entry
 			if exists {
-				recommendedVmSpecList.RecommendedVmSpecList[idx].SourceServers = append(
-					recommendedVmSpecList.RecommendedVmSpecList[idx].SourceServers,
+				recommendedVmSpecList.RecommendedSpecList[idx].SourceServers = append(
+					recommendedVmSpecList.RecommendedSpecList[idx].SourceServers,
 					server.MachineId, // Set MachineId to identify the source server
 				)
 			} else {
-				temp := cloudmodel.RecommendedVmSpec{
+				temp := cloudmodel.RecommendedSpec{
 					Status:        string(recommendation.FullyRecommended),
 					SourceServers: []string{server.MachineId}, // Set MachineId to identify the source server
 					Description:   fmt.Sprintf("Recommended VM spec for server %d: %s", i+1, server.MachineId),
-					TargetVmSpec:  spec,
+					TargetSpec:    spec,
 				}
-				recommendedVmSpecList.RecommendedVmSpecList = append(recommendedVmSpecList.RecommendedVmSpecList, temp)
+				recommendedVmSpecList.RecommendedSpecList = append(recommendedVmSpecList.RecommendedSpecList, temp)
 			}
 		}
 	}
 
 	// [Output]
 	countFailed := 0
-	for _, spec := range recommendedVmSpecList.RecommendedVmSpecList {
+	for _, spec := range recommendedVmSpecList.RecommendedSpecList {
 		if spec.Status == string(recommendation.NothingRecommended) {
 			countFailed++
 		}
 	}
 
-	recommendedVmSpecList.Count = len(recommendedVmSpecList.RecommendedVmSpecList)
+	recommendedVmSpecList.Count = len(recommendedVmSpecList.RecommendedSpecList)
 	switch countFailed {
 	case 0:
 		recommendedVmSpecList.Status = string(recommendation.FullyRecommended)
@@ -363,17 +363,17 @@ func RecommendVmSpecs(c echo.Context) error {
 // @Tags [Recommendation] Resources for VM infrastructure
 // @Accept  json
 // @Produce  json
-// @Param UserInfra body RecommendVmInfraRequest true "Specify the your infrastructure to be migrated"
+// @Param UserInfra body RecommendInfraRequest true "Specify the your infrastructure to be migrated"
 // @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[cloudmodel.RecommendedVmOsImageList] "Successfully recommended VM OS image(s)"
+// @Success 200 {object} model.ApiResponse[cloudmodel.RecommendedOsImageList] "Successfully recommended VM OS image(s)"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during recommendation"
-// @Router /recommendation/resources/vmOsImages [post]
+// @Router /recommendation/resources/osImages [post]
 func RecommendVmOsImages(c echo.Context) error {
 	// [Input]
-	var req RecommendVmInfraRequest
+	var req RecommendInfraRequest
 	if err := c.Bind(&req); err != nil {
 		log.Warn().Err(err).Msg("failed to bind request body")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
@@ -394,7 +394,7 @@ func RecommendVmOsImages(c echo.Context) error {
 	}
 
 	// [Process]
-	recommendedOsImageList := cloudmodel.RecommendedVmOsImageList{}
+	recommendedOsImageList := cloudmodel.RecommendedOsImageList{}
 	for i, server := range req.OnpremiseInfraModel.Servers {
 
 		imagesLimit := recommendation.GetDefaultImagesLimit()
@@ -404,26 +404,26 @@ func RecommendVmOsImages(c echo.Context) error {
 		if err != nil {
 			log.Error().Err(err).Msg("failed to recommend VM OS images")
 
-			temp := cloudmodel.RecommendedVmOsImage{
-				Status:          string(recommendation.NothingRecommended),
-				SourceServers:   []string{server.MachineId}, // Set MachineId to identify the source server
-				Description:     fmt.Sprintf("Failed to recommend VM OS images for server %d: %s", i+1, server.MachineId),
-				TargetVmOsImage: cloudmodel.ImageInfo{},
+			temp := cloudmodel.RecommendedOsImage{
+				Status:        string(recommendation.NothingRecommended),
+				SourceServers: []string{server.MachineId}, // Set MachineId to identify the source server
+				Description:   fmt.Sprintf("Failed to recommend VM OS images for server %d: %s", i+1, server.MachineId),
+				TargetOsImage: cloudmodel.ImageInfo{},
 			}
-			recommendedOsImageList.RecommendedVmOsImageList = append(recommendedOsImageList.RecommendedVmOsImageList, temp)
+			recommendedOsImageList.RecommendedOsImageList = append(recommendedOsImageList.RecommendedOsImageList, temp)
 			continue
 		}
 
 		if len(vmOsImageList) == 0 {
 			log.Warn().Msgf("no VM OS images recommended for server: %s", server.MachineId)
 
-			temp := cloudmodel.RecommendedVmOsImage{
-				Status:          string(recommendation.NothingRecommended),
-				SourceServers:   []string{server.MachineId}, // Set MachineId to identify the source server
-				Description:     fmt.Sprintf("No VM OS images recommended for server %d: %s", i+1, server.MachineId),
-				TargetVmOsImage: cloudmodel.ImageInfo{},
+			temp := cloudmodel.RecommendedOsImage{
+				Status:        string(recommendation.NothingRecommended),
+				SourceServers: []string{server.MachineId}, // Set MachineId to identify the source server
+				Description:   fmt.Sprintf("No VM OS images recommended for server %d: %s", i+1, server.MachineId),
+				TargetOsImage: cloudmodel.ImageInfo{},
 			}
-			recommendedOsImageList.RecommendedVmOsImageList = append(recommendedOsImageList.RecommendedVmOsImageList, temp)
+			recommendedOsImageList.RecommendedOsImageList = append(recommendedOsImageList.RecommendedOsImageList, temp)
 			continue
 		}
 
@@ -432,8 +432,8 @@ func RecommendVmOsImages(c echo.Context) error {
 			// Check if the OS image already exists in the list
 			exists := false
 			idx := -1
-			for i, existingOsImage := range recommendedOsImageList.RecommendedVmOsImageList {
-				if existingOsImage.TargetVmOsImage.Id == vmOsImage.Id {
+			for i, existingOsImage := range recommendedOsImageList.RecommendedOsImageList {
+				if existingOsImage.TargetOsImage.Id == vmOsImage.Id {
 					exists = true
 					idx = i
 					break
@@ -442,30 +442,30 @@ func RecommendVmOsImages(c echo.Context) error {
 			// If the OS image already exists, append the server to the existing list
 			// Otherwise, create a new entry
 			if exists {
-				recommendedOsImageList.RecommendedVmOsImageList[idx].SourceServers = append(
-					recommendedOsImageList.RecommendedVmOsImageList[idx].SourceServers,
+				recommendedOsImageList.RecommendedOsImageList[idx].SourceServers = append(
+					recommendedOsImageList.RecommendedOsImageList[idx].SourceServers,
 					server.MachineId, // Set MachineId to identify the source server
 				)
 			} else {
-				temp := cloudmodel.RecommendedVmOsImage{
-					Status:          string(recommendation.FullyRecommended),
-					SourceServers:   []string{server.MachineId}, // Set MachineId to identify the source server
-					Description:     fmt.Sprintf("Recommended VM OS image for server %d: %s", i+1, server.MachineId),
-					TargetVmOsImage: vmOsImage,
+				temp := cloudmodel.RecommendedOsImage{
+					Status:        string(recommendation.FullyRecommended),
+					SourceServers: []string{server.MachineId}, // Set MachineId to identify the source server
+					Description:   fmt.Sprintf("Recommended VM OS image for server %d: %s", i+1, server.MachineId),
+					TargetOsImage: vmOsImage,
 				}
-				recommendedOsImageList.RecommendedVmOsImageList = append(recommendedOsImageList.RecommendedVmOsImageList, temp)
+				recommendedOsImageList.RecommendedOsImageList = append(recommendedOsImageList.RecommendedOsImageList, temp)
 			}
 		}
 	}
 
 	// [Output]
 	countFailed := 0
-	for _, osImage := range recommendedOsImageList.RecommendedVmOsImageList {
+	for _, osImage := range recommendedOsImageList.RecommendedOsImageList {
 		if osImage.Status == string(recommendation.NothingRecommended) {
 			countFailed++
 		}
 	}
-	recommendedOsImageList.Count = len(recommendedOsImageList.RecommendedVmOsImageList)
+	recommendedOsImageList.Count = len(recommendedOsImageList.RecommendedOsImageList)
 	successCount := recommendedOsImageList.Count - countFailed
 	switch countFailed {
 	case 0:

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -39,13 +39,13 @@ import (
  * VM Infrastructure Recommendation
  */
 
-type RecommendVmInfraWithDefaultsRequest struct {
+type RecommendInfraWithDefaultsRequest struct {
 	DesiredCspAndRegionPair cloudmodel.CloudProperty `json:"desiredCspAndRegionPair"`
 	OnpremiseInfraModel     onpremmodel.OnpremInfra
 }
 
-type RecommendVmInfraWithDefaultsResponse struct {
-	cloudmodel.RecommendedVmInfraDynamicList
+type RecommendInfraWithDefaultsResponse struct {
+	cloudmodel.RecommendedInfraDynamicList
 }
 
 // RecommendVMInfraWithDefaults godoc
@@ -60,21 +60,21 @@ type RecommendVmInfraWithDefaultsResponse struct {
 // @Tags [Recommendation] Infrastructure
 // @Accept  json
 // @Produce  json
-// @Param UserInfra body RecommendVmInfraWithDefaultsRequest true "Specify the source infrastructure to be migrated"
+// @Param UserInfra body RecommendInfraWithDefaultsRequest true "Specify the source infrastructure to be migrated"
 // @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[RecommendVmInfraWithDefaultsResponse] "The result of recommended infrastructure"
+// @Success 200 {object} model.ApiResponse[RecommendInfraWithDefaultsResponse] "The result of recommended infrastructure"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
-// @Router /recommendation/mciWithDefaults [post]
+// @Router /recommendation/infraWithDefaults [post]
 func RecommendVMInfraWithDefaults(c echo.Context) error {
 
 	// [Input]
 	desiredCsp := c.QueryParam("desiredCsp")
 	desiredRegion := c.QueryParam("desiredRegion")
 
-	reqt := &RecommendVmInfraWithDefaultsRequest{}
+	reqt := &RecommendInfraWithDefaultsRequest{}
 	if err := c.Bind(reqt); err != nil {
 		log.Warn().Err(err).Msg("failed to bind a request body")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
@@ -119,85 +119,14 @@ func RecommendVMInfraWithDefaults(c echo.Context) error {
 	return c.JSON(http.StatusOK, model.SuccessResponse(recommendedInfraInfoList))
 }
 
-type RecommendVmInfraRequest struct {
+type RecommendInfraRequest struct {
 	NameSeed                string                   `json:"nameSeed" example:"my"` // Base string for resource name prefix (e.g., 'my' -> 'my-vnet-01')
 	DesiredCspAndRegionPair cloudmodel.CloudProperty `json:"desiredCspAndRegionPair"`
 	OnpremiseInfraModel     onpremmodel.OnpremInfra
 }
 
-type RecommendVmInfraResponse struct {
-	cloudmodel.RecommendedVmInfra
-}
-
-// RecommendVMInfra godoc
-// @ID RecommendVMInfra
-// @Summary **(To be deprecated)** Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration
-// @Description **(To be deprecated)** Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration
-// @Description
-// @Description [Note] `desiredCsp` and `desiredRegion` are required.
-// @Description - `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.
-// @Description
-// @Description - If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.
-// @Tags [Recommendation] Infrastructure
-// @Accept  json
-// @Produce  json
-// @Param UserInfra body RecommendVmInfraRequest true "Specify the source infrastructure to be migrated"
-// @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
-// @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
-// @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[RecommendVmInfraResponse] "The result of recommended infrastructure"
-// @Failure 404 {object} model.ApiResponse[any]
-// @Failure 500 {object} model.ApiResponse[any]
-// @Router /recommendation/mci [post]
-func RecommendVMInfra(c echo.Context) error {
-
-	// [Input]
-	desiredCsp := c.QueryParam("desiredCsp")
-	desiredRegion := c.QueryParam("desiredRegion")
-
-	reqt := &RecommendVmInfraRequest{}
-	if err := c.Bind(reqt); err != nil {
-		log.Warn().Err(err).Msg("failed to bind a request body")
-		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
-	}
-	log.Trace().Msgf("reqt: %v\n", reqt)
-
-	if reqt.DesiredCspAndRegionPair.Csp == "" && desiredCsp == "" {
-		log.Warn().Msg("desiredCsp is required")
-		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Provider required"))
-	}
-	if reqt.DesiredCspAndRegionPair.Region == "" && desiredRegion == "" {
-		log.Warn().Msg("desiredRegion is required")
-		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Region required"))
-	}
-
-	csp := reqt.DesiredCspAndRegionPair.Csp
-	if csp == "" {
-		csp = desiredCsp
-	}
-	region := reqt.DesiredCspAndRegionPair.Region
-	if region == "" {
-		region = desiredRegion
-	}
-	sourceInfra := reqt.OnpremiseInfraModel
-
-	ok, err := recommendation.IsValidCspAndRegion(csp, region)
-	if !ok {
-		log.Error().Err(err).Msg("failed to validate CSP and region")
-		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid provider or region"))
-	}
-
-	// [Process]
-	recommendedInfra, err := recommendation.RecommendVmInfra(csp, region, sourceInfra)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to recommend an appropriate multi-cloud infrastructure (MCI) for cloud migration")
-		return c.JSON(http.StatusNotFound, model.SimpleErrorResponse("Recommendation failed"))
-	}
-
-	// [Ouput]
-	//
-
-	return c.JSON(http.StatusOK, model.SuccessResponse(recommendedInfra))
+type RecommendInfraResponse struct {
+	cloudmodel.RecommendedInfra
 }
 
 // RecommendVmInfraCandidates godoc
@@ -226,16 +155,16 @@ func RecommendVMInfra(c echo.Context) error {
 // @Tags [Recommendation] Infrastructure
 // @Accept  json
 // @Produce  json
-// @Param UserInfra body RecommendVmInfraRequest true "Specify the source infrastructure to be migrated"
+// @Param UserInfra body RecommendInfraRequest true "Specify the source infrastructure to be migrated"
 // @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param limit query int false "Limit (default: 3) the number of recommended infrastructures"
 // @Param minMatchRate query number false "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[[]cloudmodel.RecommendedVmInfra] "Successfully recommended infrastructure candidates"
+// @Success 200 {object} model.ApiResponse[[]cloudmodel.RecommendedInfra] "Successfully recommended infrastructure candidates"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during recommendation"
-// @Router /recommendation/vmInfra [post]
+// @Router /recommendation/infra [post]
 func RecommendVmInfraCandidates(c echo.Context) error {
 
 	// [Input]
@@ -261,7 +190,7 @@ func RecommendVmInfraCandidates(c echo.Context) error {
 		}
 	}
 
-	reqt := &RecommendVmInfraRequest{}
+	reqt := &RecommendInfraRequest{}
 	if err := c.Bind(reqt); err != nil {
 		log.Warn().Err(err).Msg("failed to bind a request body")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
@@ -429,40 +358,4 @@ func RecommendK8sNodeGroup(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, model.SuccessResponse(result))
-}
-
-/*
- * Container Infrastructure Recommendation (Legacy - will be deprecated)
- */
-type RecommendInfraRequest struct {
-	DesiredProvider string                      `json:"desiredProvider" example:"aws"`
-	DesiredRegion   string                      `json:"desiredRegion" example:"ap-northeast-2"`
-	Servers         []recommendation.Kubernetes `json:"servers"`
-}
-
-// recommendation.KubernetesInfoList is defined in pkg/core/recommendation/container-infra.go
-
-type RecommendInfraResponse struct {
-	recommendation.RecommendedInfraInfo
-}
-
-// RecommendContainerInfra godoc
-// @ID RecommendContainerInfra
-// @Summary (Deprecated) Recommend an appropriate container infrastructure for cloud migration
-// @Description [DEPRECATED] This endpoint is deprecated. Use /recommendation/k8sCluster and /recommendation/k8sNodeGroup instead.
-// @Description
-// @Description [Note] `desiredProvider` and `desiredRegion` are required.
-// @Tags [Recommendation] Infrastructure
-// @Accept  json
-// @Produce  json
-// @Param UserInfra body RecommendInfraRequest true "Specify the source container infrastructure"
-// @Param desiredProvider query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
-// @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
-// @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[any] "Deprecated endpoint notice"
-// @Failure 400 {object} model.ApiResponse[any]
-// @Router /recommendation/containerInfra [post]
-// @Deprecated
-func RecommendContainerInfra(c echo.Context) error {
-	return c.JSON(http.StatusGone, model.SimpleErrorResponse("This endpoint is deprecated. Please use /recommendation/k8sCluster for control plane and /recommendation/k8sNodeGroup for worker nodes."))
 }

--- a/pkg/api/rest/controller/report.go
+++ b/pkg/api/rest/controller/report.go
@@ -19,10 +19,10 @@ import (
 	"net/http"
 	"strings"
 
+	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
 	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
 	"github.com/cloud-barista/cm-beetle/pkg/core/report"
 	"github.com/cloud-barista/cm-beetle/pkg/core/summary"
-	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -41,7 +41,7 @@ type GenerateMigrationReportRequest struct {
 // @Produce text/markdown
 // @Produce text/html
 // @Param nsId path string true "Namespace ID" example("mig01") default(mig01)
-// @Param mciId path string true "MCI ID" example("mci101") default(mci101)
+// @Param infraId path string true "Infra ID" example("infra101") default(infra101)
 // @Param format query string false "Report format: md or html" Enums(md,html) default(md)
 // @Param download query string false "Download as file: true for file download, false for inline display (only affects browsers/Swagger UI, not curl)" Enums(true,false) default(false)
 // @Param onpremiseInfraModel body controller.GenerateMigrationReportRequest true "Source infrastructure data from on-premise"
@@ -50,7 +50,7 @@ type GenerateMigrationReportRequest struct {
 // @Header 200 {string} Content-Type "text/markdown; charset=utf-8 or text/html; charset=utf-8"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during report generation"
-// @Router /report/migration/ns/{nsId}/mci/{mciId} [post]
+// @Router /report/migration/ns/{nsId}/infra/{infraId} [post]
 func GenerateMigrationReport(c echo.Context) error {
 	// Extract path parameters
 	nsId := c.Param("nsId")
@@ -59,10 +59,10 @@ func GenerateMigrationReport(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Namespace ID required"))
 	}
 
-	mciId := c.Param("mciId")
-	if mciId == "" {
-		log.Warn().Msg("mciId is required")
-		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("MCI ID required"))
+	infraId := c.Param("infraId")
+	if infraId == "" {
+		log.Warn().Msg("infraId is required")
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Infra ID required"))
 	}
 
 	// Extract query parameters
@@ -100,13 +100,13 @@ func GenerateMigrationReport(c echo.Context) error {
 	// Generate migration report
 	log.Info().
 		Str("nsId", nsId).
-		Str("mciId", mciId).
+		Str("infraId", infraId).
 		Int("sourceServers", len(req.OnpremiseInfraModel.Servers)).
 		Str("format", format).
 		Str("download", download).
 		Msg("Generating migration report")
 
-	migrationReport, err := report.GenerateMigrationReport(nsId, mciId, req.OnpremiseInfraModel)
+	migrationReport, err := report.GenerateMigrationReport(nsId, infraId, req.OnpremiseInfraModel)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate migration report")
 
@@ -141,7 +141,7 @@ func GenerateMigrationReport(c echo.Context) error {
 	// Set Content-Disposition header based on download parameter
 	// - "inline": displays content in browser/Swagger UI (allows both viewing and downloading)
 	// - "attachment": forces file download in browser (content not displayed in Swagger UI response body)
-	filename := fmt.Sprintf("migration-report-%s-%s.%s", nsId, mciId, fileExtension)
+	filename := fmt.Sprintf("migration-report-%s-%s.%s", nsId, infraId, fileExtension)
 	dispositionType := "inline"
 	if download == "true" {
 		dispositionType = "attachment"

--- a/pkg/api/rest/controller/summary.go
+++ b/pkg/api/rest/controller/summary.go
@@ -19,9 +19,9 @@ import (
 	"net/http"
 	"strings"
 
+	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
 	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
 	"github.com/cloud-barista/cm-beetle/pkg/core/summary"
-	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -58,7 +58,7 @@ import (
 // @Header 200 {string} Content-Type "text/markdown; charset=utf-8 or text/html; charset=utf-8"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during summary generation"
-// @Router /summary/target/ns/{nsId}/mci/{mciId} [get]
+// @Router /summary/target/ns/{nsId}/infra/{infraId} [get]
 func GenerateTargetInfraSummary(c echo.Context) error {
 
 	// [Input]
@@ -68,10 +68,10 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Namespace ID required"))
 	}
 
-	mciId := c.Param("mciId")
-	if mciId == "" {
-		log.Warn().Msg("MCI ID is required")
-		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("MCI ID required"))
+	infraId := c.Param("infraId")
+	if infraId == "" {
+		log.Warn().Msg("Infra ID is required")
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Infra ID required"))
 	}
 
 	format := c.QueryParam("format")
@@ -93,10 +93,10 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 	}
 
 	// [Process]
-	log.Info().Msgf("Generating infrastructure summary (nsId: %s, mciId: %s, format: %s, download: %s)", nsId, mciId, format, download)
+	log.Info().Msgf("Generating infrastructure summary (nsId: %s, infraId: %s, format: %s, download: %s)", nsId, infraId, format, download)
 
 	// Generate the infrastructure summary
-	infraSummary, err := summary.GenerateInfraSummary(nsId, mciId)
+	infraSum, err := summary.GenerateInfraSummary(nsId, infraId)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to generate infrastructure summary")
 
@@ -111,7 +111,7 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 	// [Output]
 	if format == "md" || format == "html" {
 		// Generate markdown summary
-		markdownSummary := summary.GenerateMarkdownSummary(infraSummary)
+		markdownSummary := summary.GenerateMarkdownSummary(infraSum)
 
 		var content []byte
 		var contentType string
@@ -132,7 +132,7 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 		// Set Content-Disposition header based on download parameter
 		// - "inline": displays content in browser/Swagger UI (allows both viewing and downloading)
 		// - "attachment": forces file download in browser (content not displayed in Swagger UI response body)
-		filename := fmt.Sprintf("target-summary-%s-%s.%s", nsId, mciId, fileExtension)
+		filename := fmt.Sprintf("target-summary-%s-%s.%s", nsId, infraId, fileExtension)
 		dispositionType := "inline"
 		if download == "true" {
 			dispositionType = "attachment"
@@ -145,7 +145,7 @@ func GenerateTargetInfraSummary(c echo.Context) error {
 	}
 
 	// Return JSON format (default)
-	return c.JSON(http.StatusOK, model.SuccessResponse(infraSummary))
+	return c.JSON(http.StatusOK, model.SuccessResponse(infraSum))
 }
 
 // GenerateSourceInfraSummaryRequest represents the request body for source infrastructure summary

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -88,7 +88,7 @@ func RunServer(port string) {
 	log.Info().Msg("CM-Beetle REST API server is starting...")
 
 	e := echo.New()
-	
+
 	// Set dynamically Swagger info
 	apiDocs.SwaggerInfo.Host = config.Beetle.Self.Endpoint
 	apiDocs.SwaggerInfo.Version = "0.5.0"
@@ -101,7 +101,7 @@ func RunServer(port string) {
 		{"/tumblebug/api"},
 		{"/.well-known/appspecific/com.chrome.devtools.json"},
 		{"/favicon.ico"},
-		// {"/mci", "option=status"},
+		// {"/infra", "option=status"},
 	}
 
 	// Custom logger middleware with zerolog
@@ -291,9 +291,8 @@ func RunServer(port string) {
 	gRecommendation.Use(middlewares.TumblebugInitChecker)
 
 	// Recommendation APIs for VM infrastructure
-	gRecommendation.POST("/vmInfra", controller.RecommendVmInfraCandidates)
-	gRecommendation.POST("/mci", controller.RecommendVMInfra) // To be deprecated
-	gRecommendation.POST("/mciWithDefaults", controller.RecommendVMInfraWithDefaults)
+	gRecommendation.POST("/infra", controller.RecommendVmInfraCandidates)
+	gRecommendation.POST("/infraWithDefaults", controller.RecommendVMInfraWithDefaults)
 
 	// Naming and validation utility APIs
 	gNaming := gBeetle.Group("/naming")
@@ -305,13 +304,12 @@ func RunServer(port string) {
 	gRecommendation.POST("/k8sNodeGroup", controller.RecommendK8sNodeGroup)
 
 	// Deprecated: Use /k8sControlPlane and /k8sNodeGroup instead
-	gRecommendation.POST("/containerInfra", controller.RecommendContainerInfra)
 
 	// Recommedation APIs for resources for VM infrastructure
 	gRecommendation.POST("/resources/vNet", controller.RecommendVNet)
 	gRecommendation.POST("/resources/securityGroups", controller.RecommendSecurityGroups)
-	gRecommendation.POST("/resources/vmOsImages", controller.RecommendVmOsImages)
-	gRecommendation.POST("/resources/vmSpecs", controller.RecommendVmSpecs)
+	gRecommendation.POST("/resources/osImages", controller.RecommendVmOsImages)
+	gRecommendation.POST("/resources/specs", controller.RecommendVmSpecs)
 
 	/*
 	 * API group for managed middleware recommendation
@@ -336,11 +334,11 @@ func RunServer(port string) {
 	// gNamespace.DELETE("/:nsId", controller.RestDeleteNs)
 
 	// Migration APIs for VM infrastructure
-	gMigration.POST("/ns/:nsId/mciWithDefaults", controller.MigrateInfraWithDefaults)
-	gMigration.POST("/ns/:nsId/mci", controller.MigrateInfra)
-	gMigration.GET("/ns/:nsId/mci", controller.ListInfra)
-	gMigration.GET("/ns/:nsId/mci/:mciId", controller.GetInfra)
-	gMigration.DELETE("/ns/:nsId/mci/:mciId", controller.DeleteInfra)
+	gMigration.POST("/ns/:nsId/infraWithDefaults", controller.MigrateInfraWithDefaults)
+	gMigration.POST("/ns/:nsId/infra", controller.MigrateInfra)
+	gMigration.GET("/ns/:nsId/infra", controller.ListInfra)
+	gMigration.GET("/ns/:nsId/infra/:infraId", controller.GetInfra)
+	gMigration.DELETE("/ns/:nsId/infra/:infraId", controller.DeleteInfra)
 
 	// Migration APIs for resources for VM infrastructure
 	// APIs for the VM spec resources
@@ -404,7 +402,7 @@ func RunServer(port string) {
 	gReport.Use(middlewares.TumblebugInitChecker)
 
 	// Report APIs for migration analysis
-	gReport.POST("/migration/ns/:nsId/mci/:mciId", controller.GenerateMigrationReport)
+	gReport.POST("/migration/ns/:nsId/infra/:infraId", controller.GenerateMigrationReport)
 
 	/*
 	 * API group for infrastructure summary
@@ -414,7 +412,7 @@ func RunServer(port string) {
 	gSummary.Use(middlewares.TumblebugInitChecker)
 
 	// Summary APIs for target infrastructure
-	gSummary.GET("/target/ns/:nsId/mci/:mciId", controller.GenerateTargetInfraSummary)
+	gSummary.GET("/target/ns/:nsId/infra/:infraId", controller.GenerateTargetInfraSummary)
 
 	// Summary APIs for source infrastructure
 	gSummary.POST("/source", controller.GenerateSourceInfraSummary)

--- a/pkg/core/common/naming.go
+++ b/pkg/core/common/naming.go
@@ -36,7 +36,7 @@ func ComposeName(baseName, seed string) string {
 // ApplyNameSeed applies the late binding naming strategy.
 // It returns a NEW RecommendedVmInfra object with prefixed names,
 // while keeping the original seed in the NameSeed field.
-func ApplyNameSeed(infra cloudmodel.RecommendedVmInfra) cloudmodel.RecommendedVmInfra {
+func ApplyNameSeed(infra cloudmodel.RecommendedInfra) cloudmodel.RecommendedInfra {
 	if infra.NameSeed == "" {
 		return infra
 	}
@@ -63,19 +63,19 @@ func ApplyNameSeed(infra cloudmodel.RecommendedVmInfra) cloudmodel.RecommendedVm
 	}
 
 	// 4. Update Infra and NodeGroups
-	result.TargetVmInfra.Name = ComposeName(infra.TargetVmInfra.Name, seed)
-	for i, ng := range infra.TargetVmInfra.NodeGroups {
-		result.TargetVmInfra.NodeGroups[i].Name = ComposeName(ng.Name, seed)
-		result.TargetVmInfra.NodeGroups[i].VNetId = ComposeName(ng.VNetId, seed)
-		result.TargetVmInfra.NodeGroups[i].SubnetId = ComposeName(ng.SubnetId, seed)
-		result.TargetVmInfra.NodeGroups[i].SshKeyId = ComposeName(ng.SshKeyId, seed)
+	result.TargetInfra.Name = ComposeName(infra.TargetInfra.Name, seed)
+	for i, ng := range infra.TargetInfra.NodeGroups {
+		result.TargetInfra.NodeGroups[i].Name = ComposeName(ng.Name, seed)
+		result.TargetInfra.NodeGroups[i].VNetId = ComposeName(ng.VNetId, seed)
+		result.TargetInfra.NodeGroups[i].SubnetId = ComposeName(ng.SubnetId, seed)
+		result.TargetInfra.NodeGroups[i].SshKeyId = ComposeName(ng.SshKeyId, seed)
 
 		// Update SecurityGroupIds
 		newSgIds := make([]string, len(ng.SecurityGroupIds))
 		for j, sgId := range ng.SecurityGroupIds {
 			newSgIds[j] = ComposeName(sgId, seed)
 		}
-		result.TargetVmInfra.NodeGroups[i].SecurityGroupIds = newSgIds
+		result.TargetInfra.NodeGroups[i].SecurityGroupIds = newSgIds
 	}
 
 	return result
@@ -88,7 +88,7 @@ const (
 	ResourceTypeSubnet        = "subnet"
 	ResourceTypeSshKey        = "sshKey"
 	ResourceTypeSecurityGroup = "securityGroup"
-	ResourceTypeMci           = "mci"
+	ResourceTypeInfra         = "infra"
 )
 
 // PropagateNameChange updates a specific resource's name in the model and propagates
@@ -100,7 +100,7 @@ const (
 //   - resourceType: One of "vNet", "subnet", "sshKey", "securityGroup", "mci"
 //   - oldName: The current name of the resource to rename
 //   - newName: The new name to assign to the resource
-func PropagateNameChange(infra cloudmodel.RecommendedVmInfra, resourceType, oldName, newName string) cloudmodel.RecommendedVmInfra {
+func PropagateNameChange(infra cloudmodel.RecommendedInfra, resourceType, oldName, newName string) cloudmodel.RecommendedInfra {
 	result := infra // Copy by value
 
 	switch resourceType {
@@ -116,9 +116,9 @@ func PropagateNameChange(infra cloudmodel.RecommendedVmInfra, resourceType, oldN
 			}
 		}
 		// 3. Propagate to NodeGroups
-		for i := range result.TargetVmInfra.NodeGroups {
-			if result.TargetVmInfra.NodeGroups[i].VNetId == oldName {
-				result.TargetVmInfra.NodeGroups[i].VNetId = newName
+		for i := range result.TargetInfra.NodeGroups {
+			if result.TargetInfra.NodeGroups[i].VNetId == oldName {
+				result.TargetInfra.NodeGroups[i].VNetId = newName
 			}
 		}
 
@@ -130,9 +130,9 @@ func PropagateNameChange(infra cloudmodel.RecommendedVmInfra, resourceType, oldN
 			}
 		}
 		// 2. Propagate to NodeGroups
-		for i := range result.TargetVmInfra.NodeGroups {
-			if result.TargetVmInfra.NodeGroups[i].SubnetId == oldName {
-				result.TargetVmInfra.NodeGroups[i].SubnetId = newName
+		for i := range result.TargetInfra.NodeGroups {
+			if result.TargetInfra.NodeGroups[i].SubnetId == oldName {
+				result.TargetInfra.NodeGroups[i].SubnetId = newName
 			}
 		}
 
@@ -142,9 +142,9 @@ func PropagateNameChange(infra cloudmodel.RecommendedVmInfra, resourceType, oldN
 			result.TargetSshKey.Name = newName
 		}
 		// 2. Propagate to NodeGroups
-		for i := range result.TargetVmInfra.NodeGroups {
-			if result.TargetVmInfra.NodeGroups[i].SshKeyId == oldName {
-				result.TargetVmInfra.NodeGroups[i].SshKeyId = newName
+		for i := range result.TargetInfra.NodeGroups {
+			if result.TargetInfra.NodeGroups[i].SshKeyId == oldName {
+				result.TargetInfra.NodeGroups[i].SshKeyId = newName
 			}
 		}
 
@@ -156,18 +156,18 @@ func PropagateNameChange(infra cloudmodel.RecommendedVmInfra, resourceType, oldN
 			}
 		}
 		// 2. Propagate to SubGroup SecurityGroupIds
-		for i, ng := range result.TargetVmInfra.NodeGroups {
+		for i, ng := range result.TargetInfra.NodeGroups {
 			for j, sgId := range ng.SecurityGroupIds {
 				if sgId == oldName {
-					result.TargetVmInfra.NodeGroups[i].SecurityGroupIds[j] = newName
+					result.TargetInfra.NodeGroups[i].SecurityGroupIds[j] = newName
 				}
 			}
 		}
 
-	case ResourceTypeMci:
-		// Rename the MCI itself (no child dependencies on MCI name)
-		if result.TargetVmInfra.Name == oldName {
-			result.TargetVmInfra.Name = newName
+	case ResourceTypeInfra:
+		// Rename the Infra itself (no child dependencies on Infra name)
+		if result.TargetInfra.Name == oldName {
+			result.TargetInfra.Name = newName
 		}
 	}
 
@@ -194,7 +194,7 @@ func IsValidName(name string) (bool, string) {
 }
 
 // ValidateComposedNames checks all resource names and referential integrity.
-func ValidateComposedNames(infra cloudmodel.RecommendedVmInfra) (bool, string) {
+func ValidateComposedNames(infra cloudmodel.RecommendedInfra) (bool, string) {
 	seed := infra.NameSeed
 
 	// 1. Validate name formats
@@ -223,10 +223,10 @@ func ValidateComposedNames(infra cloudmodel.RecommendedVmInfra) (bool, string) {
 	}
 
 	// Check Infra and NodeGroups
-	if ok, detail := IsValidName(ComposeName(infra.TargetVmInfra.Name, seed)); !ok {
-		return false, fmt.Sprintf("Infra name [%s]: %s", infra.TargetVmInfra.Name, detail)
+	if ok, detail := IsValidName(ComposeName(infra.TargetInfra.Name, seed)); !ok {
+		return false, fmt.Sprintf("Infra name [%s]: %s", infra.TargetInfra.Name, detail)
 	}
-	for _, ng := range infra.TargetVmInfra.NodeGroups {
+	for _, ng := range infra.TargetInfra.NodeGroups {
 		if ok, detail := IsValidName(ComposeName(ng.Name, seed)); !ok {
 			return false, fmt.Sprintf("NodeGroup/VM name [%s]: %s", ng.Name, detail)
 		}
@@ -242,7 +242,7 @@ func ValidateComposedNames(infra cloudmodel.RecommendedVmInfra) (bool, string) {
 
 // ValidateReferentialIntegrity verifies that all internal references (IDs)
 // in the model point to resources that exist within the same model.
-func ValidateReferentialIntegrity(infra cloudmodel.RecommendedVmInfra) (bool, string) {
+func ValidateReferentialIntegrity(infra cloudmodel.RecommendedInfra) (bool, string) {
 	vnetName := infra.TargetVNet.Name
 	sshKeyName := infra.TargetSshKey.Name
 
@@ -263,7 +263,7 @@ func ValidateReferentialIntegrity(infra cloudmodel.RecommendedVmInfra) (bool, st
 	}
 
 	// Check Infra NodeGroups references
-	for _, ng := range infra.TargetVmInfra.NodeGroups {
+	for _, ng := range infra.TargetInfra.NodeGroups {
 		if ng.VNetId != vnetName {
 			return false, fmt.Sprintf("NodeGroup [%s] refers to non-existent VNet [%s]", ng.Name, ng.VNetId)
 		}

--- a/pkg/core/migration/vm-infra.go
+++ b/pkg/core/migration/vm-infra.go
@@ -133,7 +133,7 @@ func CreateVMInfraWithDefaults(nsId string, infraModel *cloudmodel.InfraDynamicR
 }
 
 // CreateVMInfra creates a VM infrastructure for the computing infra migration
-func CreateVMInfra(nsId string, targetInfraModel *cloudmodel.RecommendedVmInfra) (cloudmodel.VmInfraInfo, error) {
+func CreateVMInfra(nsId string, targetInfraModel *cloudmodel.RecommendedInfra) (cloudmodel.VmInfraInfo, error) {
 	log.Info().Msg("Creating VM infrastructure")
 
 	emptyRet := cloudmodel.VmInfraInfo{}
@@ -163,10 +163,10 @@ func CreateVMInfra(nsId string, targetInfraModel *cloudmodel.RecommendedVmInfra)
 		return emptyRet, err
 	}
 
-	log.Debug().Msgf("Checking if the Infra (%s) exists in the namespace (%s)", targetInfraModel.TargetVmInfra.Name, nsId)
-	tempInfraInfo, err := tbclient.NewSession().ReadInfra(nsId, targetInfraModel.TargetVmInfra.Name)
+	log.Debug().Msgf("Checking if the Infra (%s) exists in the namespace (%s)", targetInfraModel.TargetInfra.Name, nsId)
+	tempInfraInfo, err := tbclient.NewSession().ReadInfra(nsId, targetInfraModel.TargetInfra.Name)
 	if tempInfraInfo.Id != "" {
-		log.Error().Err(err).Msgf("the Infra already exist (nsId: %s, infraName: %s)", nsId, targetInfraModel.TargetVmInfra.Name)
+		log.Error().Err(err).Msgf("the Infra already exist (nsId: %s, infraName: %s)", nsId, targetInfraModel.TargetInfra.Name)
 		return emptyRet, err
 	}
 
@@ -254,7 +254,7 @@ func CreateVMInfra(nsId string, targetInfraModel *cloudmodel.RecommendedVmInfra)
 
 	// 7. Create a VM infrastructure (i.e., Infra)
 	// Get multi-cloud infrastructure (Infra) request body from the input infraModel
-	infraReq := targetInfraModel.TargetVmInfra
+	infraReq := targetInfraModel.TargetInfra
 	log.Debug().Msgf("Creating a multi-cloud infrastructure (nsId: %s, infraName: %s)", nsId, infraReq.Name)
 	log.Debug().Msgf("infraReq: %+v", infraReq)
 
@@ -514,14 +514,14 @@ func DeleteVMInfra(nsId, infraId, option string) (common.SimpleMsg, error) {
 	return ret, nil
 }
 
-func validateTargeVmtInfraModel(nsId string, targetVmInfraModel *cloudmodel.RecommendedVmInfra) error {
+func validateTargeVmtInfraModel(nsId string, targetVmInfraModel *cloudmodel.RecommendedInfra) error {
 
 	// * 1. Validate that name fieleds are not empty
 	if targetVmInfraModel == nil {
 		log.Error().Msgf("target infrastructure model is nil (nsId: %s)", nsId)
 		return fmt.Errorf("target infrastructure model is nil")
 	}
-	if targetVmInfraModel.TargetVmInfra.Name == "" { // MCI name
+	if targetVmInfraModel.TargetInfra.Name == "" { // MCI name
 		log.Error().Msgf("target VM infrastructure name is empty (nsId: %s)", nsId)
 		return fmt.Errorf("target VM infrastructure name is empty")
 	}
@@ -542,7 +542,7 @@ func validateTargeVmtInfraModel(nsId string, targetVmInfraModel *cloudmodel.Reco
 
 	// * 2. Validate that the names or IDs are matched in the model
 	// Check if the each Node's vNetId matches the target VNet name
-	for _, nodegroup := range targetVmInfraModel.TargetVmInfra.NodeGroups {
+	for _, nodegroup := range targetVmInfraModel.TargetInfra.NodeGroups {
 		if nodegroup.VNetId != targetVmInfraModel.TargetVNet.Name {
 			log.Error().Msgf("target VM infrastructure vNetId (%s) does not match target VNet name (%s)",
 				nodegroup.VNetId, targetVmInfraModel.TargetVNet.Name)
@@ -552,7 +552,7 @@ func validateTargeVmtInfraModel(nsId string, targetVmInfraModel *cloudmodel.Reco
 	}
 
 	// Check if each Node's SshKeyId matches the target SSH key name
-	for _, nodegroup := range targetVmInfraModel.TargetVmInfra.NodeGroups {
+	for _, nodegroup := range targetVmInfraModel.TargetInfra.NodeGroups {
 		if nodegroup.SshKeyId != targetVmInfraModel.TargetSshKey.Name {
 			log.Error().Msgf("target VM infrastructure SshKeyId (%s) does not match target SSH key name (%s)",
 				nodegroup.SshKeyId, targetVmInfraModel.TargetSshKey.Name)
@@ -566,7 +566,7 @@ func validateTargeVmtInfraModel(nsId string, targetVmInfraModel *cloudmodel.Reco
 	// tbSess := tbclient.NewSession()
 
 	// Check if each Node's spec and image are valid and compatible
-	for _, nodegroup := range targetVmInfraModel.TargetVmInfra.NodeGroups {
+	for _, nodegroup := range targetVmInfraModel.TargetInfra.NodeGroups {
 
 		specId := strings.TrimSpace(nodegroup.SpecId)
 		imageId := strings.TrimSpace(nodegroup.ImageId)
@@ -653,7 +653,7 @@ func validateTargeVmtInfraModel(nsId string, targetVmInfraModel *cloudmodel.Reco
 	}
 
 	// Check if each security group name is contained in the target security group list
-	for _, nodegroup := range targetVmInfraModel.TargetVmInfra.NodeGroups {
+	for _, nodegroup := range targetVmInfraModel.TargetInfra.NodeGroups {
 		found := false
 		for _, sgId := range nodegroup.SecurityGroupIds {
 			// Check if the security group name matches any target security group name

--- a/pkg/core/recommendation/vm-infra.go
+++ b/pkg/core/recommendation/vm-infra.go
@@ -103,19 +103,19 @@ func IsValidCspAndRegion(csp string, region string) (bool, error) {
 }
 
 // RecommendVmInfraWithDefaults an appropriate multi-cloud infrastructure (MCI) for cloud migration
-func RecommendVmInfraWithDefaults(desiredCsp string, desiredRegion string, srcInfra onpremmodel.OnpremInfra) (cloudmodel.RecommendedVmInfraDynamicList, error) {
+func RecommendVmInfraWithDefaults(desiredCsp string, desiredRegion string, srcInfra onpremmodel.OnpremInfra) (cloudmodel.RecommendedInfraDynamicList, error) {
 
 	// var emptyResp RecommendedVmInfraInfoList
-	var recommendedVmInfraInfoList cloudmodel.RecommendedVmInfraDynamicList
+	var recommendedVmInfraInfoList cloudmodel.RecommendedInfraDynamicList
 
 	// TODO: To be updated, a user will input the desired number of recommended VMs
 	var defaultSpecsLimit int = GetDefaultSpecsLimit()
 
 	// Initialize the response body
-	recommendedVmInfraInfoList = cloudmodel.RecommendedVmInfraDynamicList{
-		Description:       "This is a list of recommended target infrastructures. Please review and use them.",
-		Count:             0,
-		TargetVmInfraList: []cloudmodel.RecommendedVmInfraDynamic{},
+	recommendedVmInfraInfoList = cloudmodel.RecommendedInfraDynamicList{
+		Description:     "This is a list of recommended target infrastructures. Please review and use them.",
+		Count:           0,
+		TargetInfraList: []cloudmodel.RecommendedInfraDynamic{},
 	}
 
 	// // Set VM info
@@ -192,14 +192,14 @@ func RecommendVmInfraWithDefaults(desiredCsp string, desiredRegion string, srcIn
 	// log.Debug().Msgf("transposed recommended VM specs and OS images: %+v", transposed)
 
 	// Build response body which includes multiple recommended infrastructures
-	recommenedVmInfraInfoList := []cloudmodel.RecommendedVmInfraDynamic{}
+	recommenedVmInfraInfoList := []cloudmodel.RecommendedInfraDynamic{}
 
 	for i, vmInfoList := range transposed {
 
-		tempVmInfraInfo := cloudmodel.RecommendedVmInfraDynamic{
+		tempVmInfraInfo := cloudmodel.RecommendedInfraDynamic{
 			Status:      string(NothingRecommended),
 			Description: "This is a recommended target infrastructure.",
-			TargetVmInfra: cloudmodel.InfraDynamicReq{
+			TargetInfra: cloudmodel.InfraDynamicReq{
 				Name:        fmt.Sprintf("migrated-%02d", i),
 				Description: "a recommended multi-cloud infrastructure",
 				NodeGroups:  []cloudmodel.CreateNodeGroupDynamicReq{},
@@ -218,10 +218,10 @@ func RecommendVmInfraWithDefaults(desiredCsp string, desiredRegion string, srcIn
 				NodeGroupSize:    1,                                                         // TBD
 				NodeUserPassword: "",                                                        // TBD
 			}
-			tempVmInfraInfo.TargetVmInfra.NodeGroups = append(tempVmInfraInfo.TargetVmInfra.NodeGroups, tempCreateNodegroupReq)
+			tempVmInfraInfo.TargetInfra.NodeGroups = append(tempVmInfraInfo.TargetInfra.NodeGroups, tempCreateNodegroupReq)
 		}
 
-		status := checkOverallSubGroupStatus(tempVmInfraInfo.TargetVmInfra.NodeGroups)
+		status := checkOverallSubGroupStatus(tempVmInfraInfo.TargetInfra.NodeGroups)
 		tempVmInfraInfo.Status = status
 		if status == string(NothingRecommended) {
 			tempVmInfraInfo.Description = "Could not find approprate VMs."
@@ -235,7 +235,7 @@ func RecommendVmInfraWithDefaults(desiredCsp string, desiredRegion string, srcIn
 	}
 
 	// Assign the target infrastructure list to the response
-	recommendedVmInfraInfoList.TargetVmInfraList = recommenedVmInfraInfoList
+	recommendedVmInfraInfoList.TargetInfraList = recommenedVmInfraInfoList
 	recommendedVmInfraInfoList.Count = len(recommenedVmInfraInfoList)
 
 	log.Trace().Msgf("the recommended infra info: %+v", recommendedVmInfraInfoList)
@@ -244,24 +244,24 @@ func RecommendVmInfraWithDefaults(desiredCsp string, desiredRegion string, srcIn
 }
 
 // RecommendVmInfra an appropriate multi-cloud infrastructure (MCI) for cloud migration
-func RecommendVmInfra(desiredCsp string, desiredRegion string, srcInfra onpremmodel.OnpremInfra) (cloudmodel.RecommendedVmInfra, error) {
+func RecommendVmInfra(desiredCsp string, desiredRegion string, srcInfra onpremmodel.OnpremInfra) (cloudmodel.RecommendedInfra, error) {
 
 	// var emptyResp RecommendedVmInfra
-	var recommendedVmInfra cloudmodel.RecommendedVmInfra
+	var recommendedVmInfra cloudmodel.RecommendedInfra
 
 	// TODO: To be updated, a user will input the desired number of recommended VMs
 	var limitSpecs int = GetDefaultSpecsLimit()
 	var limitImages int = GetDefaultImagesLimit()
 
 	// Initialize the response body
-	recommendedVmInfra = cloudmodel.RecommendedVmInfra{
+	recommendedVmInfra = cloudmodel.RecommendedInfra{
 		Description: "This is a list of recommended target infrastructures. Please review and use them.",
 		Status:      "",
 		TargetCloud: cloudmodel.CloudProperty{
 			Csp:    desiredCsp,
 			Region: desiredRegion,
 		},
-		TargetVmInfra: cloudmodel.InfraReq{
+		TargetInfra: cloudmodel.InfraReq{
 			Name:        "infra101",
 			Description: "a recommended multi-cloud infrastructure",
 			NodeGroups:  []cloudmodel.CreateNodeGroupReq{},
@@ -497,9 +497,9 @@ func RecommendVmInfra(desiredCsp string, desiredRegion string, srcInfra onpremmo
 	/*
 	 * [Output]
 	 */
-	recommendedVmInfra.TargetVmInfra.NodeGroups = recommendedNodegroupList
-	recommendedVmInfra.TargetVmSpecList = recommendedVmSpecList
-	recommendedVmInfra.TargetVmOsImageList = recommendedVmOsImageList
+	recommendedVmInfra.TargetInfra.NodeGroups = recommendedNodegroupList
+	recommendedVmInfra.TargetSpecList = recommendedVmSpecList
+	recommendedVmInfra.TargetOsImageList = recommendedVmOsImageList
 	recommendedVmInfra.TargetSecurityGroupList = recommendedSecurityGroupList
 
 	log.Trace().Msgf("the recommended infra info: %+v", recommendedVmInfra)
@@ -508,7 +508,7 @@ func RecommendVmInfra(desiredCsp string, desiredRegion string, srcInfra onpremmo
 }
 
 // RecommendVmInfraCandidates an appropriate multi-cloud infrastructure (MCI) for cloud migration
-func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfra onpremmodel.OnpremInfra, limit int, minMatchRate float64, nameSeed string) ([]cloudmodel.RecommendedVmInfra, error) {
+func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfra onpremmodel.OnpremInfra, limit int, minMatchRate float64, nameSeed string) ([]cloudmodel.RecommendedInfra, error) {
 
 	// * To recommend multiple infra candidates (i.e., multiple VM spec and OS image combinations),
 	// * this function estimates, recommends or just generates vNets, subnets, SSH key pair, and security groups
@@ -516,7 +516,7 @@ func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfr
 	// * All those are corresponding to the source servers.
 
 	// var emptyResp RecommendedVmInfra
-	var recommendedVmInfraCandidates []cloudmodel.RecommendedVmInfra
+	var recommendedVmInfraCandidates []cloudmodel.RecommendedInfra
 
 	// TODO: To be updated, a user will input the desired number of recommended VMs
 	var limitSpecs int = GetDefaultSpecsLimit()
@@ -526,7 +526,7 @@ func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfr
 	region := strings.ToLower(desiredRegion)
 
 	// Initialize the response body
-	skeletonVmInfra := cloudmodel.RecommendedVmInfra{
+	skeletonVmInfra := cloudmodel.RecommendedInfra{
 		NameSeed:    nameSeed,
 		Description: "This is a recommended target infrastructures and resources. Please review and use them.",
 		Status:      "",
@@ -534,7 +534,7 @@ func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfr
 			Csp:    csp,
 			Region: region,
 		},
-		TargetVmInfra: cloudmodel.InfraReq{
+		TargetInfra: cloudmodel.InfraReq{
 			Name:       "infra101",
 			NodeGroups: []cloudmodel.CreateNodeGroupReq{},
 			// Description: "Recommended VMs comprising the multi-cloud infrastructure",
@@ -888,11 +888,11 @@ func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfr
 
 		// Create a candidate infrastructure based on skeleton and current tempNodeGroupList
 		candidateInfra := skeletonVmInfra
-		candidateInfra.TargetVmInfra.NodeGroups = tempNodeGroupList
-		candidateInfra.TargetVmSpecList = deduplicatedVmSpecList
-		candidateInfra.TargetVmOsImageList = deduplicatedVmOsImageList
+		candidateInfra.TargetInfra.NodeGroups = tempNodeGroupList
+		candidateInfra.TargetSpecList = deduplicatedVmSpecList
+		candidateInfra.TargetOsImageList = deduplicatedVmOsImageList
 		candidateInfra.TargetSecurityGroupList = deduplicatedSecurityGroupList
-		candidateInfra.TargetVmInfra.Description = "Recommended VMs comprising multi-cloud infrastructure"
+		candidateInfra.TargetInfra.Description = "Recommended VMs comprising multi-cloud infrastructure"
 
 		// Calculate overall match rate with detailed information
 		overallStatus, overallStatusDesc, infraMatchRateSummary := calculateCandidateMatchRateWithDetails(csp, tempNodeGroupList, srcInfra, deduplicatedVmSpecList, deduplicatedVmOsImageList, minMatchRate)

--- a/pkg/core/report/markdown.go
+++ b/pkg/core/report/markdown.go
@@ -73,8 +73,8 @@ func writeExecutiveSummary(md *strings.Builder, summary *ExecutiveSummary, metad
 	md.WriteString(fmt.Sprintf("**Target Region:** %s\n\n", summary.TargetRegion))
 
 	// Metadata Information
-	md.WriteString(fmt.Sprintf("**Namespace:** %s | **MCI ID:** %s\n\n",
-		metadata.Namespace, metadata.MciID))
+	md.WriteString(fmt.Sprintf("**Namespace:** %s | **Infra ID:** %s\n\n",
+		metadata.Namespace, metadata.InfraID))
 
 	// Migration Status
 	md.WriteString(fmt.Sprintf("**Migration Status:** %s\n\n", summary.MigrationStatus))

--- a/pkg/core/report/migration-report.go
+++ b/pkg/core/report/migration-report.go
@@ -20,14 +20,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloud-barista/cm-beetle/pkg/core/summary"
 	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
+	"github.com/cloud-barista/cm-beetle/pkg/core/summary"
 	"github.com/rs/zerolog/log"
 )
 
 // GenerateMigrationReport generates a comprehensive migration report
-func GenerateMigrationReport(nsId, mciId string, sourceInfra onpremmodel.OnpremInfra) (*MigrationReport, error) {
-	log.Info().Msgf("Generating migration report (nsId: %s, mciId: %s)", nsId, mciId)
+func GenerateMigrationReport(nsId, infraId string, sourceInfra onpremmodel.OnpremInfra) (*MigrationReport, error) {
+	log.Info().Msgf("Generating migration report (nsId: %s, infraId: %s)", nsId, infraId)
 
 	// Step 1: Generate source infrastructure summary
 	sourceInfraName := fmt.Sprintf("infra-%d-servers", len(sourceInfra.Servers))
@@ -38,7 +38,7 @@ func GenerateMigrationReport(nsId, mciId string, sourceInfra onpremmodel.OnpremI
 	}
 
 	// Step 2: Generate target infrastructure summary
-	targetSummary, err := summary.GenerateInfraSummary(nsId, mciId)
+	targetSummary, err := summary.GenerateInfraSummary(nsId, infraId)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate target infrastructure summary")
 		return nil, fmt.Errorf("failed to generate target infrastructure summary: %w", err)
@@ -47,9 +47,9 @@ func GenerateMigrationReport(nsId, mciId string, sourceInfra onpremmodel.OnpremI
 	// Step 3: Build report metadata
 	metadata := ReportMetadata{
 		GeneratedAt:   time.Now(),
-		MigrationID:   fmt.Sprintf("%s/%s", nsId, mciId),
+		MigrationID:   fmt.Sprintf("%s/%s", nsId, infraId),
 		Namespace:     nsId,
-		MciID:         mciId,
+		InfraID:       infraId,
 		ReportVersion: "1.0",
 	}
 
@@ -84,7 +84,7 @@ func GenerateMigrationReport(nsId, mciId string, sourceInfra onpremmodel.OnpremI
 		TargetDetails:     targetSummary,
 	}
 
-	log.Info().Msgf("Successfully generated migration report (nsId: %s, mciId: %s)", nsId, mciId)
+	log.Info().Msgf("Successfully generated migration report (nsId: %s, infraId: %s)", nsId, infraId)
 	return report, nil
 }
 

--- a/pkg/core/report/model.go
+++ b/pkg/core/report/model.go
@@ -38,7 +38,7 @@ type ReportMetadata struct {
 	GeneratedAt   time.Time `json:"generatedAt" example:"2025-11-04T10:30:00Z"`
 	MigrationID   string    `json:"migrationId" example:"mig01/mmci01"`
 	Namespace     string    `json:"namespace" example:"mig01"`
-	MciID         string    `json:"mciId" example:"mmci01"`
+	InfraID       string    `json:"infraId" example:"infra01"`
 	ReportVersion string    `json:"reportVersion" example:"1.0"`
 }
 


### PR DESCRIPTION
**BREAKING CHANGE**: CB-Tumblebug v0.12.9 API terminology/concept alignment
- mci → infra (Multi-Cloud Infrastructure)
- vmSpec → spec (VM specification)
- vmOsImage → osImage (OS image)
- vmInfra → infra (VM infrastructure)

All API endpoints, path parameters, and response models affected:
- Migration APIs: /migration/ns/{nsId}/mci → /infra
- Recommendation APIs: /recommendation/vmInfra → /infra
- Resource APIs: /resources/vmSpecs → /specs, /resources/vmOsImages → /osImages
- Report APIs: /report/migration/ns/{nsId}/mci/{mciId} → /infra/{infraId}
- Summary APIs: /summary/target/ns/{nsId}/mci/{mciId} → /infra/{infraId}
- Path parameters: {mciId} → {infraId}
- Updated Swagger documentation and test CLI
- Refreshed test results with new naming conventions
- Bumped imdl dependency to v0.1.2

_NOTICE:_
- _This is a clean break with no backward compatibility._
- _Several rounds are expected for the update._

Review docs/api-migration-guide-tb-v0.12.9.md for complete migration details.

ref) [Infra Resource Model and Life cycle Management - Tumblebug](https://github.com/cloud-barista/cb-tumblebug/blob/main/docs/feature_guide/infra-resource-model-and-lifecycle-management.md)