### PR TITLE
feat: add IBM Cloud support with enhanced testing reliability

### DIFF
--- a/cmd/test-cli/infra/main.go
+++ b/cmd/test-cli/infra/main.go
@@ -2680,17 +2680,19 @@ func runRemoteCommandTest(client *resty.Client, config TestConfig, infraId, disp
 			// Determine username (priority: vmInfo.VmUserName > default "cb-user")
 			sshUserName := userName
 
-			// Perform SSH connectivity test with retry logic
-			log.Info().Str("nodeId", nodeId).Str("ip", publicIP).Str("user", sshUserName).Msg("🔍 Testing SSH connectivity...")
+			// Perform SSH connectivity test with retry logic.
+			// Retries every 10s for up to 3 minutes to handle cloud-init startup
+			// (e.g., IBM Cloud VPC takes 1-3 minutes to set up the SSH user after VM creation).
+			log.Info().Str("nodeId", nodeId).Str("ip", publicIP).Str("user", sshUserName).Msg("🔍 Testing SSH connectivity (up to 3 min)...")
 
-			const maxRetries = 3
-			const retryDelay = 3 * time.Second
+			const maxRetries = 19 // 1 immediate + 18 retries × 10s = 3 minutes total
+			const retryDelay = 10 * time.Second
+			const logProgressEvery = 6 // surface progress at Info every ~1 minute (6 × 10s)
 			var sshResult string
 			var lastErr error
 
 			for attempt := 1; attempt <= maxRetries; attempt++ {
 				if attempt > 1 {
-					log.Info().Str("nodeId", nodeId).Int("attempt", attempt).Int("maxRetries", maxRetries).Msg("🔄 Retrying SSH connection...")
 					time.Sleep(retryDelay)
 				}
 
@@ -2709,8 +2711,17 @@ func runRemoteCommandTest(client *resty.Client, config TestConfig, infraId, disp
 						log.Info().Str("nodeId", nodeId).Str("ip", publicIP).Msg("✅ SSH connectivity test passed")
 					}
 					break
+				}
+				// Log at Info every ~1 minute; suppress intermediate attempts to reduce noise
+				elapsed := time.Duration(attempt-1) * retryDelay
+				if (attempt-1)%logProgressEvery == 0 {
+					log.Info().Err(lastErr).Str("nodeId", nodeId).Str("ip", publicIP).
+						Str("elapsed", elapsed.String()).Int("attempt", attempt).Int("maxRetries", maxRetries).
+						Msg("🔄 SSH not ready, retrying...")
 				} else {
-					log.Warn().Err(lastErr).Str("nodeId", nodeId).Str("ip", publicIP).Int("attempt", attempt).Int("maxRetries", maxRetries).Msg("⚠️ SSH connection attempt failed")
+					log.Debug().Err(lastErr).Str("nodeId", nodeId).Str("ip", publicIP).
+						Int("attempt", attempt).Int("maxRetries", maxRetries).
+						Msg("SSH attempt failed")
 				}
 			}
 

--- a/pkg/core/recommendation/vm-infra.go
+++ b/pkg/core/recommendation/vm-infra.go
@@ -67,7 +67,7 @@ func isSupportedCSP(csp string) bool {
 		"gcp":     true,
 		"alibaba": true,
 		// "tencent": true,
-		// "ibm":   true,
+		"ibm": true,
 		"ncp": true,
 		// "nhn": true,
 		// "kt": true,
@@ -75,6 +75,52 @@ func isSupportedCSP(csp string) bool {
 	}
 
 	return supportedCSPs[csp]
+}
+
+// getCspMinRootDiskSizeGB returns the CSP-specific safe minimum root disk size in GB.
+// Values are conservative to prevent VM creation failures near the lower bound.
+//
+// Notes: IBM/NCP use fixed sizes (API ignores the field); Azure derives size from the image.
+// Ref: https://github.com/cloud-barista/cb-spider/wiki/API-and-features-of-VM-rootfs-volume-configuration
+//
+// TODO: Replace hardcoded values with dynamic lookup via CB-Spider's GET /cloudos/metainfo/{CloudOSName}
+// (returns RootDiskSize as a string enum list). Consider caching at startup to avoid per-request overhead.
+// Ref: https://github.com/cloud-barista/cb-spider/blob/master/cloud-driver-libs/cloudos_meta.yaml
+func getCspMinRootDiskSizeGB(csp string) int {
+	switch strings.ToLower(csp) {
+	case "ibm":
+		// Fixed at 100 GB by default; root disk size is not configurable via API.
+		// (Custom user images support 10~250 GB, but the standard fixed value is 100 GB.)
+		return 100
+	case "ncp", "ncpvpc":
+		// Fixed at 50 GB for Linux; root disk size cannot be changed via API or console.
+		return 50
+	case "tencent":
+		// Minimum per cloudos_meta.yaml: CLOUD_PREMIUM|50 GB, CLOUD_SSD|50 GB.
+		return 50
+	case "kt", "ktvpc":
+		// Minimum per cloudos_meta.yaml: HDD|50 GB, SSD|50 GB.
+		return 50
+	case "alibaba":
+		// Minimum per cloudos_meta.yaml: cloud_essd|20 GB, cloud_efficiency|20 GB.
+		// Using 40 GB as a conservative safe floor to avoid errors near the lower bound.
+		return 40
+	case "azure":
+		// Root disk size depends on the selected image and is not configurable via API.
+		// CB-Spider's Azure driver ignores this field; 30 GB serves as a safe fallback floor.
+		return 30
+	case "nhn":
+		// Minimum per cloudos_meta.yaml: General_HDD|20 GB, General_SSD|20 GB.
+		return 20
+	case "ktclassic":
+		// Minimum per cloudos_meta.yaml: HDD|20 GB, SSD|20 GB.
+		return 20
+	case "aws", "gcp":
+		// AWS: gp2/gp3 practical OS minimum ~8 GB. GCP: pd-standard minimum 10 GB.
+		return 10
+	default:
+		return 50 // Conservative safe default for unknown or future CSPs
+	}
 }
 
 func IsValidCspAndRegion(csp string, region string) (bool, error) {
@@ -464,6 +510,9 @@ func RecommendVmInfra(desiredCsp string, desiredRegion string, srcInfra onpremmo
 		// - KT: ["HDD", "SSD"]
 
 		// * Set names to indicate a dependency between resources.
+		// Use the source disk size as the base, with a CSP-specific minimum floor to avoid
+		// over-provisioning and keep costs low (e.g., AWS/GCP support as low as 10 GB).
+		rootDiskSize := max(int(node.RootDisk.TotalSize), getCspMinRootDiskSizeGB(csp))
 		tempCreateNodeGroupReq := cloudmodel.CreateNodeGroupReq{
 			ConnectionName:   fmt.Sprintf("%s-%s", csp, region),
 			Description:      fmt.Sprintf("a recommended virtual machine %02d for %s", i+1, node.MachineId), // Set MachineId to identify the source node
@@ -474,7 +523,7 @@ func RecommendVmInfra(desiredCsp string, desiredRegion string, srcInfra onpremmo
 			SecurityGroupIds: []string{recommendedSg.Name},                         // Set the security group ID
 			Name:             fmt.Sprintf("migrated-%s", node.MachineId),           // Set MachineId to identify the source node
 			RootDiskType:     "",                                                   // Set "" or default to use CSP's default
-			RootDiskSize:     50,                                                   // Set 50 GB as a default value
+			RootDiskSize:     rootDiskSize,                                         // max(source disk size, CSP minimum) to keep costs low
 			SshKeyId:         recommendedVmInfra.TargetSshKey.Name,                 // Set the SSH key ID
 			NodeUserName:     "",                                                   // TBD: Set the VM user name if needed
 			NodeUserPassword: "",                                                   // TBD
@@ -591,6 +640,9 @@ func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfr
 	// * Set names to indicate a dependency between resources.
 	for i, node := range srcInfra.Nodes {
 		// * Set names to indicate a dependency between resources.
+		// Use the source disk size as the base, with a CSP-specific minimum floor to avoid
+		// over-provisioning and keep costs low (e.g., AWS/GCP support as low as 10 GB).
+		rootDiskSize := max(int(node.RootDisk.TotalSize), getCspMinRootDiskSizeGB(csp))
 		tempCreateNodeGroupReq := cloudmodel.CreateNodeGroupReq{
 			ConnectionName:   fmt.Sprintf("%s-%s", csp, region),
 			Description:      fmt.Sprintf("a recommended virtual machine %02d for %s", i+1, node.MachineId), // Set MachineId to identify the source node
@@ -598,7 +650,7 @@ func RecommendVmInfraCandidates(desiredCsp string, desiredRegion string, srcInfr
 			SubnetId:         skeletonVmInfra.TargetVNet.SubnetInfoList[0].Name, // Set the first subnet for simplicity (TBD, select the appropriate subnet)
 			Name:             fmt.Sprintf("vm-%s", node.MachineId),              // Set MachineId to identify the source node
 			RootDiskType:     "",                                                // Set "" or default to use CSP's default
-			RootDiskSize:     50,                                                // Set 50 GB as a default value
+			RootDiskSize:     rootDiskSize,                                      // max(source disk size, CSP minimum) to keep costs low
 			SshKeyId:         skeletonVmInfra.TargetSshKey.Name,                 // Set the SSH key ID
 			NodeUserName:     "",                                                // TBD: Set the VM user name if needed
 			NodeUserPassword: "",                                                // TBD


### PR DESCRIPTION
This PR includes IBM Cloud support and improves testing infrastructure for multi-cloud migrations.

### Key Changes

**IBM Cloud Support (recommendation)**
- Add IBM Cloud to supported CSP list (9 CSPs total)
- Implement CSP-aware disk sizing with provider-specific minimums
- Optimize costs by using max(source size, CSP minimum)

**Testing Reliability (test-cli)**
- Extend SSH retry timeout from 9s to 3 minutes
- Handle cloud-init delays (IBM Cloud VPC startup)
- Reduce log noise with progressive reporting
- Log at Info level every ~1 minute


(To be tested)

- IBM Cloud VPC VM creation and SSH connectivity
- Disk sizing validation across all 9 supported CSPs
- SSH retry logic with extended timeout window