### PR TITLE
refactor(model): add K8s cluster support

### DIFF
--- a/imdl/on-premise-model/cluster.go
+++ b/imdl/on-premise-model/cluster.go
@@ -1,0 +1,13 @@
+package onpremisemodel
+
+// K8sClusterProperty describes an on-premise Kubernetes cluster
+// that may be migrated together with its nodes.
+type K8sClusterProperty struct {
+	Name    string `json:"name" validate:"required"`    // [Required] Cluster name
+	Version string `json:"version" validate:"required"` // [Required] Kubernetes version (e.g., "1.29.3")
+
+	PodCIDR       string `json:"podCIDR,omitempty"`       // [Reference] Pod network CIDR (e.g., "10.244.0.0/16")
+	ServiceCIDR   string `json:"serviceCIDR,omitempty"`   // [Reference] Service network CIDR (e.g., "10.96.0.0/12")
+	CNIPlugin     string `json:"cniPlugin,omitempty"`     // [Reference] CNI plugin name (e.g., "calico", "flannel", "cilium")
+	NodePortRange string `json:"nodePortRange,omitempty"` // [Reference] NodePort range (e.g., "30000-32767")
+}

--- a/imdl/on-premise-model/model.go
+++ b/imdl/on-premise-model/model.go
@@ -5,8 +5,11 @@ type OnpremiseInfraModel struct {
 }
 
 type OnpremInfra struct {
-	Network NetworkProperty  `json:"network,omitempty"`
-	Servers []ServerProperty `json:"servers" validate:"required"`
+	Network NetworkProperty `json:"network,omitempty"`
+	Nodes   []NodeProperty  `json:"nodes" validate:"required"`
+
+	// TODO: Extend to a general ClusterProperty if other orchestrators (e.g., OpenShift, Rancher) are needed.
+	K8sCluster *K8sClusterProperty `json:"k8sCluster,omitempty"`
 	// TODO: Add other fields
 	// Example: FirewallDevice FirewallDeviceProperty `json:"firewallDevice,omitempty"`
 }

--- a/imdl/on-premise-model/node.go
+++ b/imdl/on-premise-model/node.go
@@ -1,8 +1,11 @@
 package onpremisemodel
 
-type ServerProperty struct {
+// NodeProperty represents a node in the on-premise infrastructure.
+// The node includes a physical server, virtual machine (VM), and Kubernetes node.
+type NodeProperty struct {
 	Hostname      string                     `json:"hostname"`
-	MachineId     string                     `json:"machineId"` // Unique identifier for the server (e.g., UUID)
+	MachineId     string                     `json:"machineId"`                              // Unique identifier for the node (e.g., UUID)
+	Role          string                     `json:"role,omitempty" example:"control-plane"` // Node role (e.g., "control-plane", "worker", "standalone")
 	CPU           CpuProperty                `json:"cpu"`
 	Memory        MemoryProperty             `json:"memory"`
 	RootDisk      DiskProperty               `json:"rootDisk"`


### PR DESCRIPTION
- Rename ServerProperty to NodeProperty (breaking)
- Add K8sClusterProperty with cluster metadata
  - Include pod/service CIDR, CNI plugin config

BREAKING CHANGE: Servers → Nodes, ServerProperty → NodeProperty

(cc @hanizang77)

