### PR TITLE
docs(test-cli): refresh test results for 5 CSPs

### DIFF
--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-alibaba.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-alibaba.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 07:24:00*
+*Report generated: 2026-05-18 08:03:27*
 
 ---
 
@@ -31,7 +31,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | ecs.e-c1m1.large, ecs.e-c1m4.large, ecs.e-c1m4.xlarge |
+| 2 | **VM Spec** | 3 | ✅ Selected | ecs.e-c1m4.large, ecs.e-c1m4.xlarge, ecs.e-c1m1.large |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my04-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my04-vnet-01) |
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj7bmodw2wgq0m2c1yd7<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj7iivd2028xy3i16lty<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj76s1u22n44umn80wav<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj7ctm2infbmnn6vq0ex<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj70qfjkj53k1lfmwem5<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj7bmodw2wgq13tm2g8j<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-01
 
-**CSP ID:** sg-mj7fxe8c2piizwjczdu5 | **VNet:** my04-vnet-01 | **Rules:** 14
+**CSP ID:** sg-mj75hai0hn9b26o6u0lu | **VNet:** my04-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-02
 
-**CSP ID:** sg-mj78vtpurhkjr0732i14 | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj71whg4s0wud8qlexce | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-03
 
-**CSP ID:** sg-mj7c5bpxi1r8ykqrnnst | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj78vtpurhkjrhyd2zt7 | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj7q8zrkwhesk9h7ilc0b | 10.0.0.0/21 |
+| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj7kupnhl8vcko5nzmtjs | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj7utyh2dolpsrw3t0oad | 10.0.1.0/24 | my04-vnet-01 |
+| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj7noc100izqdsv9ei3ge | 10.0.1.0/24 | my04-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my04-sshkey-01 | tbd85bsfmpr9ha6oh6f2bg | 43e8a23c72ccaeab23668003ce328889 | Used by all 3 VMs |
+| 1 | my04-sshkey-01 | tbd85ceuupr9ha6omvqisg | c69cc213139d883941a8c2a7d9b26ed1 | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-aws.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-aws.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-14 09:13:12*
+*Report generated: 2026-05-18 08:03:11*
 
 ---
 
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-0601b01e9bc9c2095<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-0586524d744cd9f60<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0277b8136c06aec96<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-05cc436e2832ffd93<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-055c3be58ba3b717a<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0fa2d84cd0c6e08bb<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-01
 
-**CSP ID:** sg-0709d80c5c0511f7a | **VNet:** my01-vnet-01 | **Rules:** 14
+**CSP ID:** sg-094d187b192dfdf77 | **VNet:** my01-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-02
 
-**CSP ID:** sg-0460dcefd8098e744 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-014a3bc57edc785c7 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-03
 
-**CSP ID:** sg-03ad9dc5e16b37c4e | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0b2020b2fa704162e | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-01aed90ffbbedd137 | 10.0.0.0/21 |
+| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-07e218262146e7003 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0a94dc0d9c456d177 | 10.0.1.0/24 | my01-vnet-01 |
+| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0695096ac3c17916f | 10.0.1.0/24 | my01-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my01-sshkey-01 | tbd82p3ndlp7sdqchhjddg | ef:da:bd:b2:9f:a5:9a:e3:3e:66:c4:ff:8c:21:5b:c6:77:bb:89:02 | Used by all 3 VMs |
+| 1 | my01-sshkey-01 | tbd85cetmpr9ha6omvqiog | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-azure.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-azure.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-12 09:46:48*
+*Report generated: 2026-05-18 08:04:07*
 
 ---
 
@@ -31,7 +31,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B4as_v2, Standard_B2als_v2, Standard_B2as_v2 |
+| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B2as_v2, Standard_B4as_v2, Standard_B2als_v2 |
 | 3 | **VM OS Image** | 2 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my02-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my02-vnet-01) |
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 | 2 | my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-01
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fcvm6aji65qtg7s80 | **VNet:** my02-vnet-01 | **Rules:** 14
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g | **VNet:** my02-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-02
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd0u6aji65qtg7s8g | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-03
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd1u6aji65qtg7s90 | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug | 10.0.0.0/21 |
+| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0 | 10.0.1.0/24 | my02-vnet-01 |
+| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 | my02-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g |  | Used by all 3 VMs |
+| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-gcp.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-gcp.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-12 09:51:25*
+*Report generated: 2026-05-18 08:09:10*
 
 ---
 
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tbd81ffbm6aji65qtg7sog<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tbd81ffbm6aji65qtg7sqg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbd81ffbm6aji65qtg7spg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tbd85chgupr9ha6omvqjrg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tbd85chgupr9ha6omvqjtg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbd85chgupr9ha6omvqjsg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-01
 
-**CSP ID:** tbd81fd466aji65qtg7sg0 | **VNet:** my03-vnet-01 | **Rules:** 14
+**CSP ID:** tbd85cf7epr9ha6omvqjh0 | **VNet:** my03-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-02
 
-**CSP ID:** tbd81fdnm6aji65qtg7sh0 | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbd85cfrepr9ha6omvqjhg | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-03
 
-**CSP ID:** tbd81feh66aji65qtg7sn0 | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbd85cgkmpr9ha6omvqjkg | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my03-vnet-01<br>**ID:** tbd81fcrm6aji65qtg7rtg | 10.0.0.0/21 |
+| 1 | **Name:** my03-vnet-01<br>**ID:** tbd85cevepr9ha6omvqj20 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my03-subnet-01<br>**ID:** tbd81fcrm6aji65qtg7ru0 | 10.0.1.0/24 | my03-vnet-01 |
+| 1 | **Name:** my03-subnet-01<br>**ID:** tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 | my03-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my03-sshkey-01 | tbd81fd466aji65qtg7sfg |  | Used by all 3 VMs |
+| 1 | my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-ncp.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-ncp.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-12 09:52:13*
+*Report generated: 2026-05-18 08:11:44*
 
 ---
 
@@ -12,7 +12,7 @@ This report provides a comprehensive summary of the infrastructure migration fro
 
 **Target Region:** KR
 
-**Namespace:** mig01 | **Infra ID:** my04-infra101
+**Namespace:** mig01 | **Infra ID:** my08-infra101
 
 **Migration Status:** Completed
 
@@ -31,10 +31,10 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | s4-g3a, ci2-g3, s2-g3a |
+| 2 | **VM Spec** | 3 | ✅ Selected | ci2-g3, s2-g3a, s4-g3a |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
-| 4 | **VNet (VPC)** | 1 | ✅ Created | my04-vnet-01, CIDR: 10.0.0.0/21 |
-| 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my04-vnet-01) |
+| 4 | **VNet (VPC)** | 1 | ✅ Created | my08-vnet-01, CIDR: 10.0.0.0/21 |
+| 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my08-vnet-01) |
 | 6 | **Security Group** | 3 security groups | ✅ Created | Total 55 rules in 3 sgs |
 | 7 | **SSH Key** | 1 keys | ✅ Created | For VM access control |
 
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 138234481<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 138234474<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 138234467<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 138993641<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 138993649<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 138993635<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -58,9 +58,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM Spec | Source Server | Source Server Spec |
 |-----|-------------|---------|---------------|--------------------|
-| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** ci2-g3<br>**vCPUs:** 2<br>**Memory:** 4.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3a<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Spec ID:** s4-g3a<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 1 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** ci2-g3<br>**vCPUs:** 2<br>**Memory:** 4.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3a<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 3 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Spec ID:** s4-g3a<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -80,13 +80,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 **Summary:** 3 security group(s) with 55 security rule(s) have been created and configured for the migrated VMs.
 
-### Security Group: my04-sg-01
+### Security Group: my08-sg-01
 
-**CSP ID:** 352888 | **VNet:** my04-vnet-01 | **Rules:** 15
+**CSP ID:** 353896 | **VNet:** my08-vnet-01 | **Rules:** 15
 
 **Assigned VMs:**
 
-- **VM:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1
+- **VM:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1
   - **Source Server:** **Hostname:** N/A, **Machine ID:** vm-ec268ed7-821e-9d73-e79f
 
 **Security Rules:**
@@ -109,13 +109,13 @@ Summary of key infrastructure resources created or configured in the target clou
 | 14 | outbound | UDP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 | 15 | outbound | TCP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 
-### Security Group: my04-sg-02
+### Security Group: my08-sg-02
 
-**CSP ID:** 352889 | **VNet:** my04-vnet-01 | **Rules:** 20
+**CSP ID:** 353897 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
-- **VM:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1
+- **VM:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1
   - **Source Server:** **Hostname:** N/A, **Machine ID:** vm-ec2d32b5-98fb-5a96-7913
 
 **Security Rules:**
@@ -143,13 +143,13 @@ Summary of key infrastructure resources created or configured in the target clou
 | 19 | outbound | UDP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 | 20 | outbound | TCP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 
-### Security Group: my04-sg-03
+### Security Group: my08-sg-03
 
-**CSP ID:** 352890 | **VNet:** my04-vnet-01 | **Rules:** 20
+**CSP ID:** 353898 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
-- **VM:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1
+- **VM:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1
   - **Source Server:** **Hostname:** N/A, **Machine ID:** vm-ec288dd0-c6fa-8a49-2f60
 
 **Security Rules:**
@@ -187,13 +187,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my04-vnet-01<br>**ID:** 138792 | 10.0.0.0/21 |
+| 1 | **Name:** my08-vnet-01<br>**ID:** 139135 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my04-subnet-01<br>**ID:** 300131 | 10.0.1.0/24 | my04-vnet-01 |
+| 1 | **Name:** my08-subnet-01<br>**ID:** 300855 | 10.0.1.0/24 | my08-vnet-01 |
 
 ### Source Network Information
 
@@ -235,7 +235,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my04-sshkey-01 | tbd81fd3e6aji65qtg7seg |  | Used by all 3 VMs |
+| 1 | my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-source.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-source.md
@@ -1,6 +1,6 @@
 # Source Infrastructure Summary
 
-**Generated At:** 2026-05-18 07:22:15
+**Generated At:** 2026-05-18 08:01:38
 
 **Infrastructure Name:** infra-3-nodes
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-alibaba.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-alibaba.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 07:23:55
+**Generated At:** 2026-05-18 08:03:21
 
 **Namespace:** mig01
 
@@ -28,9 +28,9 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 | ecs.e-c1m1.large | 2 | 2.0 | - | x86_64 |  | $0.0178 | 1 |
 | ecs.e-c1m4.large | 2 | 8.0 | - | x86_64 |  | $0.0791 | 1 |
-| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 
 ### VM Images
 
@@ -42,9 +42,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj7bmodw2wgq0m2c1yd7 | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.57.53<br>**Private IP:** 10.0.1.244<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj7iivd2028xy3i16lty | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.220.222.227<br>**Private IP:** 10.0.1.246<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj76s1u22n44umn80wav | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.240.250<br>**Private IP:** 10.0.1.245<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj7ctm2infbmnn6vq0ex | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.240.250<br>**Private IP:** 10.0.1.15<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj70qfjkj53k1lfmwem5 | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.220.222.227<br>**Private IP:** 10.0.1.17<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj7bmodw2wgq13tm2g8j | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.57.53<br>**Private IP:** 10.0.1.16<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-vnet-01 |
-| **CSP VNet ID** | vpc-mj7q8zrkwhesk9h7ilc0b |
+| **CSP VNet ID** | vpc-mj7kupnhl8vcko5nzmtjs |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | alibaba-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my04-subnet-01 | vsw-mj7utyh2dolpsrw3t0oad | 10.0.1.0/24 | ap-northeast-2a |
+| my04-subnet-01 | vsw-mj7noc100izqdsv9ei3ge | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my04-sshkey-01 | tbd85bsfmpr9ha6oh6f2bg |  | 43e8a23c72ccaeab23668003ce328889 |
+| my04-sshkey-01 | tbd85ceuupr9ha6omvqisg |  | c69cc213139d883941a8c2a7d9b26ed1 |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-01 |
-| **CSP Security Group ID** | sg-mj7fxe8c2piizwjczdu5 |
+| **CSP Security Group ID** | sg-mj75hai0hn9b26o6u0lu |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-02 |
-| **CSP Security Group ID** | sg-mj78vtpurhkjr0732i14 |
+| **CSP Security Group ID** | sg-mj71whg4s0wud8qlexce |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-03 |
-| **CSP Security Group ID** | sg-mj7c5bpxi1r8ykqrnnst |
+| **CSP Security Group ID** | sg-mj78vtpurhkjrhyd2zt7 |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-aws.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-aws.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-14 09:13:07
+**Generated At:** 2026-05-18 08:03:08
 
 **Namespace:** mig01
 
@@ -28,9 +28,9 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 | t3a.small | 2 | 2.0 | - | x86_64 |  | $0.0234 | 1 |
 | t3a.large | 2 | 8.0 | - | x86_64 |  | $0.0936 | 1 |
-| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 
 ### VM Images
 
@@ -42,9 +42,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-0601b01e9bc9c2095 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 3.36.126.236<br>**Private IP:** 10.0.1.153<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-0586524d744cd9f60 | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.172.180<br>**Private IP:** 10.0.1.231<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0277b8136c06aec96 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.241.178<br>**Private IP:** 10.0.1.123<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-05cc436e2832ffd93 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.239.151<br>**Private IP:** 10.0.1.41<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-055c3be58ba3b717a | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 13.124.168.73<br>**Private IP:** 10.0.1.46<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0fa2d84cd0c6e08bb | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.166.174<br>**Private IP:** 10.0.1.204<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-vnet-01 |
-| **CSP VNet ID** | vpc-01aed90ffbbedd137 |
+| **CSP VNet ID** | vpc-07e218262146e7003 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my01-subnet-01 | subnet-0a94dc0d9c456d177 | 10.0.1.0/24 | ap-northeast-2a |
+| my01-subnet-01 | subnet-0695096ac3c17916f | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my01-sshkey-01 | tbd82p3ndlp7sdqchhjddg |  | ef:da:bd:b2:9f:a5:9a:e3:3e:66:c4:ff:8c:21:5b:c6:77:bb:89:02 |
+| my01-sshkey-01 | tbd85cetmpr9ha6omvqiog |  | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-01 |
-| **CSP Security Group ID** | sg-0709d80c5c0511f7a |
+| **CSP Security Group ID** | sg-094d187b192dfdf77 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-02 |
-| **CSP Security Group ID** | sg-0460dcefd8098e744 |
+| **CSP Security Group ID** | sg-014a3bc57edc785c7 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-03 |
-| **CSP Security Group ID** | sg-03ad9dc5e16b37c4e |
+| **CSP Security Group ID** | sg-0b2020b2fa704162e |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-azure.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-azure.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-12 09:46:42
+**Generated At:** 2026-05-18 08:04:01
 
 **Namespace:** mig01
 
@@ -28,24 +28,24 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| Standard_B4as_v2 | 4 | 15.6 | - | x86_64 |  | $0.1730 | 1 |
 | Standard_B2als_v2 | 2 | 3.9 | - | x86_64 |  | $0.0432 | 1 |
 | Standard_B2as_v2 | 2 | 7.8 | - | x86_64 |  | $0.0865 | 1 |
-| Standard_B4as_v2 | 4 | 15.6 | - | x86_64 |  | $0.1730 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 2 |
+| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.4.247<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.199.161<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.199.157<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.25.229<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.26.6<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.195.68<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
 
 
 ## Network Resources
@@ -57,7 +57,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-vnet-01 |
-| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug |
+| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | azure-koreasouth |
 | **Subnet Count** | 1 |
@@ -66,7 +66,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0 | 10.0.1.0/24 |  |
+| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -75,7 +75,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g |  |  |
+| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  |  |
 
 ### Security Groups
 
@@ -84,7 +84,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-01 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fcvm6aji65qtg7s80 |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -112,7 +112,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-02 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd0u6aji65qtg7s8g |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -145,7 +145,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-03 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd1u6aji65qtg7s90 |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-gcp.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-gcp.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-12 09:51:20
+**Generated At:** 2026-05-18 08:09:08
 
 **Namespace:** mig01
 
@@ -28,9 +28,9 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
-| e2-highcpu-2 | 2 | 2.0 | - | x86_64 |  | $0.0635 | 1 |
 | e2-standard-2 | 2 | 7.8 | - | x86_64 |  | $0.0860 | 1 |
 | e2-standard-4 | 4 | 15.6 | - | x86_64 |  | $0.1719 | 1 |
+| e2-highcpu-2 | 2 | 2.0 | - | x86_64 |  | $0.0635 | 1 |
 
 ### VM Images
 
@@ -42,9 +42,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tbd81ffbm6aji65qtg7sog | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.158.204.63<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tbd81ffbm6aji65qtg7sqg | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.50.35.103<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbd81ffbm6aji65qtg7spg | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.171.230<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tbd85chgupr9ha6omvqjrg | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.47.88.87<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tbd85chgupr9ha6omvqjtg | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.234.91<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbd85chgupr9ha6omvqjsg | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.135.175<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-vnet-01 |
-| **CSP VNet ID** | tbd81fcrm6aji65qtg7rtg |
+| **CSP VNet ID** | tbd85cevepr9ha6omvqj20 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | gcp-asia-northeast3 |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my03-subnet-01 | tbd81fcrm6aji65qtg7ru0 | 10.0.1.0/24 |  |
+| my03-subnet-01 | tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my03-sshkey-01 | tbd81fd466aji65qtg7sfg |  |  |
+| my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  |  |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-01 |
-| **CSP Security Group ID** | tbd81fd466aji65qtg7sg0 |
+| **CSP Security Group ID** | tbd85cf7epr9ha6omvqjh0 |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-02 |
-| **CSP Security Group ID** | tbd81fdnm6aji65qtg7sh0 |
+| **CSP Security Group ID** | tbd85cfrepr9ha6omvqjhg |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-03 |
-| **CSP Security Group ID** | tbd81feh66aji65qtg7sn0 |
+| **CSP Security Group ID** | tbd85cgkmpr9ha6omvqjkg |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-ncp.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-ncp.md
@@ -1,10 +1,10 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-12 09:52:07
+**Generated At:** 2026-05-18 08:11:39
 
 **Namespace:** mig01
 
-**Infra Name:** my04-infra101
+**Infra Name:** my08-infra101
 
 ---
 
@@ -12,7 +12,7 @@
 
 | Property | Value |
 |----------|-------|
-| **Infra Name** | my04-infra101 |
+| **Infra Name** | my08-infra101 |
 | **Description** | Recommended VMs comprising multi-cloud infrastructure |
 | **Status** | Running:3 (R:3/3) |
 | **Target Cloud** | NCP |
@@ -42,21 +42,21 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 138234481 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 101.79.19.173<br>**Private IP:** 10.0.1.8<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 138234474 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 101.79.20.23<br>**Private IP:** 10.0.1.7<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 138234467 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 101.79.19.56<br>**Private IP:** 10.0.1.6<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
+| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 138993641 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 223.130.156.82<br>**Private IP:** 10.0.1.7<br>**SGs:** my08-sg-01<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 138993649 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.20.97<br>**Private IP:** 10.0.1.8<br>**SGs:** my08-sg-03<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 138993635 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.16.239<br>**Private IP:** 10.0.1.6<br>**SGs:** my08-sg-02<br>**SSH:** my08-sshkey-01 |
 
 
 ## Network Resources
 
 ### Virtual Networks (VPC/VNet)
 
-#### VNet: my04-vnet-01
+#### VNet: my08-vnet-01
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-vnet-01 |
-| **CSP VNet ID** | 138792 |
+| **Name** | my08-vnet-01 |
+| **CSP VNet ID** | 139135 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | ncp-kr |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my04-subnet-01 | 300131 | 10.0.1.0/24 | KR-1 |
+| my08-subnet-01 | 300855 | 10.0.1.0/24 | KR-1 |
 
 
 ## Security Resources
@@ -74,17 +74,17 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my04-sshkey-01 | tbd81fd3e6aji65qtg7seg | cb-user |  |
+| my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 | cb-user |  |
 
 ### Security Groups
 
-#### Security Group: my04-sg-01
+#### Security Group: my08-sg-01
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-sg-01 |
-| **CSP Security Group ID** | 352888 |
-| **VNet** | my04-vnet-01 |
+| **Name** | my08-sg-01 |
+| **CSP Security Group ID** | 353896 |
+| **VNet** | my08-vnet-01 |
 | **Rule Count** | 15 rules |
 
 **Security Group Rules:**
@@ -107,13 +107,13 @@
 | outbound | UDP | 1-65535 | 0.0.0.0/0 |
 | outbound | TCP | 1-65535 | 0.0.0.0/0 |
 
-#### Security Group: my04-sg-02
+#### Security Group: my08-sg-02
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-sg-02 |
-| **CSP Security Group ID** | 352889 |
-| **VNet** | my04-vnet-01 |
+| **Name** | my08-sg-02 |
+| **CSP Security Group ID** | 353897 |
+| **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
 **Security Group Rules:**
@@ -141,13 +141,13 @@
 | outbound | UDP | 1-65535 | 0.0.0.0/0 |
 | outbound | TCP | 1-65535 | 0.0.0.0/0 |
 
-#### Security Group: my04-sg-03
+#### Security Group: my08-sg-03
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-sg-03 |
-| **CSP Security Group ID** | 352890 |
-| **VNet** | my04-vnet-01 |
+| **Name** | my08-sg-03 |
+| **CSP Security Group ID** | 353898 |
+| **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
 **Security Group Rules:**
@@ -196,8 +196,8 @@
 
 | VM Name | Spec | Cost/Hour (USD) | Cost/Month (USD) |
 |---------|------|-----------------|------------------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | ci2-g3 | $0.0730 | $52.56 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3a | $0.0848 | $61.06 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | s4-g3a | $0.1747 | $125.78 |
+| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | ci2-g3 | $0.0730 | $52.56 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3a | $0.0848 | $61.06 |
+| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | s4-g3a | $0.1747 | $125.78 |
 
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-alibaba.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-alibaba.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (42ade13)
+- CM-Beetle: imdl/v0.1.5+ (c574040)
 - cm-model: unknown
 - CB-Tumblebug: vunknown
 - CB-Spider: vunknown
@@ -18,8 +18,8 @@
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
 - Test Date: May 18, 2026
-- Test Time: 16:22:15 KST
-- Test Execution: 2026-05-18 16:22:15 KST
+- Test Time: 17:01:41 KST
+- Test Execution: 2026-05-18 17:01:41 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 6.804s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m3.204s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 27ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 4ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 19ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 5.907s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m5.535s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 37ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 6ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 31ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.353s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.308s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 23.644s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.27s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.332s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 23.674s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 2m46.073194791s
+**Total Duration**: 2m47.317808091s
 
-*Test executed on May 18, 2026 at 16:22:15 KST (2026-05-18 16:22:15 KST) using CM-Beetle automated test CLI*
+*Test executed on May 18, 2026 at 17:01:41 KST (2026-05-18 17:01:41 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -3504,7 +3504,7 @@
 {
   "resourceType": "infra",
   "id": "my04-infra101",
-  "uid": "tbd85bsi6pr9ha6oh6f2dg",
+  "uid": "tbd85cf1upr9ha6omvqj60",
   "name": "my04-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -3532,7 +3532,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my04-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85bsi6pr9ha6oh6f2dg"
+    "sys.uid": "tbd85cf1upr9ha6omvqj60"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -3541,9 +3541,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85bsi6pr9ha6oh6f2eg",
-      "cspResourceName": "tbd85bsi6pr9ha6oh6f2eg",
-      "cspResourceId": "i-mj7bmodw2wgq0m2c1yd7",
+      "uid": "tbd85cf1upr9ha6omvqj70",
+      "cspResourceName": "tbd85cf1upr9ha6omvqj70",
+      "cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
       "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -3557,13 +3557,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 07:23:19",
+      "createdTime": "2026-05-18 08:02:47",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 07:23:19",
-        "sys.cspResourceId": "i-mj7bmodw2wgq0m2c1yd7",
-        "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2eg",
+        "sys.createdTime": "2026-05-18 08:02:47",
+        "sys.cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
+        "sys.cspResourceName": "tbd85cf1upr9ha6omvqj70",
         "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -3572,7 +3572,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd85bsi6pr9ha6oh6f2eg",
+        "sys.uid": "tbd85cf1upr9ha6omvqj70",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -3580,10 +3580,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.57.53",
+      "publicIP": "47.80.240.250",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.244",
+      "privateIP": "10.0.1.15",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": 40,
@@ -3635,23 +3635,23 @@
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+      "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-      "networkInterface": "eni-mj7bmodw2wgq0m2ilh4w",
+      "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+      "networkInterface": "eni-mj7ctm2infbmnn6uucox",
       "securityGroupIds": [
         "my04-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+      "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "8$bptA1!sd5bi6",
+      "nodeUserPassword": "upb!t1$1fd8c5A",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBImrnQ1OLqeJX5QkeseBQDL6cp6QxlVw9ugzvNKG+sRdgjry3e6aSom3hime/qhctodX/eDLu07lhHFLpk4lKV0=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIxjgydAuYGlPu0chuI8q9j7hzoY0Rq4M/6ULrhSpcsPA78KSE4g2MEgG2KnC/Y9kaOYioaIMVk355QCS+/2JM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:XvJmDadkdy+ee6r1hLgon38wSlkG7vHhjMiLp3aAKj0",
-        "firstUsedAt": "2026-05-18T07:23:29Z"
+        "fingerprint": "SHA256:ElR8y8aTDUmfc8Kf9iCIhXjocBPKZg5jjX79lSxer8U",
+        "firstUsedAt": "2026-05-18T08:02:56Z"
       },
       "commandStatus": [
         {
@@ -3659,11 +3659,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T07:23:29Z",
-          "completedTime": "2026-05-18T07:23:30Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:02:55Z",
+          "completedTime": "2026-05-18T08:02:57Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj7bmodw2wgq0m2c1yd7Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -3698,7 +3698,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbd85bsi6pr9ha6oh6f2eg"
+          "value": "tbd85cf1upr9ha6omvqj70"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -3718,7 +3718,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "ZoneId",
@@ -3734,7 +3734,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj7bmodw2wgq0m2c1yd7Z"
+          "value": "iZmj7ctm2infbmnn6vq0exZ"
         },
         {
           "key": "Status",
@@ -3766,7 +3766,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "e5bf153c-cb27-4946-a211-b4cccd0b403b"
+          "value": "13344c44-f69b-4fdb-bc04-e9e4756fde66"
         },
         {
           "key": "RegionId",
@@ -3786,7 +3786,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj7bmodw2wgq0m2c1yd7"
+          "value": "i-mj7ctm2infbmnn6vq0ex"
         },
         {
           "key": "Recyclable",
@@ -3806,11 +3806,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbd85bsfmpr9ha6oh6f2bg"
+          "value": "tbd85ceuupr9ha6omvqisg"
         },
         {
           "key": "LocalStorageCapacity",
@@ -3834,7 +3834,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7fxe8c2piizwjczdu5]}"
+          "value": "{SecurityGroupId:[sg-mj75hai0hn9b26o6u0lu]}"
         },
         {
           "key": "InnerIpAddress",
@@ -3842,7 +3842,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.57.53]}"
+          "value": "{IpAddress:[47.80.240.250]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -3890,7 +3890,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.244]}}"
+          "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.15]}}"
         },
         {
           "key": "Tags",
@@ -3898,7 +3898,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:98,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq0m2ilh4w,PrimaryIpAddress:10.0.1.244,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.244,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:30,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7ctm2infbmnn6uucox,PrimaryIpAddress:10.0.1.15,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.15,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -3909,9 +3909,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85bsi6pr9ha6oh6f2gg",
-      "cspResourceName": "tbd85bsi6pr9ha6oh6f2gg",
-      "cspResourceId": "i-mj7iivd2028xy3i16lty",
+      "uid": "tbd85cf1upr9ha6omvqj90",
+      "cspResourceName": "tbd85cf1upr9ha6omvqj90",
+      "cspResourceId": "i-mj70qfjkj53k1lfmwem5",
       "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -3925,13 +3925,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 07:23:21",
+      "createdTime": "2026-05-18 08:02:47",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 07:23:21",
-        "sys.cspResourceId": "i-mj7iivd2028xy3i16lty",
-        "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2gg",
+        "sys.createdTime": "2026-05-18 08:02:47",
+        "sys.cspResourceId": "i-mj70qfjkj53k1lfmwem5",
+        "sys.cspResourceName": "tbd85cf1upr9ha6omvqj90",
         "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -3940,7 +3940,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd85bsi6pr9ha6oh6f2gg",
+        "sys.uid": "tbd85cf1upr9ha6omvqj90",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -3951,7 +3951,7 @@
       "publicIP": "8.220.222.227",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.246",
+      "privateIP": "10.0.1.17",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": 40,
@@ -4003,23 +4003,23 @@
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+      "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-      "networkInterface": "eni-mj7iivd2028xy3i6fvkf",
+      "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+      "networkInterface": "eni-mj70qfjkj53k1lfk3g4v",
       "securityGroupIds": [
         "my04-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+      "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "iptbsA8!$61bd5",
+      "nodeUserPassword": "1bc15$udf8pAt!",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAqGOQgKJS8UdcsRVUfr5i+Pgv0ORX62ugwd1yYNxexKIVogXT682Vgw9TECnUjA3cSqFVgesvJYpwjJtYcgoxc=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjpJO+iCEU9UWWxdK8tLAyQm+wo3x/MrYpIbM/i6AEC/aXL7gIArd+gJWLDbG4U7beYUDeqNCYoNaQ84LkntQ4=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:HvqcqnsMLncQbFRcpY+PiEon3QkJOSXgz+7Fx84gy0E",
-        "firstUsedAt": "2026-05-18T07:23:29Z"
+        "fingerprint": "SHA256:CN3Vr5UeDqGvqf+08il0YBKW/Q92T5KR3JBAFnULA/I",
+        "firstUsedAt": "2026-05-18T08:02:56Z"
       },
       "commandStatus": [
         {
@@ -4027,11 +4027,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T07:23:29Z",
-          "completedTime": "2026-05-18T07:23:30Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:02:55Z",
+          "completedTime": "2026-05-18T08:02:57Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj7iivd2028xy3i16ltyZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4066,7 +4066,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbd85bsi6pr9ha6oh6f2gg"
+          "value": "tbd85cf1upr9ha6omvqj90"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -4086,7 +4086,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "ZoneId",
@@ -4102,7 +4102,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj7iivd2028xy3i16ltyZ"
+          "value": "iZmj70qfjkj53k1lfmwem5Z"
         },
         {
           "key": "Status",
@@ -4134,7 +4134,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "2ce7f1bc-e537-45dc-8b19-cd5899649d0a"
+          "value": "59a11a5d-1a8e-4b85-8c4f-4e84016912bd"
         },
         {
           "key": "RegionId",
@@ -4154,7 +4154,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj7iivd2028xy3i16lty"
+          "value": "i-mj70qfjkj53k1lfmwem5"
         },
         {
           "key": "Recyclable",
@@ -4174,11 +4174,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbd85bsfmpr9ha6oh6f2bg"
+          "value": "tbd85ceuupr9ha6omvqisg"
         },
         {
           "key": "LocalStorageCapacity",
@@ -4202,7 +4202,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7c5bpxi1r8ykqrnnst]}"
+          "value": "{SecurityGroupId:[sg-mj78vtpurhkjrhyd2zt7]}"
         },
         {
           "key": "InnerIpAddress",
@@ -4258,7 +4258,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.246]}}"
+          "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.17]}}"
         },
         {
           "key": "Tags",
@@ -4266,7 +4266,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:9a,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7iivd2028xy3i6fvkf,PrimaryIpAddress:10.0.1.246,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.246,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:32,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70qfjkj53k1lfk3g4v,PrimaryIpAddress:10.0.1.17,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.17,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -4277,9 +4277,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85bsi6pr9ha6oh6f2fg",
-      "cspResourceName": "tbd85bsi6pr9ha6oh6f2fg",
-      "cspResourceId": "i-mj76s1u22n44umn80wav",
+      "uid": "tbd85cf1upr9ha6omvqj80",
+      "cspResourceName": "tbd85cf1upr9ha6omvqj80",
+      "cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
       "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4293,13 +4293,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 07:23:12",
+      "createdTime": "2026-05-18 08:02:47",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 07:23:12",
-        "sys.cspResourceId": "i-mj76s1u22n44umn80wav",
-        "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2fg",
+        "sys.createdTime": "2026-05-18 08:02:47",
+        "sys.cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
+        "sys.cspResourceName": "tbd85cf1upr9ha6omvqj80",
         "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -4308,7 +4308,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd85bsi6pr9ha6oh6f2fg",
+        "sys.uid": "tbd85cf1upr9ha6omvqj80",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -4316,10 +4316,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.240.250",
+      "publicIP": "47.80.57.53",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.245",
+      "privateIP": "10.0.1.16",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": 40,
@@ -4371,23 +4371,23 @@
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+      "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-      "networkInterface": "eni-mj76s1u22n44umn1evzu",
+      "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+      "networkInterface": "eni-mj7bmodw2wgq13tslyzg",
       "securityGroupIds": [
         "my04-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+      "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "p5i1tb6b8d!sA$",
+      "nodeUserPassword": "$dA5bucp!f1t81",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCM/UUlUEt2qBIAGxsO9f59EwxFdKH5wMqBGOGYnxNjgrTDAq6PS8eEBL+fN8aoYq+oJ42KGkaWCbl9FPxaXFTs=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIoOQ2gvfcNkTlNvuqkusRt8H2qhBA89swB2tyZNTyPQI6IG5Rq30BzABy4uD/mVN5T1FFu4vaI+o5kEgApc87Q=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:+SrCDwxr0rszio/vIV3LF4L/NjMiNDzD9XYChCn+7lQ",
-        "firstUsedAt": "2026-05-18T07:23:29Z"
+        "fingerprint": "SHA256:Y6GQw48WwR78o9JdeZKtnxMOFr9e5MIESK+ZhUdpvPM",
+        "firstUsedAt": "2026-05-18T08:02:55Z"
       },
       "commandStatus": [
         {
@@ -4395,10 +4395,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T07:23:29Z",
-          "completedTime": "2026-05-18T07:23:29Z",
+          "startedTime": "2026-05-18T08:02:55Z",
+          "completedTime": "2026-05-18T08:02:56Z",
+          "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj76s1u22n44umn80wavZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4433,7 +4434,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbd85bsi6pr9ha6oh6f2fg"
+          "value": "tbd85cf1upr9ha6omvqj80"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -4453,7 +4454,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "ZoneId",
@@ -4469,7 +4470,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj76s1u22n44umn80wavZ"
+          "value": "iZmj7bmodw2wgq13tm2g8jZ"
         },
         {
           "key": "Status",
@@ -4501,7 +4502,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "eb6bcd3f-4858-48d5-8243-269a61ba9528"
+          "value": "3e72e546-fbd2-4921-a2ff-d588c6c712fc"
         },
         {
           "key": "RegionId",
@@ -4521,7 +4522,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj76s1u22n44umn80wav"
+          "value": "i-mj7bmodw2wgq13tm2g8j"
         },
         {
           "key": "Recyclable",
@@ -4541,11 +4542,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbd85bsfmpr9ha6oh6f2bg"
+          "value": "tbd85ceuupr9ha6omvqisg"
         },
         {
           "key": "LocalStorageCapacity",
@@ -4569,7 +4570,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj78vtpurhkjr0732i14]}"
+          "value": "{SecurityGroupId:[sg-mj71whg4s0wud8qlexce]}"
         },
         {
           "key": "InnerIpAddress",
@@ -4577,7 +4578,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.240.250]}"
+          "value": "{IpAddress:[47.80.57.53]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -4625,7 +4626,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.245]}}"
+          "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.16]}}"
         },
         {
           "key": "Tags",
@@ -4633,7 +4634,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:99,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj76s1u22n44umn1evzu,PrimaryIpAddress:10.0.1.245,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.245,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:31,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq13tslyzg,PrimaryIpAddress:10.0.1.16,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.16,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -4654,12 +4655,12 @@
       {
         "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "47.80.240.250",
+        "nodeIp": "47.80.57.53",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj76s1u22n44umn80wavZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4669,12 +4670,12 @@
       {
         "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "47.80.57.53",
+        "nodeIp": "47.80.240.250",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj7bmodw2wgq0m2c1yd7Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4689,7 +4690,7 @@
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj7iivd2028xy3i16ltyZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4724,8 +4725,1181 @@
   "infra": [
     {
       "resourceType": "infra",
+      "id": "my01-infra101",
+      "uid": "tbd85cevepr9ha6omvqit0",
+      "name": "my01-infra101",
+      "status": "Running:3 (R:3/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 0,
+        "countRunning": 3,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "None",
+      "targetAction": "None",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my01-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my01-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbd85cevepr9ha6omvqit0"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbd85cevepr9ha6omvqiu0",
+          "cspResourceName": "tbd85cevepr9ha6omvqiu0",
+          "cspResourceId": "i-05cc436e2832ffd93",
+          "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-05-18 08:02:29",
+          "label": {
+            "Name": "tbd85cevepr9ha6omvqiu0",
+            "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.connectionName": "aws-ap-northeast-2",
+            "sys.createdTime": "2026-05-18 08:02:29",
+            "sys.cspResourceId": "i-05cc436e2832ffd93",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
+            "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.infraId": "my01-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.subnetId": "my01-subnet-01",
+            "sys.uid": "tbd85cevepr9ha6omvqiu0",
+            "sys.vNetId": "my01-vnet-01"
+          },
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "43.203.239.151",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.41",
+          "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
+          "rootDiskType": "gp2",
+          "rootDiskSize": 10,
+          "RootDeviceName": "/dev/sda1",
+          "connectionName": "aws-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "aws-ap-northeast-2",
+            "providerName": "aws",
+            "driverName": "aws-driver-v1.0.so",
+            "credentialName": "aws",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "aws-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "Asia Pacific (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b",
+                "ap-northeast-2c",
+                "ap-northeast-2d"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "aws+ap-northeast-2+t3a.small",
+          "cspSpecName": "t3a.small",
+          "spec": {
+            "cspSpecName": "t3a.small",
+            "vCPU": 2,
+            "memoryGiB": 2,
+            "costPerHour": 0.0234
+          },
+          "imageId": "ami-08a1c21841a4c7a5f",
+          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+          },
+          "vNetId": "my01-vnet-01",
+          "cspVNetId": "vpc-07e218262146e7003",
+          "subnetId": "my01-subnet-01",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-04753091ce5855ac2",
+          "securityGroupIds": [
+            "my01-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my01-sshkey-01",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
+            "firstUsedAt": "2026-05-18T08:02:39Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "AmiLaunchIndex",
+              "value": "0"
+            },
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CapacityReservationSpecification",
+              "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+            },
+            {
+              "key": "ClientToken",
+              "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{CoreCount:1,ThreadsPerCore:2}"
+            },
+            {
+              "key": "EbsOptimized",
+              "value": "false"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "EnclaveOptions",
+              "value": "{Enabled:false}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-08a1c21841a4c7a5f"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-05cc436e2832ffd93"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.small"
+            },
+            {
+              "key": "KeyName",
+              "value": "tbd85cetmpr9ha6omvqiog"
+            },
+            {
+              "key": "LaunchTime",
+              "value": "2026-05-18T08:02:08Z"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+            },
+            {
+              "key": "Monitoring",
+              "value": "{State:disabled}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+            },
+            {
+              "key": "Placement",
+              "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+            },
+            {
+              "key": "PrivateDnsName",
+              "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
+            },
+            {
+              "key": "PrivateIpAddress",
+              "value": "10.0.1.41"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "43.203.239.151"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SecurityGroups",
+              "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
+            },
+            {
+              "key": "SourceDestCheck",
+              "value": "true"
+            },
+            {
+              "key": "State",
+              "value": "{Code:16,Name:running}"
+            },
+            {
+              "key": "SubnetId",
+              "value": "subnet-0695096ac3c17916f"
+            },
+            {
+              "key": "Tags",
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            },
+            {
+              "key": "VpcId",
+              "value": "vpc-07e218262146e7003"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd85cevepr9ha6omvqj00",
+          "cspResourceName": "tbd85cevepr9ha6omvqj00",
+          "cspResourceId": "i-055c3be58ba3b717a",
+          "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-05-18 08:02:31",
+          "label": {
+            "Name": "tbd85cevepr9ha6omvqj00",
+            "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.connectionName": "aws-ap-northeast-2",
+            "sys.createdTime": "2026-05-18 08:02:31",
+            "sys.cspResourceId": "i-055c3be58ba3b717a",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
+            "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.infraId": "my01-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.subnetId": "my01-subnet-01",
+            "sys.uid": "tbd85cevepr9ha6omvqj00",
+            "sys.vNetId": "my01-vnet-01"
+          },
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "13.124.168.73",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.46",
+          "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
+          "rootDiskType": "gp2",
+          "rootDiskSize": 10,
+          "RootDeviceName": "/dev/sda1",
+          "connectionName": "aws-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "aws-ap-northeast-2",
+            "providerName": "aws",
+            "driverName": "aws-driver-v1.0.so",
+            "credentialName": "aws",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "aws-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "Asia Pacific (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b",
+                "ap-northeast-2c",
+                "ap-northeast-2d"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "aws+ap-northeast-2+t3a.large",
+          "cspSpecName": "t3a.large",
+          "spec": {
+            "cspSpecName": "t3a.large",
+            "vCPU": 2,
+            "memoryGiB": 8,
+            "costPerHour": 0.0936
+          },
+          "imageId": "ami-08a1c21841a4c7a5f",
+          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+          },
+          "vNetId": "my01-vnet-01",
+          "cspVNetId": "vpc-07e218262146e7003",
+          "subnetId": "my01-subnet-01",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-0512107afc0efe575",
+          "securityGroupIds": [
+            "my01-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my01-sshkey-01",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
+            "firstUsedAt": "2026-05-18T08:02:39Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "AmiLaunchIndex",
+              "value": "0"
+            },
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CapacityReservationSpecification",
+              "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+            },
+            {
+              "key": "ClientToken",
+              "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{CoreCount:1,ThreadsPerCore:2}"
+            },
+            {
+              "key": "EbsOptimized",
+              "value": "false"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "EnclaveOptions",
+              "value": "{Enabled:false}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-08a1c21841a4c7a5f"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-055c3be58ba3b717a"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.large"
+            },
+            {
+              "key": "KeyName",
+              "value": "tbd85cetmpr9ha6omvqiog"
+            },
+            {
+              "key": "LaunchTime",
+              "value": "2026-05-18T08:02:08Z"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+            },
+            {
+              "key": "Monitoring",
+              "value": "{State:disabled}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+            },
+            {
+              "key": "Placement",
+              "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+            },
+            {
+              "key": "PrivateDnsName",
+              "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
+            },
+            {
+              "key": "PrivateIpAddress",
+              "value": "10.0.1.46"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "13.124.168.73"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SecurityGroups",
+              "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
+            },
+            {
+              "key": "SourceDestCheck",
+              "value": "true"
+            },
+            {
+              "key": "State",
+              "value": "{Code:16,Name:running}"
+            },
+            {
+              "key": "SubnetId",
+              "value": "subnet-0695096ac3c17916f"
+            },
+            {
+              "key": "Tags",
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            },
+            {
+              "key": "VpcId",
+              "value": "vpc-07e218262146e7003"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbd85cevepr9ha6omvqiv0",
+          "cspResourceName": "tbd85cevepr9ha6omvqiv0",
+          "cspResourceId": "i-0fa2d84cd0c6e08bb",
+          "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-05-18 08:02:28",
+          "label": {
+            "Name": "tbd85cevepr9ha6omvqiv0",
+            "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.connectionName": "aws-ap-northeast-2",
+            "sys.createdTime": "2026-05-18 08:02:28",
+            "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
+            "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.infraId": "my01-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.subnetId": "my01-subnet-01",
+            "sys.uid": "tbd85cevepr9ha6omvqiv0",
+            "sys.vNetId": "my01-vnet-01"
+          },
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "52.78.166.174",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.204",
+          "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
+          "rootDiskType": "gp2",
+          "rootDiskSize": 10,
+          "RootDeviceName": "/dev/sda1",
+          "connectionName": "aws-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "aws-ap-northeast-2",
+            "providerName": "aws",
+            "driverName": "aws-driver-v1.0.so",
+            "credentialName": "aws",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "aws-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "Asia Pacific (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b",
+                "ap-northeast-2c",
+                "ap-northeast-2d"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "aws+ap-northeast-2+t3a.xlarge",
+          "cspSpecName": "t3a.xlarge",
+          "spec": {
+            "cspSpecName": "t3a.xlarge",
+            "vCPU": 4,
+            "memoryGiB": 16,
+            "costPerHour": 0.1872
+          },
+          "imageId": "ami-08a1c21841a4c7a5f",
+          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+          },
+          "vNetId": "my01-vnet-01",
+          "cspVNetId": "vpc-07e218262146e7003",
+          "subnetId": "my01-subnet-01",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-0dacfd07e29c82162",
+          "securityGroupIds": [
+            "my01-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my01-sshkey-01",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
+            "firstUsedAt": "2026-05-18T08:02:37Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "AmiLaunchIndex",
+              "value": "0"
+            },
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CapacityReservationSpecification",
+              "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+            },
+            {
+              "key": "ClientToken",
+              "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{CoreCount:2,ThreadsPerCore:2}"
+            },
+            {
+              "key": "EbsOptimized",
+              "value": "false"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "EnclaveOptions",
+              "value": "{Enabled:false}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-08a1c21841a4c7a5f"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-0fa2d84cd0c6e08bb"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.xlarge"
+            },
+            {
+              "key": "KeyName",
+              "value": "tbd85cetmpr9ha6omvqiog"
+            },
+            {
+              "key": "LaunchTime",
+              "value": "2026-05-18T08:02:07Z"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+            },
+            {
+              "key": "Monitoring",
+              "value": "{State:disabled}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+            },
+            {
+              "key": "Placement",
+              "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+            },
+            {
+              "key": "PrivateDnsName",
+              "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
+            },
+            {
+              "key": "PrivateIpAddress",
+              "value": "10.0.1.204"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "52.78.166.174"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SecurityGroups",
+              "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
+            },
+            {
+              "key": "SourceDestCheck",
+              "value": "true"
+            },
+            {
+              "key": "State",
+              "value": "{Code:16,Name:running}"
+            },
+            {
+              "key": "SubnetId",
+              "value": "subnet-0695096ac3c17916f"
+            },
+            {
+              "key": "Tags",
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            },
+            {
+              "key": "VpcId",
+              "value": "vpc-07e218262146e7003"
+            }
+          ]
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": [
+          {
+            "infraId": "my01-infra101",
+            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "52.78.166.174",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my01-infra101",
+            "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "43.203.239.151",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my01-infra101",
+            "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "13.124.168.73",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": "infra",
+      "id": "my02-infra101",
+      "uid": "tbd85cf3epr9ha6omvqjbg",
+      "name": "my02-infra101",
+      "status": "Creating:3 (R:0/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 3,
+        "countRunning": 0,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "Running",
+      "targetAction": "Create",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my02-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my02-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbd85cf3epr9ha6omvqjbg"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbd85cf3epr9ha6omvqjcg",
+          "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2als_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd85cf3epr9ha6omvqjeg",
+          "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2as_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbd85cf3epr9ha6omvqjdg",
+          "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b4as_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": null
+      }
+    },
+    {
+      "resourceType": "infra",
       "id": "my04-infra101",
-      "uid": "tbd85bsi6pr9ha6oh6f2dg",
+      "uid": "tbd85cf1upr9ha6omvqj60",
       "name": "my04-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -4753,7 +5927,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my04-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85bsi6pr9ha6oh6f2dg"
+        "sys.uid": "tbd85cf1upr9ha6omvqj60"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -4762,9 +5936,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85bsi6pr9ha6oh6f2eg",
-          "cspResourceName": "tbd85bsi6pr9ha6oh6f2eg",
-          "cspResourceId": "i-mj7bmodw2wgq0m2c1yd7",
+          "uid": "tbd85cf1upr9ha6omvqj70",
+          "cspResourceName": "tbd85cf1upr9ha6omvqj70",
+          "cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
           "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -4778,13 +5952,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 07:23:19",
+          "createdTime": "2026-05-18 08:02:47",
           "label": {
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 07:23:19",
-            "sys.cspResourceId": "i-mj7bmodw2wgq0m2c1yd7",
-            "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2eg",
+            "sys.createdTime": "2026-05-18 08:02:47",
+            "sys.cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
+            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj70",
             "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -4793,7 +5967,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd85bsi6pr9ha6oh6f2eg",
+            "sys.uid": "tbd85cf1upr9ha6omvqj70",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -4801,10 +5975,10 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "47.80.57.53",
+          "publicIP": "47.80.240.250",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.244",
+          "privateIP": "10.0.1.15",
           "privateDNS": "",
           "rootDiskType": "cloud_essd",
           "rootDiskSize": 40,
@@ -4856,23 +6030,23 @@
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-          "networkInterface": "eni-mj7bmodw2wgq0m2ilh4w",
+          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+          "networkInterface": "eni-mj7ctm2infbmnn6uucox",
           "securityGroupIds": [
             "my04-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "8$bptA1!sd5bi6",
+          "nodeUserPassword": "upb!t1$1fd8c5A",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBImrnQ1OLqeJX5QkeseBQDL6cp6QxlVw9ugzvNKG+sRdgjry3e6aSom3hime/qhctodX/eDLu07lhHFLpk4lKV0=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIxjgydAuYGlPu0chuI8q9j7hzoY0Rq4M/6ULrhSpcsPA78KSE4g2MEgG2KnC/Y9kaOYioaIMVk355QCS+/2JM=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:XvJmDadkdy+ee6r1hLgon38wSlkG7vHhjMiLp3aAKj0",
-            "firstUsedAt": "2026-05-18T07:23:29Z"
+            "fingerprint": "SHA256:ElR8y8aTDUmfc8Kf9iCIhXjocBPKZg5jjX79lSxer8U",
+            "firstUsedAt": "2026-05-18T08:02:56Z"
           },
           "commandStatus": [
             {
@@ -4880,11 +6054,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T07:23:29Z",
-              "completedTime": "2026-05-18T07:23:30Z",
-              "elapsedTime": 1,
+              "startedTime": "2026-05-18T08:02:55Z",
+              "completedTime": "2026-05-18T08:02:57Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj7bmodw2wgq0m2c1yd7Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -4919,7 +6093,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbd85bsi6pr9ha6oh6f2eg"
+              "value": "tbd85cf1upr9ha6omvqj70"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -4939,7 +6113,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-18T07:22Z"
+              "value": "2026-05-18T08:02Z"
             },
             {
               "key": "ZoneId",
@@ -4955,7 +6129,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj7bmodw2wgq0m2c1yd7Z"
+              "value": "iZmj7ctm2infbmnn6vq0exZ"
             },
             {
               "key": "Status",
@@ -4987,7 +6161,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "e5bf153c-cb27-4946-a211-b4cccd0b403b"
+              "value": "13344c44-f69b-4fdb-bc04-e9e4756fde66"
             },
             {
               "key": "RegionId",
@@ -5007,7 +6181,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj7bmodw2wgq0m2c1yd7"
+              "value": "i-mj7ctm2infbmnn6vq0ex"
             },
             {
               "key": "Recyclable",
@@ -5027,11 +6201,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-18T07:22Z"
+              "value": "2026-05-18T08:02Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbd85bsfmpr9ha6oh6f2bg"
+              "value": "tbd85ceuupr9ha6omvqisg"
             },
             {
               "key": "LocalStorageCapacity",
@@ -5055,7 +6229,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj7fxe8c2piizwjczdu5]}"
+              "value": "{SecurityGroupId:[sg-mj75hai0hn9b26o6u0lu]}"
             },
             {
               "key": "InnerIpAddress",
@@ -5063,7 +6237,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[47.80.57.53]}"
+              "value": "{IpAddress:[47.80.240.250]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -5111,7 +6285,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.244]}}"
+              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.15]}}"
             },
             {
               "key": "Tags",
@@ -5119,7 +6293,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:98,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq0m2ilh4w,PrimaryIpAddress:10.0.1.244,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.244,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:30,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7ctm2infbmnn6uucox,PrimaryIpAddress:10.0.1.15,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.15,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -5130,9 +6304,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85bsi6pr9ha6oh6f2gg",
-          "cspResourceName": "tbd85bsi6pr9ha6oh6f2gg",
-          "cspResourceId": "i-mj7iivd2028xy3i16lty",
+          "uid": "tbd85cf1upr9ha6omvqj90",
+          "cspResourceName": "tbd85cf1upr9ha6omvqj90",
+          "cspResourceId": "i-mj70qfjkj53k1lfmwem5",
           "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5146,13 +6320,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 07:23:21",
+          "createdTime": "2026-05-18 08:02:47",
           "label": {
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 07:23:21",
-            "sys.cspResourceId": "i-mj7iivd2028xy3i16lty",
-            "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2gg",
+            "sys.createdTime": "2026-05-18 08:02:47",
+            "sys.cspResourceId": "i-mj70qfjkj53k1lfmwem5",
+            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj90",
             "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -5161,7 +6335,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd85bsi6pr9ha6oh6f2gg",
+            "sys.uid": "tbd85cf1upr9ha6omvqj90",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -5172,7 +6346,7 @@
           "publicIP": "8.220.222.227",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.246",
+          "privateIP": "10.0.1.17",
           "privateDNS": "",
           "rootDiskType": "cloud_essd",
           "rootDiskSize": 40,
@@ -5224,23 +6398,23 @@
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-          "networkInterface": "eni-mj7iivd2028xy3i6fvkf",
+          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+          "networkInterface": "eni-mj70qfjkj53k1lfk3g4v",
           "securityGroupIds": [
             "my04-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "iptbsA8!$61bd5",
+          "nodeUserPassword": "1bc15$udf8pAt!",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAqGOQgKJS8UdcsRVUfr5i+Pgv0ORX62ugwd1yYNxexKIVogXT682Vgw9TECnUjA3cSqFVgesvJYpwjJtYcgoxc=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjpJO+iCEU9UWWxdK8tLAyQm+wo3x/MrYpIbM/i6AEC/aXL7gIArd+gJWLDbG4U7beYUDeqNCYoNaQ84LkntQ4=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:HvqcqnsMLncQbFRcpY+PiEon3QkJOSXgz+7Fx84gy0E",
-            "firstUsedAt": "2026-05-18T07:23:29Z"
+            "fingerprint": "SHA256:CN3Vr5UeDqGvqf+08il0YBKW/Q92T5KR3JBAFnULA/I",
+            "firstUsedAt": "2026-05-18T08:02:56Z"
           },
           "commandStatus": [
             {
@@ -5248,11 +6422,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T07:23:29Z",
-              "completedTime": "2026-05-18T07:23:30Z",
-              "elapsedTime": 1,
+              "startedTime": "2026-05-18T08:02:55Z",
+              "completedTime": "2026-05-18T08:02:57Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj7iivd2028xy3i16ltyZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5287,7 +6461,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbd85bsi6pr9ha6oh6f2gg"
+              "value": "tbd85cf1upr9ha6omvqj90"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -5307,7 +6481,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-18T07:22Z"
+              "value": "2026-05-18T08:02Z"
             },
             {
               "key": "ZoneId",
@@ -5323,7 +6497,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj7iivd2028xy3i16ltyZ"
+              "value": "iZmj70qfjkj53k1lfmwem5Z"
             },
             {
               "key": "Status",
@@ -5355,7 +6529,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "2ce7f1bc-e537-45dc-8b19-cd5899649d0a"
+              "value": "59a11a5d-1a8e-4b85-8c4f-4e84016912bd"
             },
             {
               "key": "RegionId",
@@ -5375,7 +6549,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj7iivd2028xy3i16lty"
+              "value": "i-mj70qfjkj53k1lfmwem5"
             },
             {
               "key": "Recyclable",
@@ -5395,11 +6569,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-18T07:22Z"
+              "value": "2026-05-18T08:02Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbd85bsfmpr9ha6oh6f2bg"
+              "value": "tbd85ceuupr9ha6omvqisg"
             },
             {
               "key": "LocalStorageCapacity",
@@ -5423,7 +6597,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj7c5bpxi1r8ykqrnnst]}"
+              "value": "{SecurityGroupId:[sg-mj78vtpurhkjrhyd2zt7]}"
             },
             {
               "key": "InnerIpAddress",
@@ -5479,7 +6653,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.246]}}"
+              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.17]}}"
             },
             {
               "key": "Tags",
@@ -5487,7 +6661,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:9a,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7iivd2028xy3i6fvkf,PrimaryIpAddress:10.0.1.246,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.246,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:32,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70qfjkj53k1lfk3g4v,PrimaryIpAddress:10.0.1.17,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.17,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -5498,9 +6672,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85bsi6pr9ha6oh6f2fg",
-          "cspResourceName": "tbd85bsi6pr9ha6oh6f2fg",
-          "cspResourceId": "i-mj76s1u22n44umn80wav",
+          "uid": "tbd85cf1upr9ha6omvqj80",
+          "cspResourceName": "tbd85cf1upr9ha6omvqj80",
+          "cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
           "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5514,13 +6688,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 07:23:12",
+          "createdTime": "2026-05-18 08:02:47",
           "label": {
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 07:23:12",
-            "sys.cspResourceId": "i-mj76s1u22n44umn80wav",
-            "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2fg",
+            "sys.createdTime": "2026-05-18 08:02:47",
+            "sys.cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
+            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj80",
             "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -5529,7 +6703,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd85bsi6pr9ha6oh6f2fg",
+            "sys.uid": "tbd85cf1upr9ha6omvqj80",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -5537,10 +6711,10 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "47.80.240.250",
+          "publicIP": "47.80.57.53",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.245",
+          "privateIP": "10.0.1.16",
           "privateDNS": "",
           "rootDiskType": "cloud_essd",
           "rootDiskSize": 40,
@@ -5592,23 +6766,23 @@
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-          "networkInterface": "eni-mj76s1u22n44umn1evzu",
+          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+          "networkInterface": "eni-mj7bmodw2wgq13tslyzg",
           "securityGroupIds": [
             "my04-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "p5i1tb6b8d!sA$",
+          "nodeUserPassword": "$dA5bucp!f1t81",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCM/UUlUEt2qBIAGxsO9f59EwxFdKH5wMqBGOGYnxNjgrTDAq6PS8eEBL+fN8aoYq+oJ42KGkaWCbl9FPxaXFTs=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIoOQ2gvfcNkTlNvuqkusRt8H2qhBA89swB2tyZNTyPQI6IG5Rq30BzABy4uD/mVN5T1FFu4vaI+o5kEgApc87Q=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:+SrCDwxr0rszio/vIV3LF4L/NjMiNDzD9XYChCn+7lQ",
-            "firstUsedAt": "2026-05-18T07:23:29Z"
+            "fingerprint": "SHA256:Y6GQw48WwR78o9JdeZKtnxMOFr9e5MIESK+ZhUdpvPM",
+            "firstUsedAt": "2026-05-18T08:02:55Z"
           },
           "commandStatus": [
             {
@@ -5616,10 +6790,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T07:23:29Z",
-              "completedTime": "2026-05-18T07:23:29Z",
+              "startedTime": "2026-05-18T08:02:55Z",
+              "completedTime": "2026-05-18T08:02:56Z",
+              "elapsedTime": 1,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj76s1u22n44umn80wavZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5654,7 +6829,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbd85bsi6pr9ha6oh6f2fg"
+              "value": "tbd85cf1upr9ha6omvqj80"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -5674,7 +6849,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-18T07:22Z"
+              "value": "2026-05-18T08:02Z"
             },
             {
               "key": "ZoneId",
@@ -5690,7 +6865,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj76s1u22n44umn80wavZ"
+              "value": "iZmj7bmodw2wgq13tm2g8jZ"
             },
             {
               "key": "Status",
@@ -5722,7 +6897,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "eb6bcd3f-4858-48d5-8243-269a61ba9528"
+              "value": "3e72e546-fbd2-4921-a2ff-d588c6c712fc"
             },
             {
               "key": "RegionId",
@@ -5742,7 +6917,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj76s1u22n44umn80wav"
+              "value": "i-mj7bmodw2wgq13tm2g8j"
             },
             {
               "key": "Recyclable",
@@ -5762,11 +6937,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-18T07:22Z"
+              "value": "2026-05-18T08:02Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbd85bsfmpr9ha6oh6f2bg"
+              "value": "tbd85ceuupr9ha6omvqisg"
             },
             {
               "key": "LocalStorageCapacity",
@@ -5790,7 +6965,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj78vtpurhkjr0732i14]}"
+              "value": "{SecurityGroupId:[sg-mj71whg4s0wud8qlexce]}"
             },
             {
               "key": "InnerIpAddress",
@@ -5798,7 +6973,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[47.80.240.250]}"
+              "value": "{IpAddress:[47.80.57.53]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -5846,7 +7021,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.245]}}"
+              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.16]}}"
             },
             {
               "key": "Tags",
@@ -5854,7 +7029,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:99,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj76s1u22n44umn1evzu,PrimaryIpAddress:10.0.1.245,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.245,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:31,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq13tslyzg,PrimaryIpAddress:10.0.1.16,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.16,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -5875,12 +7050,12 @@
           {
             "infraId": "my04-infra101",
             "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "47.80.240.250",
+            "nodeIp": "47.80.57.53",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj76s1u22n44umn80wavZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5890,12 +7065,12 @@
           {
             "infraId": "my04-infra101",
             "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "47.80.57.53",
+            "nodeIp": "47.80.240.250",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj7bmodw2wgq0m2c1yd7Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5910,7 +7085,7 @@
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj7iivd2028xy3i16ltyZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5944,6 +7119,8 @@
 ```json
 {
   "idList": [
+    "my01-infra101",
+    "my02-infra101",
     "my04-infra101"
   ]
 }
@@ -5973,7 +7150,7 @@
 {
   "resourceType": "infra",
   "id": "my04-infra101",
-  "uid": "tbd85bsi6pr9ha6oh6f2dg",
+  "uid": "tbd85cf1upr9ha6omvqj60",
   "name": "my04-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -6001,7 +7178,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my04-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85bsi6pr9ha6oh6f2dg"
+    "sys.uid": "tbd85cf1upr9ha6omvqj60"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -6010,9 +7187,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85bsi6pr9ha6oh6f2eg",
-      "cspResourceName": "tbd85bsi6pr9ha6oh6f2eg",
-      "cspResourceId": "i-mj7bmodw2wgq0m2c1yd7",
+      "uid": "tbd85cf1upr9ha6omvqj70",
+      "cspResourceName": "tbd85cf1upr9ha6omvqj70",
+      "cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
       "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -6026,13 +7203,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 07:23:19",
+      "createdTime": "2026-05-18 08:02:47",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 07:23:19",
-        "sys.cspResourceId": "i-mj7bmodw2wgq0m2c1yd7",
-        "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2eg",
+        "sys.createdTime": "2026-05-18 08:02:47",
+        "sys.cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
+        "sys.cspResourceName": "tbd85cf1upr9ha6omvqj70",
         "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -6041,7 +7218,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd85bsi6pr9ha6oh6f2eg",
+        "sys.uid": "tbd85cf1upr9ha6omvqj70",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -6049,10 +7226,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.57.53",
+      "publicIP": "47.80.240.250",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.244",
+      "privateIP": "10.0.1.15",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": 40,
@@ -6104,23 +7281,23 @@
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+      "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-      "networkInterface": "eni-mj7bmodw2wgq0m2ilh4w",
+      "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+      "networkInterface": "eni-mj7ctm2infbmnn6uucox",
       "securityGroupIds": [
         "my04-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+      "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "8$bptA1!sd5bi6",
+      "nodeUserPassword": "upb!t1$1fd8c5A",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBImrnQ1OLqeJX5QkeseBQDL6cp6QxlVw9ugzvNKG+sRdgjry3e6aSom3hime/qhctodX/eDLu07lhHFLpk4lKV0=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIxjgydAuYGlPu0chuI8q9j7hzoY0Rq4M/6ULrhSpcsPA78KSE4g2MEgG2KnC/Y9kaOYioaIMVk355QCS+/2JM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:XvJmDadkdy+ee6r1hLgon38wSlkG7vHhjMiLp3aAKj0",
-        "firstUsedAt": "2026-05-18T07:23:29Z"
+        "fingerprint": "SHA256:ElR8y8aTDUmfc8Kf9iCIhXjocBPKZg5jjX79lSxer8U",
+        "firstUsedAt": "2026-05-18T08:02:56Z"
       },
       "commandStatus": [
         {
@@ -6128,11 +7305,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T07:23:29Z",
-          "completedTime": "2026-05-18T07:23:30Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:02:55Z",
+          "completedTime": "2026-05-18T08:02:57Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj7bmodw2wgq0m2c1yd7Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6167,7 +7344,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbd85bsi6pr9ha6oh6f2eg"
+          "value": "tbd85cf1upr9ha6omvqj70"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -6187,7 +7364,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "ZoneId",
@@ -6203,7 +7380,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj7bmodw2wgq0m2c1yd7Z"
+          "value": "iZmj7ctm2infbmnn6vq0exZ"
         },
         {
           "key": "Status",
@@ -6235,7 +7412,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "e5bf153c-cb27-4946-a211-b4cccd0b403b"
+          "value": "13344c44-f69b-4fdb-bc04-e9e4756fde66"
         },
         {
           "key": "RegionId",
@@ -6255,7 +7432,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj7bmodw2wgq0m2c1yd7"
+          "value": "i-mj7ctm2infbmnn6vq0ex"
         },
         {
           "key": "Recyclable",
@@ -6275,11 +7452,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbd85bsfmpr9ha6oh6f2bg"
+          "value": "tbd85ceuupr9ha6omvqisg"
         },
         {
           "key": "LocalStorageCapacity",
@@ -6303,7 +7480,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7fxe8c2piizwjczdu5]}"
+          "value": "{SecurityGroupId:[sg-mj75hai0hn9b26o6u0lu]}"
         },
         {
           "key": "InnerIpAddress",
@@ -6311,7 +7488,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.57.53]}"
+          "value": "{IpAddress:[47.80.240.250]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -6359,7 +7536,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.244]}}"
+          "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.15]}}"
         },
         {
           "key": "Tags",
@@ -6367,7 +7544,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:98,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq0m2ilh4w,PrimaryIpAddress:10.0.1.244,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.244,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:30,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7ctm2infbmnn6uucox,PrimaryIpAddress:10.0.1.15,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.15,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -6378,9 +7555,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85bsi6pr9ha6oh6f2gg",
-      "cspResourceName": "tbd85bsi6pr9ha6oh6f2gg",
-      "cspResourceId": "i-mj7iivd2028xy3i16lty",
+      "uid": "tbd85cf1upr9ha6omvqj90",
+      "cspResourceName": "tbd85cf1upr9ha6omvqj90",
+      "cspResourceId": "i-mj70qfjkj53k1lfmwem5",
       "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6394,13 +7571,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 07:23:21",
+      "createdTime": "2026-05-18 08:02:47",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 07:23:21",
-        "sys.cspResourceId": "i-mj7iivd2028xy3i16lty",
-        "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2gg",
+        "sys.createdTime": "2026-05-18 08:02:47",
+        "sys.cspResourceId": "i-mj70qfjkj53k1lfmwem5",
+        "sys.cspResourceName": "tbd85cf1upr9ha6omvqj90",
         "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -6409,7 +7586,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd85bsi6pr9ha6oh6f2gg",
+        "sys.uid": "tbd85cf1upr9ha6omvqj90",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -6420,7 +7597,7 @@
       "publicIP": "8.220.222.227",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.246",
+      "privateIP": "10.0.1.17",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": 40,
@@ -6472,23 +7649,23 @@
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+      "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-      "networkInterface": "eni-mj7iivd2028xy3i6fvkf",
+      "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+      "networkInterface": "eni-mj70qfjkj53k1lfk3g4v",
       "securityGroupIds": [
         "my04-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+      "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "iptbsA8!$61bd5",
+      "nodeUserPassword": "1bc15$udf8pAt!",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAqGOQgKJS8UdcsRVUfr5i+Pgv0ORX62ugwd1yYNxexKIVogXT682Vgw9TECnUjA3cSqFVgesvJYpwjJtYcgoxc=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjpJO+iCEU9UWWxdK8tLAyQm+wo3x/MrYpIbM/i6AEC/aXL7gIArd+gJWLDbG4U7beYUDeqNCYoNaQ84LkntQ4=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:HvqcqnsMLncQbFRcpY+PiEon3QkJOSXgz+7Fx84gy0E",
-        "firstUsedAt": "2026-05-18T07:23:29Z"
+        "fingerprint": "SHA256:CN3Vr5UeDqGvqf+08il0YBKW/Q92T5KR3JBAFnULA/I",
+        "firstUsedAt": "2026-05-18T08:02:56Z"
       },
       "commandStatus": [
         {
@@ -6496,11 +7673,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T07:23:29Z",
-          "completedTime": "2026-05-18T07:23:30Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:02:55Z",
+          "completedTime": "2026-05-18T08:02:57Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj7iivd2028xy3i16ltyZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6535,7 +7712,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbd85bsi6pr9ha6oh6f2gg"
+          "value": "tbd85cf1upr9ha6omvqj90"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -6555,7 +7732,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "ZoneId",
@@ -6571,7 +7748,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj7iivd2028xy3i16ltyZ"
+          "value": "iZmj70qfjkj53k1lfmwem5Z"
         },
         {
           "key": "Status",
@@ -6603,7 +7780,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "2ce7f1bc-e537-45dc-8b19-cd5899649d0a"
+          "value": "59a11a5d-1a8e-4b85-8c4f-4e84016912bd"
         },
         {
           "key": "RegionId",
@@ -6623,7 +7800,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj7iivd2028xy3i16lty"
+          "value": "i-mj70qfjkj53k1lfmwem5"
         },
         {
           "key": "Recyclable",
@@ -6643,11 +7820,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbd85bsfmpr9ha6oh6f2bg"
+          "value": "tbd85ceuupr9ha6omvqisg"
         },
         {
           "key": "LocalStorageCapacity",
@@ -6671,7 +7848,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7c5bpxi1r8ykqrnnst]}"
+          "value": "{SecurityGroupId:[sg-mj78vtpurhkjrhyd2zt7]}"
         },
         {
           "key": "InnerIpAddress",
@@ -6727,7 +7904,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.246]}}"
+          "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.17]}}"
         },
         {
           "key": "Tags",
@@ -6735,7 +7912,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:9a,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7iivd2028xy3i6fvkf,PrimaryIpAddress:10.0.1.246,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.246,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:32,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70qfjkj53k1lfk3g4v,PrimaryIpAddress:10.0.1.17,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.17,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -6746,9 +7923,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85bsi6pr9ha6oh6f2fg",
-      "cspResourceName": "tbd85bsi6pr9ha6oh6f2fg",
-      "cspResourceId": "i-mj76s1u22n44umn80wav",
+      "uid": "tbd85cf1upr9ha6omvqj80",
+      "cspResourceName": "tbd85cf1upr9ha6omvqj80",
+      "cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
       "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -6762,13 +7939,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 07:23:12",
+      "createdTime": "2026-05-18 08:02:47",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 07:23:12",
-        "sys.cspResourceId": "i-mj76s1u22n44umn80wav",
-        "sys.cspResourceName": "tbd85bsi6pr9ha6oh6f2fg",
+        "sys.createdTime": "2026-05-18 08:02:47",
+        "sys.cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
+        "sys.cspResourceName": "tbd85cf1upr9ha6omvqj80",
         "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -6777,7 +7954,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd85bsi6pr9ha6oh6f2fg",
+        "sys.uid": "tbd85cf1upr9ha6omvqj80",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -6785,10 +7962,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.240.250",
+      "publicIP": "47.80.57.53",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.245",
+      "privateIP": "10.0.1.16",
       "privateDNS": "",
       "rootDiskType": "cloud_essd",
       "rootDiskSize": 40,
@@ -6840,23 +8017,23 @@
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7q8zrkwhesk9h7ilc0b",
+      "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7utyh2dolpsrw3t0oad",
-      "networkInterface": "eni-mj76s1u22n44umn1evzu",
+      "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+      "networkInterface": "eni-mj7bmodw2wgq13tslyzg",
       "securityGroupIds": [
         "my04-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd85bsfmpr9ha6oh6f2bg",
+      "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "p5i1tb6b8d!sA$",
+      "nodeUserPassword": "$dA5bucp!f1t81",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCM/UUlUEt2qBIAGxsO9f59EwxFdKH5wMqBGOGYnxNjgrTDAq6PS8eEBL+fN8aoYq+oJ42KGkaWCbl9FPxaXFTs=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIoOQ2gvfcNkTlNvuqkusRt8H2qhBA89swB2tyZNTyPQI6IG5Rq30BzABy4uD/mVN5T1FFu4vaI+o5kEgApc87Q=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:+SrCDwxr0rszio/vIV3LF4L/NjMiNDzD9XYChCn+7lQ",
-        "firstUsedAt": "2026-05-18T07:23:29Z"
+        "fingerprint": "SHA256:Y6GQw48WwR78o9JdeZKtnxMOFr9e5MIESK+ZhUdpvPM",
+        "firstUsedAt": "2026-05-18T08:02:55Z"
       },
       "commandStatus": [
         {
@@ -6864,10 +8041,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T07:23:29Z",
-          "completedTime": "2026-05-18T07:23:29Z",
+          "startedTime": "2026-05-18T08:02:55Z",
+          "completedTime": "2026-05-18T08:02:56Z",
+          "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj76s1u22n44umn80wavZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6902,7 +8080,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbd85bsi6pr9ha6oh6f2fg"
+          "value": "tbd85cf1upr9ha6omvqj80"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -6922,7 +8100,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "ZoneId",
@@ -6938,7 +8116,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj76s1u22n44umn80wavZ"
+          "value": "iZmj7bmodw2wgq13tm2g8jZ"
         },
         {
           "key": "Status",
@@ -6970,7 +8148,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "eb6bcd3f-4858-48d5-8243-269a61ba9528"
+          "value": "3e72e546-fbd2-4921-a2ff-d588c6c712fc"
         },
         {
           "key": "RegionId",
@@ -6990,7 +8168,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj76s1u22n44umn80wav"
+          "value": "i-mj7bmodw2wgq13tm2g8j"
         },
         {
           "key": "Recyclable",
@@ -7010,11 +8188,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-18T07:22Z"
+          "value": "2026-05-18T08:02Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbd85bsfmpr9ha6oh6f2bg"
+          "value": "tbd85ceuupr9ha6omvqisg"
         },
         {
           "key": "LocalStorageCapacity",
@@ -7038,7 +8216,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj78vtpurhkjr0732i14]}"
+          "value": "{SecurityGroupId:[sg-mj71whg4s0wud8qlexce]}"
         },
         {
           "key": "InnerIpAddress",
@@ -7046,7 +8224,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.240.250]}"
+          "value": "{IpAddress:[47.80.57.53]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -7094,7 +8272,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7utyh2dolpsrw3t0oad,VpcId:vpc-mj7q8zrkwhesk9h7ilc0b,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.245]}}"
+          "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.16]}}"
         },
         {
           "key": "Tags",
@@ -7102,7 +8280,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0a:99,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj76s1u22n44umn1evzu,PrimaryIpAddress:10.0.1.245,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.245,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:31,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq13tslyzg,PrimaryIpAddress:10.0.1.16,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.16,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -7123,12 +8301,12 @@
       {
         "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "47.80.240.250",
+        "nodeIp": "47.80.57.53",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj76s1u22n44umn80wavZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7138,12 +8316,12 @@
       {
         "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "47.80.57.53",
+        "nodeIp": "47.80.240.250",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj7bmodw2wgq0m2c1yd7Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7158,7 +8336,7 @@
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj7iivd2028xy3i16ltyZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7216,8 +8394,8 @@
       "command": "uname -a",
       "nodeGroup": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux iZmj7bmodw2wgq0m2c1yd7Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "47.80.57.53",
+      "output": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "47.80.240.250",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -7228,7 +8406,7 @@
       "command": "uname -a",
       "nodeGroup": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux iZmj7iivd2028xy3i16ltyZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "output": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
       "publicIP": "8.220.222.227",
       "sshTest": "successful",
       "status": "success",
@@ -7240,8 +8418,8 @@
       "command": "uname -a",
       "nodeGroup": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux iZmj76s1u22n44umn80wavZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "47.80.240.250",
+      "output": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "47.80.57.53",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -7271,7 +8449,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 07:23:55
+**Generated At:** 2026-05-18 08:03:21
 
 **Namespace:** mig01
 
@@ -7299,9 +8477,9 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 | ecs.e-c1m1.large | 2 | 2.0 | - | x86_64 |  | $0.0178 | 1 |
 | ecs.e-c1m4.large | 2 | 8.0 | - | x86_64 |  | $0.0791 | 1 |
-| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 
 ### VM Images
 
@@ -7313,9 +8491,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj7bmodw2wgq0m2c1yd7 | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.57.53<br>**Private IP:** 10.0.1.244<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj7iivd2028xy3i16lty | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.220.222.227<br>**Private IP:** 10.0.1.246<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj76s1u22n44umn80wav | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.240.250<br>**Private IP:** 10.0.1.245<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj7ctm2infbmnn6vq0ex | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.240.250<br>**Private IP:** 10.0.1.15<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj70qfjkj53k1lfmwem5 | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.220.222.227<br>**Private IP:** 10.0.1.17<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj7bmodw2wgq13tm2g8j | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.57.53<br>**Private IP:** 10.0.1.16<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
 
 
 ## Network Resources
@@ -7327,7 +8505,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-vnet-01 |
-| **CSP VNet ID** | vpc-mj7q8zrkwhesk9h7ilc0b |
+| **CSP VNet ID** | vpc-mj7kupnhl8vcko5nzmtjs |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | alibaba-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -7336,7 +8514,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my04-subnet-01 | vsw-mj7utyh2dolpsrw3t0oad | 10.0.1.0/24 | ap-northeast-2a |
+| my04-subnet-01 | vsw-mj7noc100izqdsv9ei3ge | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -7345,7 +8523,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my04-sshkey-01 | tbd85bsfmpr9ha6oh6f2bg |  | 43e8a23c72ccaeab23668003ce328889 |
+| my04-sshkey-01 | tbd85ceuupr9ha6omvqisg |  | c69cc213139d883941a8c2a7d9b26ed1 |
 
 ### Security Groups
 
@@ -7354,7 +8532,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-01 |
-| **CSP Security Group ID** | sg-mj7fxe8c2piizwjczdu5 |
+| **CSP Security Group ID** | sg-mj75hai0hn9b26o6u0lu |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -7382,7 +8560,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-02 |
-| **CSP Security Group ID** | sg-mj78vtpurhkjr0732i14 |
+| **CSP Security Group ID** | sg-mj71whg4s0wud8qlexce |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7415,7 +8593,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-03 |
-| **CSP Security Group ID** | sg-mj7c5bpxi1r8ykqrnnst |
+| **CSP Security Group ID** | sg-mj78vtpurhkjrhyd2zt7 |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7490,7 +8668,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 07:24:00*
+*Report generated: 2026-05-18 08:03:27*
 
 ---
 
@@ -7519,7 +8697,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | ecs.e-c1m1.large, ecs.e-c1m4.large, ecs.e-c1m4.xlarge |
+| 2 | **VM Spec** | 3 | ✅ Selected | ecs.e-c1m4.large, ecs.e-c1m4.xlarge, ecs.e-c1m1.large |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my04-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my04-vnet-01) |
@@ -7534,9 +8712,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj7bmodw2wgq0m2c1yd7<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj7iivd2028xy3i16lty<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj76s1u22n44umn80wav<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj7ctm2infbmnn6vq0ex<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj70qfjkj53k1lfmwem5<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj7bmodw2wgq13tm2g8j<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7570,7 +8748,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-01
 
-**CSP ID:** sg-mj7fxe8c2piizwjczdu5 | **VNet:** my04-vnet-01 | **Rules:** 14
+**CSP ID:** sg-mj75hai0hn9b26o6u0lu | **VNet:** my04-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7598,7 +8776,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-02
 
-**CSP ID:** sg-mj78vtpurhkjr0732i14 | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj71whg4s0wud8qlexce | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7631,7 +8809,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-03
 
-**CSP ID:** sg-mj7c5bpxi1r8ykqrnnst | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj78vtpurhkjrhyd2zt7 | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7672,13 +8850,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj7q8zrkwhesk9h7ilc0b | 10.0.0.0/21 |
+| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj7kupnhl8vcko5nzmtjs | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj7utyh2dolpsrw3t0oad | 10.0.1.0/24 | my04-vnet-01 |
+| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj7noc100izqdsv9ei3ge | 10.0.1.0/24 | my04-vnet-01 |
 
 ### Source Network Information
 
@@ -7720,7 +8898,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my04-sshkey-01 | tbd85bsfmpr9ha6oh6f2bg | 43e8a23c72ccaeab23668003ce328889 | Used by all 3 VMs |
+| 1 | my04-sshkey-01 | tbd85ceuupr9ha6omvqisg | c69cc213139d883941a8c2a7d9b26ed1 | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-aws.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-aws.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (fa84f8d)
+- CM-Beetle: imdl/v0.1.5+ (c574040)
 - cm-model: unknown
 - CB-Tumblebug: vunknown
 - CB-Spider: vunknown
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 14, 2026
-- Test Time: 18:11:40 KST
-- Test Execution: 2026-05-14 18:11:40 KST
+- Test Date: May 18, 2026
+- Test Time: 17:01:38 KST
+- Test Execution: 2026-05-18 17:01:38 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 2.963s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 52.104s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 23ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 3ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 29ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 8.161s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 51.47s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 67ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 7ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 14ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.959s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.382s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 47.798s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.26s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.261s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 48.582s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 2m56.310009396s
+**Total Duration**: 3m1.278720403s
 
-*Test executed on May 14, 2026 at 18:11:40 KST (2026-05-14 18:11:40 KST) using CM-Beetle automated test CLI*
+*Test executed on May 18, 2026 at 17:01:38 KST (2026-05-18 17:01:38 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1974,7 +1974,7 @@
               "sg-01"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -1993,7 +1993,7 @@
               "sg-02"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -2012,7 +2012,7 @@
               "sg-03"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           }
         ],
@@ -2864,7 +2864,7 @@
               "sg-01"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -2883,7 +2883,7 @@
               "sg-02"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -2902,7 +2902,7 @@
               "sg-03"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           }
         ],
@@ -4092,7 +4092,7 @@
 {
   "resourceType": "infra",
   "id": "my01-infra101",
-  "uid": "tbd82p3ollp7sdqchhjdfg",
+  "uid": "tbd85cevepr9ha6omvqit0",
   "name": "my01-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -4120,7 +4120,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my01-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd82p3ollp7sdqchhjdfg"
+    "sys.uid": "tbd85cevepr9ha6omvqit0"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -4129,9 +4129,9 @@
     {
       "resourceType": "node",
       "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd82p3ollp7sdqchhjdgg",
-      "cspResourceName": "tbd82p3ollp7sdqchhjdgg",
-      "cspResourceId": "i-0601b01e9bc9c2095",
+      "uid": "tbd85cevepr9ha6omvqiu0",
+      "cspResourceName": "tbd85cevepr9ha6omvqiu0",
+      "cspResourceId": "i-05cc436e2832ffd93",
       "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -4145,14 +4145,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-14 09:12:29",
+      "createdTime": "2026-05-18 08:02:29",
       "label": {
-        "Name": "tbd82p3ollp7sdqchhjdgg",
+        "Name": "tbd85cevepr9ha6omvqiu0",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-14 09:12:29",
-        "sys.cspResourceId": "i-0601b01e9bc9c2095",
-        "sys.cspResourceName": "tbd82p3ollp7sdqchhjdgg",
+        "sys.createdTime": "2026-05-18 08:02:29",
+        "sys.cspResourceId": "i-05cc436e2832ffd93",
+        "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
         "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4161,7 +4161,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd82p3ollp7sdqchhjdgg",
+        "sys.uid": "tbd85cevepr9ha6omvqiu0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4169,13 +4169,13 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.36.126.236",
+      "publicIP": "43.203.239.151",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.153",
-      "privateDNS": "ip-10-0-1-153.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.41",
+      "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
       "connectionName": "aws-ap-northeast-2",
       "connectionConfig": {
@@ -4226,22 +4226,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-01aed90ffbbedd137",
+      "cspVNetId": "vpc-07e218262146e7003",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0a94dc0d9c456d177",
-      "networkInterface": "eni-attach-02a6ff6375f0b3751",
+      "cspSubnetId": "subnet-0695096ac3c17916f",
+      "networkInterface": "eni-attach-04753091ce5855ac2",
       "securityGroupIds": [
         "my01-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAaxKLL/VsuLqo7ZcZIRtfH/vNh8pnSh7iqTezjDunpY/v07KFcrV1hZjEH6B2qpeXKhecCChq/wPSYa95m1uNA=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:n04hhT+rs8YBxSnCmeY5DcjUK5dOsV9BkfzZAlyXuhU",
-        "firstUsedAt": "2026-05-14T09:12:39Z"
+        "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
+        "firstUsedAt": "2026-05-18T08:02:39Z"
       },
       "commandStatus": [
         {
@@ -4249,11 +4249,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-14T09:12:35Z",
-          "completedTime": "2026-05-14T09:12:41Z",
-          "elapsedTime": 6,
+          "startedTime": "2026-05-18T08:02:37Z",
+          "completedTime": "2026-05-18T08:02:40Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-153 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4268,7 +4268,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-08c839ed31f8b5136}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
         },
         {
           "key": "BootMode",
@@ -4280,7 +4280,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "7219ABB7-2DCD-4740-A7E6-F5BB6937391F"
+          "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
         },
         {
           "key": "CpuOptions",
@@ -4312,7 +4312,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0601b01e9bc9c2095"
+          "value": "i-05cc436e2832ffd93"
         },
         {
           "key": "InstanceType",
@@ -4320,11 +4320,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd82p3ndlp7sdqchhjddg"
+          "value": "tbd85cetmpr9ha6omvqiog"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-14T09:12:08Z"
+          "value": "2026-05-18T08:02:08Z"
         },
         {
           "key": "MetadataOptions",
@@ -4336,7 +4336,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.126.236},Attachment:{AttachTime:2026-05-14T09:12:08Z,AttachmentId:eni-attach-02a6ff6375f0b3751,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0709d80c5c0511f7a,GroupName:tbd82p3nllp7sdqchhjde0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:3e:29:09:a9:9d,NetworkInterfaceId:eni-01f745a45f7ce181d,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.153,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.126.236},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.153}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
         },
         {
           "key": "Placement",
@@ -4344,15 +4344,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-153.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.153"
+          "value": "10.0.1.41"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.36.126.236"
+          "value": "43.203.239.151"
         },
         {
           "key": "RootDeviceName",
@@ -4364,7 +4364,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-0709d80c5c0511f7a,GroupName:tbd82p3nllp7sdqchhjde0}"
+          "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
         },
         {
           "key": "SourceDestCheck",
@@ -4376,11 +4376,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0a94dc0d9c456d177"
+          "value": "subnet-0695096ac3c17916f"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdgg}"
+          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
         },
         {
           "key": "VirtualizationType",
@@ -4388,16 +4388,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-01aed90ffbbedd137"
+          "value": "vpc-07e218262146e7003"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd82p3ollp7sdqchhjdig",
-      "cspResourceName": "tbd82p3ollp7sdqchhjdig",
-      "cspResourceId": "i-0586524d744cd9f60",
+      "uid": "tbd85cevepr9ha6omvqj00",
+      "cspResourceName": "tbd85cevepr9ha6omvqj00",
+      "cspResourceId": "i-055c3be58ba3b717a",
       "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -4411,14 +4411,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-14 09:12:28",
+      "createdTime": "2026-05-18 08:02:31",
       "label": {
-        "Name": "tbd82p3ollp7sdqchhjdig",
+        "Name": "tbd85cevepr9ha6omvqj00",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-14 09:12:28",
-        "sys.cspResourceId": "i-0586524d744cd9f60",
-        "sys.cspResourceName": "tbd82p3ollp7sdqchhjdig",
+        "sys.createdTime": "2026-05-18 08:02:31",
+        "sys.cspResourceId": "i-055c3be58ba3b717a",
+        "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
         "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4427,7 +4427,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd82p3ollp7sdqchhjdig",
+        "sys.uid": "tbd85cevepr9ha6omvqj00",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4435,13 +4435,13 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.203.172.180",
+      "publicIP": "13.124.168.73",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.231",
-      "privateDNS": "ip-10-0-1-231.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.46",
+      "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
       "connectionName": "aws-ap-northeast-2",
       "connectionConfig": {
@@ -4492,22 +4492,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-01aed90ffbbedd137",
+      "cspVNetId": "vpc-07e218262146e7003",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0a94dc0d9c456d177",
-      "networkInterface": "eni-attach-08af86455d81e0028",
+      "cspSubnetId": "subnet-0695096ac3c17916f",
+      "networkInterface": "eni-attach-0512107afc0efe575",
       "securityGroupIds": [
         "my01-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNjRlwT1XwCANfjWlsfVZDcWapqf77JfbnMDzmLvlFinbAcx88l1LOnp20aZC3SEawvKn+F1w5hL5JG7WuigwjA=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:84MCnaHp/G0h699xo3GtXfpu9ulDX29ysyPij629UVw",
-        "firstUsedAt": "2026-05-14T09:12:35Z"
+        "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
+        "firstUsedAt": "2026-05-18T08:02:39Z"
       },
       "commandStatus": [
         {
@@ -4515,11 +4515,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-14T09:12:35Z",
-          "completedTime": "2026-05-14T09:12:40Z",
-          "elapsedTime": 5,
+          "startedTime": "2026-05-18T08:02:37Z",
+          "completedTime": "2026-05-18T08:02:40Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-231 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4534,7 +4534,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0d7797664e8fa4ed6}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
         },
         {
           "key": "BootMode",
@@ -4546,7 +4546,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "8F65E17F-CAA8-4DDB-8FCA-7EE2778F9761"
+          "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
         },
         {
           "key": "CpuOptions",
@@ -4578,7 +4578,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0586524d744cd9f60"
+          "value": "i-055c3be58ba3b717a"
         },
         {
           "key": "InstanceType",
@@ -4586,11 +4586,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd82p3ndlp7sdqchhjddg"
+          "value": "tbd85cetmpr9ha6omvqiog"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-14T09:12:06Z"
+          "value": "2026-05-18T08:02:08Z"
         },
         {
           "key": "MetadataOptions",
@@ -4602,7 +4602,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.172.180},Attachment:{AttachTime:2026-05-14T09:12:06Z,AttachmentId:eni-attach-08af86455d81e0028,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-03ad9dc5e16b37c4e,GroupName:tbd82p3o5lp7sdqchhjdf0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:ab:22:98:ec:37,NetworkInterfaceId:eni-0bde9feca6d275a8f,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.231,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.172.180},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.231}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
         },
         {
           "key": "Placement",
@@ -4610,15 +4610,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-231.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.231"
+          "value": "10.0.1.46"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.203.172.180"
+          "value": "13.124.168.73"
         },
         {
           "key": "RootDeviceName",
@@ -4630,7 +4630,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-03ad9dc5e16b37c4e,GroupName:tbd82p3o5lp7sdqchhjdf0}"
+          "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
         },
         {
           "key": "SourceDestCheck",
@@ -4642,11 +4642,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0a94dc0d9c456d177"
+          "value": "subnet-0695096ac3c17916f"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdig}"
+          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
         },
         {
           "key": "VirtualizationType",
@@ -4654,16 +4654,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-01aed90ffbbedd137"
+          "value": "vpc-07e218262146e7003"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd82p3ollp7sdqchhjdhg",
-      "cspResourceName": "tbd82p3ollp7sdqchhjdhg",
-      "cspResourceId": "i-0277b8136c06aec96",
+      "uid": "tbd85cevepr9ha6omvqiv0",
+      "cspResourceName": "tbd85cevepr9ha6omvqiv0",
+      "cspResourceId": "i-0fa2d84cd0c6e08bb",
       "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4677,14 +4677,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-14 09:12:30",
+      "createdTime": "2026-05-18 08:02:28",
       "label": {
-        "Name": "tbd82p3ollp7sdqchhjdhg",
+        "Name": "tbd85cevepr9ha6omvqiv0",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-14 09:12:30",
-        "sys.cspResourceId": "i-0277b8136c06aec96",
-        "sys.cspResourceName": "tbd82p3ollp7sdqchhjdhg",
+        "sys.createdTime": "2026-05-18 08:02:28",
+        "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
+        "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
         "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4693,7 +4693,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd82p3ollp7sdqchhjdhg",
+        "sys.uid": "tbd85cevepr9ha6omvqiv0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4701,13 +4701,13 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.203.241.178",
+      "publicIP": "52.78.166.174",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.123",
-      "privateDNS": "ip-10-0-1-123.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.204",
+      "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
       "connectionName": "aws-ap-northeast-2",
       "connectionConfig": {
@@ -4758,22 +4758,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-01aed90ffbbedd137",
+      "cspVNetId": "vpc-07e218262146e7003",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0a94dc0d9c456d177",
-      "networkInterface": "eni-attach-08d327f7df6f08088",
+      "cspSubnetId": "subnet-0695096ac3c17916f",
+      "networkInterface": "eni-attach-0dacfd07e29c82162",
       "securityGroupIds": [
         "my01-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJ7QVaTv12Io5FkBVBGPfuSv5oLBadMVwOeTRRp+4eTJVhVvPPXOrjoUj+L1Pw4sko1mwuRzSSwJ1DuPSIbHEUQ=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:eCR/3dWtr3JK2VU3+0LESRlka9BhVGtEx74qBK2bwTE",
-        "firstUsedAt": "2026-05-14T09:12:39Z"
+        "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
+        "firstUsedAt": "2026-05-18T08:02:37Z"
       },
       "commandStatus": [
         {
@@ -4781,11 +4781,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-14T09:12:35Z",
-          "completedTime": "2026-05-14T09:12:41Z",
-          "elapsedTime": 6,
+          "startedTime": "2026-05-18T08:02:37Z",
+          "completedTime": "2026-05-18T08:02:40Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-123 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4800,7 +4800,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:05Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd9acea3dc6fe1a4}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
         },
         {
           "key": "BootMode",
@@ -4812,7 +4812,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "81FB8E99-D001-4BD2-A27A-808B471E69A8"
+          "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
         },
         {
           "key": "CpuOptions",
@@ -4844,7 +4844,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0277b8136c06aec96"
+          "value": "i-0fa2d84cd0c6e08bb"
         },
         {
           "key": "InstanceType",
@@ -4852,11 +4852,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd82p3ndlp7sdqchhjddg"
+          "value": "tbd85cetmpr9ha6omvqiog"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-14T09:12:04Z"
+          "value": "2026-05-18T08:02:07Z"
         },
         {
           "key": "MetadataOptions",
@@ -4868,7 +4868,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.241.178},Attachment:{AttachTime:2026-05-14T09:12:04Z,AttachmentId:eni-attach-08d327f7df6f08088,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0460dcefd8098e744,GroupName:tbd82p3o5lp7sdqchhjdeg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:3c:f3:f2:29:5d,NetworkInterfaceId:eni-047d2425edaf6aa44,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.123,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.241.178},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.123}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
         },
         {
           "key": "Placement",
@@ -4876,15 +4876,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-123.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.123"
+          "value": "10.0.1.204"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.203.241.178"
+          "value": "52.78.166.174"
         },
         {
           "key": "RootDeviceName",
@@ -4896,7 +4896,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-0460dcefd8098e744,GroupName:tbd82p3o5lp7sdqchhjdeg}"
+          "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
         },
         {
           "key": "SourceDestCheck",
@@ -4908,11 +4908,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0a94dc0d9c456d177"
+          "value": "subnet-0695096ac3c17916f"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdhg}"
+          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
         },
         {
           "key": "VirtualizationType",
@@ -4920,7 +4920,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-01aed90ffbbedd137"
+          "value": "vpc-07e218262146e7003"
         }
       ]
     }
@@ -4936,13 +4936,13 @@
     "results": [
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "43.203.172.180",
+        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "52.78.166.174",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-231 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4952,12 +4952,12 @@
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "3.36.126.236",
+        "nodeIp": "43.203.239.151",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-153 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4966,13 +4966,13 @@
       },
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "43.203.241.178",
+        "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "13.124.168.73",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-123 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -5008,7 +5008,7 @@
     {
       "resourceType": "infra",
       "id": "my01-infra101",
-      "uid": "tbd82p3ollp7sdqchhjdfg",
+      "uid": "tbd85cevepr9ha6omvqit0",
       "name": "my01-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -5036,7 +5036,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my01-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd82p3ollp7sdqchhjdfg"
+        "sys.uid": "tbd85cevepr9ha6omvqit0"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5045,9 +5045,9 @@
         {
           "resourceType": "node",
           "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd82p3ollp7sdqchhjdgg",
-          "cspResourceName": "tbd82p3ollp7sdqchhjdgg",
-          "cspResourceId": "i-0601b01e9bc9c2095",
+          "uid": "tbd85cevepr9ha6omvqiu0",
+          "cspResourceName": "tbd85cevepr9ha6omvqiu0",
+          "cspResourceId": "i-05cc436e2832ffd93",
           "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -5061,14 +5061,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-14 09:12:29",
+          "createdTime": "2026-05-18 08:02:29",
           "label": {
-            "Name": "tbd82p3ollp7sdqchhjdgg",
+            "Name": "tbd85cevepr9ha6omvqiu0",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-14 09:12:29",
-            "sys.cspResourceId": "i-0601b01e9bc9c2095",
-            "sys.cspResourceName": "tbd82p3ollp7sdqchhjdgg",
+            "sys.createdTime": "2026-05-18 08:02:29",
+            "sys.cspResourceId": "i-05cc436e2832ffd93",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
             "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5077,7 +5077,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd82p3ollp7sdqchhjdgg",
+            "sys.uid": "tbd85cevepr9ha6omvqiu0",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5085,13 +5085,13 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "3.36.126.236",
+          "publicIP": "43.203.239.151",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.153",
-          "privateDNS": "ip-10-0-1-153.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.41",
+          "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
           "connectionName": "aws-ap-northeast-2",
           "connectionConfig": {
@@ -5142,22 +5142,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-01aed90ffbbedd137",
+          "cspVNetId": "vpc-07e218262146e7003",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0a94dc0d9c456d177",
-          "networkInterface": "eni-attach-02a6ff6375f0b3751",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-04753091ce5855ac2",
           "securityGroupIds": [
             "my01-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAaxKLL/VsuLqo7ZcZIRtfH/vNh8pnSh7iqTezjDunpY/v07KFcrV1hZjEH6B2qpeXKhecCChq/wPSYa95m1uNA=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:n04hhT+rs8YBxSnCmeY5DcjUK5dOsV9BkfzZAlyXuhU",
-            "firstUsedAt": "2026-05-14T09:12:39Z"
+            "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
+            "firstUsedAt": "2026-05-18T08:02:39Z"
           },
           "commandStatus": [
             {
@@ -5165,11 +5165,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-14T09:12:35Z",
-              "completedTime": "2026-05-14T09:12:41Z",
-              "elapsedTime": 6,
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-153 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5184,7 +5184,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-08c839ed31f8b5136}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
             },
             {
               "key": "BootMode",
@@ -5196,7 +5196,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "7219ABB7-2DCD-4740-A7E6-F5BB6937391F"
+              "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
             },
             {
               "key": "CpuOptions",
@@ -5228,7 +5228,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0601b01e9bc9c2095"
+              "value": "i-05cc436e2832ffd93"
             },
             {
               "key": "InstanceType",
@@ -5236,11 +5236,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd82p3ndlp7sdqchhjddg"
+              "value": "tbd85cetmpr9ha6omvqiog"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-14T09:12:08Z"
+              "value": "2026-05-18T08:02:08Z"
             },
             {
               "key": "MetadataOptions",
@@ -5252,7 +5252,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.126.236},Attachment:{AttachTime:2026-05-14T09:12:08Z,AttachmentId:eni-attach-02a6ff6375f0b3751,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0709d80c5c0511f7a,GroupName:tbd82p3nllp7sdqchhjde0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:3e:29:09:a9:9d,NetworkInterfaceId:eni-01f745a45f7ce181d,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.153,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.126.236},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.153}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
             },
             {
               "key": "Placement",
@@ -5260,15 +5260,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-153.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.153"
+              "value": "10.0.1.41"
             },
             {
               "key": "PublicIpAddress",
-              "value": "3.36.126.236"
+              "value": "43.203.239.151"
             },
             {
               "key": "RootDeviceName",
@@ -5280,7 +5280,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-0709d80c5c0511f7a,GroupName:tbd82p3nllp7sdqchhjde0}"
+              "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
             },
             {
               "key": "SourceDestCheck",
@@ -5292,11 +5292,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0a94dc0d9c456d177"
+              "value": "subnet-0695096ac3c17916f"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdgg}"
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
             },
             {
               "key": "VirtualizationType",
@@ -5304,16 +5304,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-01aed90ffbbedd137"
+              "value": "vpc-07e218262146e7003"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd82p3ollp7sdqchhjdig",
-          "cspResourceName": "tbd82p3ollp7sdqchhjdig",
-          "cspResourceId": "i-0586524d744cd9f60",
+          "uid": "tbd85cevepr9ha6omvqj00",
+          "cspResourceName": "tbd85cevepr9ha6omvqj00",
+          "cspResourceId": "i-055c3be58ba3b717a",
           "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5327,14 +5327,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-14 09:12:28",
+          "createdTime": "2026-05-18 08:02:31",
           "label": {
-            "Name": "tbd82p3ollp7sdqchhjdig",
+            "Name": "tbd85cevepr9ha6omvqj00",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-14 09:12:28",
-            "sys.cspResourceId": "i-0586524d744cd9f60",
-            "sys.cspResourceName": "tbd82p3ollp7sdqchhjdig",
+            "sys.createdTime": "2026-05-18 08:02:31",
+            "sys.cspResourceId": "i-055c3be58ba3b717a",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
             "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5343,7 +5343,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd82p3ollp7sdqchhjdig",
+            "sys.uid": "tbd85cevepr9ha6omvqj00",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5351,13 +5351,13 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "43.203.172.180",
+          "publicIP": "13.124.168.73",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.231",
-          "privateDNS": "ip-10-0-1-231.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.46",
+          "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
           "connectionName": "aws-ap-northeast-2",
           "connectionConfig": {
@@ -5408,22 +5408,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-01aed90ffbbedd137",
+          "cspVNetId": "vpc-07e218262146e7003",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0a94dc0d9c456d177",
-          "networkInterface": "eni-attach-08af86455d81e0028",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-0512107afc0efe575",
           "securityGroupIds": [
             "my01-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNjRlwT1XwCANfjWlsfVZDcWapqf77JfbnMDzmLvlFinbAcx88l1LOnp20aZC3SEawvKn+F1w5hL5JG7WuigwjA=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:84MCnaHp/G0h699xo3GtXfpu9ulDX29ysyPij629UVw",
-            "firstUsedAt": "2026-05-14T09:12:35Z"
+            "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
+            "firstUsedAt": "2026-05-18T08:02:39Z"
           },
           "commandStatus": [
             {
@@ -5431,11 +5431,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-14T09:12:35Z",
-              "completedTime": "2026-05-14T09:12:40Z",
-              "elapsedTime": 5,
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-231 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5450,7 +5450,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0d7797664e8fa4ed6}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
             },
             {
               "key": "BootMode",
@@ -5462,7 +5462,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "8F65E17F-CAA8-4DDB-8FCA-7EE2778F9761"
+              "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
             },
             {
               "key": "CpuOptions",
@@ -5494,7 +5494,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0586524d744cd9f60"
+              "value": "i-055c3be58ba3b717a"
             },
             {
               "key": "InstanceType",
@@ -5502,11 +5502,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd82p3ndlp7sdqchhjddg"
+              "value": "tbd85cetmpr9ha6omvqiog"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-14T09:12:06Z"
+              "value": "2026-05-18T08:02:08Z"
             },
             {
               "key": "MetadataOptions",
@@ -5518,7 +5518,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.172.180},Attachment:{AttachTime:2026-05-14T09:12:06Z,AttachmentId:eni-attach-08af86455d81e0028,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-03ad9dc5e16b37c4e,GroupName:tbd82p3o5lp7sdqchhjdf0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:ab:22:98:ec:37,NetworkInterfaceId:eni-0bde9feca6d275a8f,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.231,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.172.180},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.231}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
             },
             {
               "key": "Placement",
@@ -5526,15 +5526,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-231.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.231"
+              "value": "10.0.1.46"
             },
             {
               "key": "PublicIpAddress",
-              "value": "43.203.172.180"
+              "value": "13.124.168.73"
             },
             {
               "key": "RootDeviceName",
@@ -5546,7 +5546,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-03ad9dc5e16b37c4e,GroupName:tbd82p3o5lp7sdqchhjdf0}"
+              "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
             },
             {
               "key": "SourceDestCheck",
@@ -5558,11 +5558,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0a94dc0d9c456d177"
+              "value": "subnet-0695096ac3c17916f"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdig}"
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
             },
             {
               "key": "VirtualizationType",
@@ -5570,16 +5570,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-01aed90ffbbedd137"
+              "value": "vpc-07e218262146e7003"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd82p3ollp7sdqchhjdhg",
-          "cspResourceName": "tbd82p3ollp7sdqchhjdhg",
-          "cspResourceId": "i-0277b8136c06aec96",
+          "uid": "tbd85cevepr9ha6omvqiv0",
+          "cspResourceName": "tbd85cevepr9ha6omvqiv0",
+          "cspResourceId": "i-0fa2d84cd0c6e08bb",
           "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5593,14 +5593,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-14 09:12:30",
+          "createdTime": "2026-05-18 08:02:28",
           "label": {
-            "Name": "tbd82p3ollp7sdqchhjdhg",
+            "Name": "tbd85cevepr9ha6omvqiv0",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-14 09:12:30",
-            "sys.cspResourceId": "i-0277b8136c06aec96",
-            "sys.cspResourceName": "tbd82p3ollp7sdqchhjdhg",
+            "sys.createdTime": "2026-05-18 08:02:28",
+            "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
             "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5609,7 +5609,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd82p3ollp7sdqchhjdhg",
+            "sys.uid": "tbd85cevepr9ha6omvqiv0",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5617,13 +5617,13 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "43.203.241.178",
+          "publicIP": "52.78.166.174",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.123",
-          "privateDNS": "ip-10-0-1-123.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.204",
+          "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
           "connectionName": "aws-ap-northeast-2",
           "connectionConfig": {
@@ -5674,22 +5674,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-01aed90ffbbedd137",
+          "cspVNetId": "vpc-07e218262146e7003",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0a94dc0d9c456d177",
-          "networkInterface": "eni-attach-08d327f7df6f08088",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-0dacfd07e29c82162",
           "securityGroupIds": [
             "my01-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJ7QVaTv12Io5FkBVBGPfuSv5oLBadMVwOeTRRp+4eTJVhVvPPXOrjoUj+L1Pw4sko1mwuRzSSwJ1DuPSIbHEUQ=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:eCR/3dWtr3JK2VU3+0LESRlka9BhVGtEx74qBK2bwTE",
-            "firstUsedAt": "2026-05-14T09:12:39Z"
+            "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
+            "firstUsedAt": "2026-05-18T08:02:37Z"
           },
           "commandStatus": [
             {
@@ -5697,11 +5697,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-14T09:12:35Z",
-              "completedTime": "2026-05-14T09:12:41Z",
-              "elapsedTime": 6,
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-123 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5716,7 +5716,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:05Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd9acea3dc6fe1a4}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
             },
             {
               "key": "BootMode",
@@ -5728,7 +5728,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "81FB8E99-D001-4BD2-A27A-808B471E69A8"
+              "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
             },
             {
               "key": "CpuOptions",
@@ -5760,7 +5760,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0277b8136c06aec96"
+              "value": "i-0fa2d84cd0c6e08bb"
             },
             {
               "key": "InstanceType",
@@ -5768,11 +5768,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd82p3ndlp7sdqchhjddg"
+              "value": "tbd85cetmpr9ha6omvqiog"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-14T09:12:04Z"
+              "value": "2026-05-18T08:02:07Z"
             },
             {
               "key": "MetadataOptions",
@@ -5784,7 +5784,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.241.178},Attachment:{AttachTime:2026-05-14T09:12:04Z,AttachmentId:eni-attach-08d327f7df6f08088,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0460dcefd8098e744,GroupName:tbd82p3o5lp7sdqchhjdeg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:3c:f3:f2:29:5d,NetworkInterfaceId:eni-047d2425edaf6aa44,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.123,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.241.178},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.123}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
             },
             {
               "key": "Placement",
@@ -5792,15 +5792,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-123.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.123"
+              "value": "10.0.1.204"
             },
             {
               "key": "PublicIpAddress",
-              "value": "43.203.241.178"
+              "value": "52.78.166.174"
             },
             {
               "key": "RootDeviceName",
@@ -5812,7 +5812,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-0460dcefd8098e744,GroupName:tbd82p3o5lp7sdqchhjdeg}"
+              "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
             },
             {
               "key": "SourceDestCheck",
@@ -5824,11 +5824,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0a94dc0d9c456d177"
+              "value": "subnet-0695096ac3c17916f"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdhg}"
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
             },
             {
               "key": "VirtualizationType",
@@ -5836,7 +5836,7 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-01aed90ffbbedd137"
+              "value": "vpc-07e218262146e7003"
             }
           ]
         }
@@ -5852,13 +5852,13 @@
         "results": [
           {
             "infraId": "my01-infra101",
-            "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "43.203.172.180",
+            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "52.78.166.174",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-231 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5868,12 +5868,12 @@
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "3.36.126.236",
+            "nodeIp": "43.203.239.151",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-153 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5882,13 +5882,13 @@
           },
           {
             "infraId": "my01-infra101",
-            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "43.203.241.178",
+            "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "13.124.168.73",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-123 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5896,6 +5896,575 @@
             "err": null
           }
         ]
+      }
+    },
+    {
+      "resourceType": "infra",
+      "id": "my02-infra101",
+      "uid": "tbd85cf3epr9ha6omvqjbg",
+      "name": "my02-infra101",
+      "status": "Creating:3 (R:0/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 3,
+        "countRunning": 0,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "Running",
+      "targetAction": "Create",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my02-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my02-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbd85cf3epr9ha6omvqjbg"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbd85cf3epr9ha6omvqjcg",
+          "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2als_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd85cf3epr9ha6omvqjeg",
+          "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2as_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbd85cf3epr9ha6omvqjdg",
+          "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b4as_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": null
+      }
+    },
+    {
+      "resourceType": "infra",
+      "id": "my04-infra101",
+      "uid": "tbd85cf1upr9ha6omvqj60",
+      "name": "my04-infra101",
+      "status": "Creating:3 (R:0/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 3,
+        "countRunning": 0,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "Running",
+      "targetAction": "Create",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my04-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my04-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbd85cf1upr9ha6omvqj60"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbd85cf1upr9ha6omvqj70",
+          "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 40,
+          "RootDeviceName": "",
+          "connectionName": "alibaba-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "alibaba-ap-northeast-2",
+            "providerName": "alibaba",
+            "driverName": "alibaba-driver-v1.0.so",
+            "credentialName": "alibaba",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "alibaba-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "South Korea (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my04-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my04-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my04-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my04-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd85cf1upr9ha6omvqj90",
+          "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 40,
+          "RootDeviceName": "",
+          "connectionName": "alibaba-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "alibaba-ap-northeast-2",
+            "providerName": "alibaba",
+            "driverName": "alibaba-driver-v1.0.so",
+            "credentialName": "alibaba",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "alibaba-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "South Korea (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my04-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my04-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my04-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my04-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbd85cf1upr9ha6omvqj80",
+          "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 40,
+          "RootDeviceName": "",
+          "connectionName": "alibaba-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "alibaba-ap-northeast-2",
+            "providerName": "alibaba",
+            "driverName": "alibaba-driver-v1.0.so",
+            "credentialName": "alibaba",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "alibaba-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "South Korea (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my04-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my04-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my04-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my04-sshkey-01",
+          "cspSshKeyId": ""
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": null
       }
     }
   ]
@@ -5922,7 +6491,9 @@
 ```json
 {
   "idList": [
-    "my01-infra101"
+    "my01-infra101",
+    "my02-infra101",
+    "my04-infra101"
   ]
 }
 ```
@@ -5951,7 +6522,7 @@
 {
   "resourceType": "infra",
   "id": "my01-infra101",
-  "uid": "tbd82p3ollp7sdqchhjdfg",
+  "uid": "tbd85cevepr9ha6omvqit0",
   "name": "my01-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -5979,7 +6550,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my01-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd82p3ollp7sdqchhjdfg"
+    "sys.uid": "tbd85cevepr9ha6omvqit0"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -5988,9 +6559,9 @@
     {
       "resourceType": "node",
       "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd82p3ollp7sdqchhjdgg",
-      "cspResourceName": "tbd82p3ollp7sdqchhjdgg",
-      "cspResourceId": "i-0601b01e9bc9c2095",
+      "uid": "tbd85cevepr9ha6omvqiu0",
+      "cspResourceName": "tbd85cevepr9ha6omvqiu0",
+      "cspResourceId": "i-05cc436e2832ffd93",
       "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -6004,14 +6575,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-14 09:12:29",
+      "createdTime": "2026-05-18 08:02:29",
       "label": {
-        "Name": "tbd82p3ollp7sdqchhjdgg",
+        "Name": "tbd85cevepr9ha6omvqiu0",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-14 09:12:29",
-        "sys.cspResourceId": "i-0601b01e9bc9c2095",
-        "sys.cspResourceName": "tbd82p3ollp7sdqchhjdgg",
+        "sys.createdTime": "2026-05-18 08:02:29",
+        "sys.cspResourceId": "i-05cc436e2832ffd93",
+        "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
         "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6020,7 +6591,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd82p3ollp7sdqchhjdgg",
+        "sys.uid": "tbd85cevepr9ha6omvqiu0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6028,13 +6599,13 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.36.126.236",
+      "publicIP": "43.203.239.151",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.153",
-      "privateDNS": "ip-10-0-1-153.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.41",
+      "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
       "connectionName": "aws-ap-northeast-2",
       "connectionConfig": {
@@ -6085,22 +6656,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-01aed90ffbbedd137",
+      "cspVNetId": "vpc-07e218262146e7003",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0a94dc0d9c456d177",
-      "networkInterface": "eni-attach-02a6ff6375f0b3751",
+      "cspSubnetId": "subnet-0695096ac3c17916f",
+      "networkInterface": "eni-attach-04753091ce5855ac2",
       "securityGroupIds": [
         "my01-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAaxKLL/VsuLqo7ZcZIRtfH/vNh8pnSh7iqTezjDunpY/v07KFcrV1hZjEH6B2qpeXKhecCChq/wPSYa95m1uNA=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:n04hhT+rs8YBxSnCmeY5DcjUK5dOsV9BkfzZAlyXuhU",
-        "firstUsedAt": "2026-05-14T09:12:39Z"
+        "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
+        "firstUsedAt": "2026-05-18T08:02:39Z"
       },
       "commandStatus": [
         {
@@ -6108,11 +6679,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-14T09:12:35Z",
-          "completedTime": "2026-05-14T09:12:41Z",
-          "elapsedTime": 6,
+          "startedTime": "2026-05-18T08:02:37Z",
+          "completedTime": "2026-05-18T08:02:40Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-153 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6127,7 +6698,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-08c839ed31f8b5136}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
         },
         {
           "key": "BootMode",
@@ -6139,7 +6710,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "7219ABB7-2DCD-4740-A7E6-F5BB6937391F"
+          "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
         },
         {
           "key": "CpuOptions",
@@ -6171,7 +6742,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0601b01e9bc9c2095"
+          "value": "i-05cc436e2832ffd93"
         },
         {
           "key": "InstanceType",
@@ -6179,11 +6750,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd82p3ndlp7sdqchhjddg"
+          "value": "tbd85cetmpr9ha6omvqiog"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-14T09:12:08Z"
+          "value": "2026-05-18T08:02:08Z"
         },
         {
           "key": "MetadataOptions",
@@ -6195,7 +6766,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.126.236},Attachment:{AttachTime:2026-05-14T09:12:08Z,AttachmentId:eni-attach-02a6ff6375f0b3751,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0709d80c5c0511f7a,GroupName:tbd82p3nllp7sdqchhjde0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:3e:29:09:a9:9d,NetworkInterfaceId:eni-01f745a45f7ce181d,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.153,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.126.236},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.153}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
         },
         {
           "key": "Placement",
@@ -6203,15 +6774,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-153.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.153"
+          "value": "10.0.1.41"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.36.126.236"
+          "value": "43.203.239.151"
         },
         {
           "key": "RootDeviceName",
@@ -6223,7 +6794,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-0709d80c5c0511f7a,GroupName:tbd82p3nllp7sdqchhjde0}"
+          "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
         },
         {
           "key": "SourceDestCheck",
@@ -6235,11 +6806,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0a94dc0d9c456d177"
+          "value": "subnet-0695096ac3c17916f"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdgg}"
+          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
         },
         {
           "key": "VirtualizationType",
@@ -6247,16 +6818,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-01aed90ffbbedd137"
+          "value": "vpc-07e218262146e7003"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd82p3ollp7sdqchhjdig",
-      "cspResourceName": "tbd82p3ollp7sdqchhjdig",
-      "cspResourceId": "i-0586524d744cd9f60",
+      "uid": "tbd85cevepr9ha6omvqj00",
+      "cspResourceName": "tbd85cevepr9ha6omvqj00",
+      "cspResourceId": "i-055c3be58ba3b717a",
       "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6270,14 +6841,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-14 09:12:28",
+      "createdTime": "2026-05-18 08:02:31",
       "label": {
-        "Name": "tbd82p3ollp7sdqchhjdig",
+        "Name": "tbd85cevepr9ha6omvqj00",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-14 09:12:28",
-        "sys.cspResourceId": "i-0586524d744cd9f60",
-        "sys.cspResourceName": "tbd82p3ollp7sdqchhjdig",
+        "sys.createdTime": "2026-05-18 08:02:31",
+        "sys.cspResourceId": "i-055c3be58ba3b717a",
+        "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
         "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6286,7 +6857,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd82p3ollp7sdqchhjdig",
+        "sys.uid": "tbd85cevepr9ha6omvqj00",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6294,13 +6865,13 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.203.172.180",
+      "publicIP": "13.124.168.73",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.231",
-      "privateDNS": "ip-10-0-1-231.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.46",
+      "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
       "connectionName": "aws-ap-northeast-2",
       "connectionConfig": {
@@ -6351,22 +6922,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-01aed90ffbbedd137",
+      "cspVNetId": "vpc-07e218262146e7003",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0a94dc0d9c456d177",
-      "networkInterface": "eni-attach-08af86455d81e0028",
+      "cspSubnetId": "subnet-0695096ac3c17916f",
+      "networkInterface": "eni-attach-0512107afc0efe575",
       "securityGroupIds": [
         "my01-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNjRlwT1XwCANfjWlsfVZDcWapqf77JfbnMDzmLvlFinbAcx88l1LOnp20aZC3SEawvKn+F1w5hL5JG7WuigwjA=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:84MCnaHp/G0h699xo3GtXfpu9ulDX29ysyPij629UVw",
-        "firstUsedAt": "2026-05-14T09:12:35Z"
+        "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
+        "firstUsedAt": "2026-05-18T08:02:39Z"
       },
       "commandStatus": [
         {
@@ -6374,11 +6945,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-14T09:12:35Z",
-          "completedTime": "2026-05-14T09:12:40Z",
-          "elapsedTime": 5,
+          "startedTime": "2026-05-18T08:02:37Z",
+          "completedTime": "2026-05-18T08:02:40Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-231 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6393,7 +6964,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0d7797664e8fa4ed6}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
         },
         {
           "key": "BootMode",
@@ -6405,7 +6976,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "8F65E17F-CAA8-4DDB-8FCA-7EE2778F9761"
+          "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
         },
         {
           "key": "CpuOptions",
@@ -6437,7 +7008,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0586524d744cd9f60"
+          "value": "i-055c3be58ba3b717a"
         },
         {
           "key": "InstanceType",
@@ -6445,11 +7016,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd82p3ndlp7sdqchhjddg"
+          "value": "tbd85cetmpr9ha6omvqiog"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-14T09:12:06Z"
+          "value": "2026-05-18T08:02:08Z"
         },
         {
           "key": "MetadataOptions",
@@ -6461,7 +7032,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.172.180},Attachment:{AttachTime:2026-05-14T09:12:06Z,AttachmentId:eni-attach-08af86455d81e0028,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-03ad9dc5e16b37c4e,GroupName:tbd82p3o5lp7sdqchhjdf0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:ab:22:98:ec:37,NetworkInterfaceId:eni-0bde9feca6d275a8f,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.231,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.172.180},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.231}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
         },
         {
           "key": "Placement",
@@ -6469,15 +7040,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-231.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.231"
+          "value": "10.0.1.46"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.203.172.180"
+          "value": "13.124.168.73"
         },
         {
           "key": "RootDeviceName",
@@ -6489,7 +7060,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-03ad9dc5e16b37c4e,GroupName:tbd82p3o5lp7sdqchhjdf0}"
+          "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
         },
         {
           "key": "SourceDestCheck",
@@ -6501,11 +7072,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0a94dc0d9c456d177"
+          "value": "subnet-0695096ac3c17916f"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdig}"
+          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
         },
         {
           "key": "VirtualizationType",
@@ -6513,16 +7084,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-01aed90ffbbedd137"
+          "value": "vpc-07e218262146e7003"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd82p3ollp7sdqchhjdhg",
-      "cspResourceName": "tbd82p3ollp7sdqchhjdhg",
-      "cspResourceId": "i-0277b8136c06aec96",
+      "uid": "tbd85cevepr9ha6omvqiv0",
+      "cspResourceName": "tbd85cevepr9ha6omvqiv0",
+      "cspResourceId": "i-0fa2d84cd0c6e08bb",
       "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -6536,14 +7107,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-14 09:12:30",
+      "createdTime": "2026-05-18 08:02:28",
       "label": {
-        "Name": "tbd82p3ollp7sdqchhjdhg",
+        "Name": "tbd85cevepr9ha6omvqiv0",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-14 09:12:30",
-        "sys.cspResourceId": "i-0277b8136c06aec96",
-        "sys.cspResourceName": "tbd82p3ollp7sdqchhjdhg",
+        "sys.createdTime": "2026-05-18 08:02:28",
+        "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
+        "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
         "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6552,7 +7123,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd82p3ollp7sdqchhjdhg",
+        "sys.uid": "tbd85cevepr9ha6omvqiv0",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6560,13 +7131,13 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.203.241.178",
+      "publicIP": "52.78.166.174",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.123",
-      "privateDNS": "ip-10-0-1-123.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.204",
+      "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
       "connectionName": "aws-ap-northeast-2",
       "connectionConfig": {
@@ -6617,22 +7188,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-01aed90ffbbedd137",
+      "cspVNetId": "vpc-07e218262146e7003",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0a94dc0d9c456d177",
-      "networkInterface": "eni-attach-08d327f7df6f08088",
+      "cspSubnetId": "subnet-0695096ac3c17916f",
+      "networkInterface": "eni-attach-0dacfd07e29c82162",
       "securityGroupIds": [
         "my01-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd82p3ndlp7sdqchhjddg",
+      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJ7QVaTv12Io5FkBVBGPfuSv5oLBadMVwOeTRRp+4eTJVhVvPPXOrjoUj+L1Pw4sko1mwuRzSSwJ1DuPSIbHEUQ=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:eCR/3dWtr3JK2VU3+0LESRlka9BhVGtEx74qBK2bwTE",
-        "firstUsedAt": "2026-05-14T09:12:39Z"
+        "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
+        "firstUsedAt": "2026-05-18T08:02:37Z"
       },
       "commandStatus": [
         {
@@ -6640,11 +7211,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-14T09:12:35Z",
-          "completedTime": "2026-05-14T09:12:41Z",
-          "elapsedTime": 6,
+          "startedTime": "2026-05-18T08:02:37Z",
+          "completedTime": "2026-05-18T08:02:40Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-123 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6659,7 +7230,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-14T09:12:05Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd9acea3dc6fe1a4}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
         },
         {
           "key": "BootMode",
@@ -6671,7 +7242,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "81FB8E99-D001-4BD2-A27A-808B471E69A8"
+          "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
         },
         {
           "key": "CpuOptions",
@@ -6703,7 +7274,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0277b8136c06aec96"
+          "value": "i-0fa2d84cd0c6e08bb"
         },
         {
           "key": "InstanceType",
@@ -6711,11 +7282,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd82p3ndlp7sdqchhjddg"
+          "value": "tbd85cetmpr9ha6omvqiog"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-14T09:12:04Z"
+          "value": "2026-05-18T08:02:07Z"
         },
         {
           "key": "MetadataOptions",
@@ -6727,7 +7298,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.241.178},Attachment:{AttachTime:2026-05-14T09:12:04Z,AttachmentId:eni-attach-08d327f7df6f08088,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0460dcefd8098e744,GroupName:tbd82p3o5lp7sdqchhjdeg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:3c:f3:f2:29:5d,NetworkInterfaceId:eni-047d2425edaf6aa44,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.123,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.241.178},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.123}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0a94dc0d9c456d177,VpcId:vpc-01aed90ffbbedd137}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
         },
         {
           "key": "Placement",
@@ -6735,15 +7306,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-123.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.123"
+          "value": "10.0.1.204"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.203.241.178"
+          "value": "52.78.166.174"
         },
         {
           "key": "RootDeviceName",
@@ -6755,7 +7326,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-0460dcefd8098e744,GroupName:tbd82p3o5lp7sdqchhjdeg}"
+          "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
         },
         {
           "key": "SourceDestCheck",
@@ -6767,11 +7338,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0a94dc0d9c456d177"
+          "value": "subnet-0695096ac3c17916f"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd82p3ollp7sdqchhjdhg}"
+          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
         },
         {
           "key": "VirtualizationType",
@@ -6779,7 +7350,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-01aed90ffbbedd137"
+          "value": "vpc-07e218262146e7003"
         }
       ]
     }
@@ -6795,13 +7366,13 @@
     "results": [
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "43.203.172.180",
+        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "52.78.166.174",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-231 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6811,12 +7382,12 @@
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "3.36.126.236",
+        "nodeIp": "43.203.239.151",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-153 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6825,13 +7396,13 @@
       },
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "43.203.241.178",
+        "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "13.124.168.73",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-123 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6889,8 +7460,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux ip-10-0-1-153 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "3.36.126.236",
+      "output": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "43.203.239.151",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -6901,8 +7472,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux ip-10-0-1-231 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "43.203.172.180",
+      "output": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "13.124.168.73",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -6913,8 +7484,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux ip-10-0-1-123 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "43.203.241.178",
+      "output": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "52.78.166.174",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -6944,7 +7515,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-14 09:13:07
+**Generated At:** 2026-05-18 08:03:08
 
 **Namespace:** mig01
 
@@ -6972,9 +7543,9 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 | t3a.small | 2 | 2.0 | - | x86_64 |  | $0.0234 | 1 |
 | t3a.large | 2 | 8.0 | - | x86_64 |  | $0.0936 | 1 |
-| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 
 ### VM Images
 
@@ -6986,9 +7557,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-0601b01e9bc9c2095 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 3.36.126.236<br>**Private IP:** 10.0.1.153<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-0586524d744cd9f60 | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.172.180<br>**Private IP:** 10.0.1.231<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0277b8136c06aec96 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.241.178<br>**Private IP:** 10.0.1.123<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-05cc436e2832ffd93 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.239.151<br>**Private IP:** 10.0.1.41<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-055c3be58ba3b717a | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 13.124.168.73<br>**Private IP:** 10.0.1.46<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0fa2d84cd0c6e08bb | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.166.174<br>**Private IP:** 10.0.1.204<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
 
 
 ## Network Resources
@@ -7000,7 +7571,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-vnet-01 |
-| **CSP VNet ID** | vpc-01aed90ffbbedd137 |
+| **CSP VNet ID** | vpc-07e218262146e7003 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -7009,7 +7580,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my01-subnet-01 | subnet-0a94dc0d9c456d177 | 10.0.1.0/24 | ap-northeast-2a |
+| my01-subnet-01 | subnet-0695096ac3c17916f | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -7018,7 +7589,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my01-sshkey-01 | tbd82p3ndlp7sdqchhjddg |  | ef:da:bd:b2:9f:a5:9a:e3:3e:66:c4:ff:8c:21:5b:c6:77:bb:89:02 |
+| my01-sshkey-01 | tbd85cetmpr9ha6omvqiog |  | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 |
 
 ### Security Groups
 
@@ -7027,7 +7598,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-01 |
-| **CSP Security Group ID** | sg-0709d80c5c0511f7a |
+| **CSP Security Group ID** | sg-094d187b192dfdf77 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -7055,7 +7626,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-02 |
-| **CSP Security Group ID** | sg-0460dcefd8098e744 |
+| **CSP Security Group ID** | sg-014a3bc57edc785c7 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7088,7 +7659,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-03 |
-| **CSP Security Group ID** | sg-03ad9dc5e16b37c4e |
+| **CSP Security Group ID** | sg-0b2020b2fa704162e |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7163,7 +7734,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-14 09:13:12*
+*Report generated: 2026-05-18 08:03:11*
 
 ---
 
@@ -7207,9 +7778,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-0601b01e9bc9c2095<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-0586524d744cd9f60<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0277b8136c06aec96<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-05cc436e2832ffd93<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-055c3be58ba3b717a<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0fa2d84cd0c6e08bb<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7243,7 +7814,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-01
 
-**CSP ID:** sg-0709d80c5c0511f7a | **VNet:** my01-vnet-01 | **Rules:** 14
+**CSP ID:** sg-094d187b192dfdf77 | **VNet:** my01-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7271,7 +7842,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-02
 
-**CSP ID:** sg-0460dcefd8098e744 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-014a3bc57edc785c7 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7304,7 +7875,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-03
 
-**CSP ID:** sg-03ad9dc5e16b37c4e | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0b2020b2fa704162e | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7345,13 +7916,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-01aed90ffbbedd137 | 10.0.0.0/21 |
+| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-07e218262146e7003 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0a94dc0d9c456d177 | 10.0.1.0/24 | my01-vnet-01 |
+| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0695096ac3c17916f | 10.0.1.0/24 | my01-vnet-01 |
 
 ### Source Network Information
 
@@ -7393,7 +7964,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my01-sshkey-01 | tbd82p3ndlp7sdqchhjddg | ef:da:bd:b2:9f:a5:9a:e3:3e:66:c4:ff:8c:21:5b:c6:77:bb:89:02 | Used by all 3 VMs |
+| 1 | my01-sshkey-01 | tbd85cetmpr9ha6omvqiog | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-azure.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-azure.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.4+ (d99ac81)
+- CM-Beetle: imdl/v0.1.5+ (c574040)
 - cm-model: unknown
 - CB-Tumblebug: vunknown
 - CB-Spider: vunknown
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 12, 2026
-- Test Time: 18:43:58 KST
-- Test Execution: 2026-05-12 18:43:58 KST
+- Test Date: May 18, 2026
+- Test Time: 17:01:38 KST
+- Test Execution: 2026-05-18 17:01:38 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 2.53s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m49.869s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 37ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 12ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 140ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 7.581s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m39.898s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 42ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 4ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 28ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 7.434s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.355s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m56.399s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.269s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.399s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m48.41s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 5m15.987516747s
+**Total Duration**: 4m56.692755828s
 
-*Test executed on May 12, 2026 at 18:43:58 KST (2026-05-12 18:43:58 KST) using CM-Beetle automated test CLI*
+*Test executed on May 18, 2026 at 17:01:38 KST (2026-05-18 17:01:38 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1967,14 +1967,15 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2als_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
               "sg-01"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 30,
             "dataDiskIds": null
           },
           {
@@ -1986,14 +1987,15 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b4as_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
               "sg-02"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 30,
             "dataDiskIds": null
           },
           {
@@ -2006,13 +2008,14 @@
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2as_v2",
             "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
               "sg-03"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 30,
             "dataDiskIds": null
           }
         ],
@@ -2617,79 +2620,6 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "azure",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "regionList": [
-            "common"
-          ],
-          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "uid": "d7k8lctq1uu3ogn5gg30",
-          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "sourceNodeUid": "",
-          "sourceCspImageName": "",
-          "connectionName": "azure-australiacentral",
-          "infraType": "",
-          "fetchedTime": "2026.04.22 08:45:39 Wed",
-          "creationDate": "",
-          "isGPUImage": false,
-          "isKubernetesImage": false,
-          "isBasicImage": false,
-          "osType": "Ubuntu 22.04",
-          "osArchitecture": "x86_64",
-          "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "osDiskType": "default",
-          "osDiskSizeGB": -1,
-          "imageStatus": "Available",
-          "details": [
-            {
-              "key": "Location",
-              "value": "australiacentral"
-            },
-            {
-              "key": "Publisher",
-              "value": "Canonical"
-            },
-            {
-              "key": "Offer",
-              "value": "0001-com-ubuntu-server-jammy-daily"
-            },
-            {
-              "key": "SKU",
-              "value": "22_04-daily-lts-gen2"
-            },
-            {
-              "key": "Version",
-              "value": "22.04.202604160"
-            },
-            {
-              "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202604160"
-            },
-            {
-              "key": "HyperVGeneration",
-              "value": "V2"
-            },
-            {
-              "key": "Features",
-              "value": "SecurityType=TrustedLaunchSupported, IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, NVMe, IsHibernateSupported=True"
-            },
-            {
-              "key": "FeatureCount",
-              "value": "4"
-            },
-            {
-              "key": "ImageDeprecationState",
-              "value": "Active"
-            }
-          ],
-          "systemLabel": "",
-          "description": "",
-          "commandHistory": null
-        },
-        {
-          "resourceType": "image",
-          "namespace": "system",
-          "providerName": "azure",
           "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
           "regionList": [
             "common"
@@ -2749,6 +2679,79 @@
             {
               "key": "FeatureCount",
               "value": "3"
+            },
+            {
+              "key": "ImageDeprecationState",
+              "value": "Active"
+            }
+          ],
+          "systemLabel": "",
+          "description": "",
+          "commandHistory": null
+        },
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "azure",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "regionList": [
+            "common"
+          ],
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "uid": "d7k8lctq1uu3ogn5gg30",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "azure-australiacentral",
+          "infraType": "",
+          "fetchedTime": "2026.04.22 08:45:39 Wed",
+          "creationDate": "",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "osDiskType": "default",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Location",
+              "value": "australiacentral"
+            },
+            {
+              "key": "Publisher",
+              "value": "Canonical"
+            },
+            {
+              "key": "Offer",
+              "value": "0001-com-ubuntu-server-jammy-daily"
+            },
+            {
+              "key": "SKU",
+              "value": "22_04-daily-lts-gen2"
+            },
+            {
+              "key": "Version",
+              "value": "22.04.202604160"
+            },
+            {
+              "key": "ID",
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202604160"
+            },
+            {
+              "key": "HyperVGeneration",
+              "value": "V2"
+            },
+            {
+              "key": "Features",
+              "value": "SecurityType=TrustedLaunchSupported, IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, NVMe, IsHibernateSupported=True"
+            },
+            {
+              "key": "FeatureCount",
+              "value": "4"
             },
             {
               "key": "ImageDeprecationState",
@@ -3107,14 +3110,15 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2ls_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
               "sg-01"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 30,
             "dataDiskIds": null
           },
           {
@@ -3126,14 +3130,15 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b4s_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
               "sg-02"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 30,
             "dataDiskIds": null
           },
           {
@@ -3146,13 +3151,14 @@
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2s_v2",
             "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
               "sg-03"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 30,
             "dataDiskIds": null
           }
         ],
@@ -4321,79 +4327,6 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "azure",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "regionList": [
-            "common"
-          ],
-          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "uid": "d7k8lctq1uu3ogn5gg30",
-          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "sourceNodeUid": "",
-          "sourceCspImageName": "",
-          "connectionName": "azure-australiacentral",
-          "infraType": "",
-          "fetchedTime": "2026.04.22 08:45:39 Wed",
-          "creationDate": "",
-          "isGPUImage": false,
-          "isKubernetesImage": false,
-          "isBasicImage": false,
-          "osType": "Ubuntu 22.04",
-          "osArchitecture": "x86_64",
-          "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "osDiskType": "default",
-          "osDiskSizeGB": -1,
-          "imageStatus": "Available",
-          "details": [
-            {
-              "key": "Location",
-              "value": "australiacentral"
-            },
-            {
-              "key": "Publisher",
-              "value": "Canonical"
-            },
-            {
-              "key": "Offer",
-              "value": "0001-com-ubuntu-server-jammy-daily"
-            },
-            {
-              "key": "SKU",
-              "value": "22_04-daily-lts-gen2"
-            },
-            {
-              "key": "Version",
-              "value": "22.04.202604160"
-            },
-            {
-              "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202604160"
-            },
-            {
-              "key": "HyperVGeneration",
-              "value": "V2"
-            },
-            {
-              "key": "Features",
-              "value": "SecurityType=TrustedLaunchSupported, IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, NVMe, IsHibernateSupported=True"
-            },
-            {
-              "key": "FeatureCount",
-              "value": "4"
-            },
-            {
-              "key": "ImageDeprecationState",
-              "value": "Active"
-            }
-          ],
-          "systemLabel": "",
-          "description": "",
-          "commandHistory": null
-        },
-        {
-          "resourceType": "image",
-          "namespace": "system",
-          "providerName": "azure",
           "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
           "regionList": [
             "common"
@@ -4453,6 +4386,79 @@
             {
               "key": "FeatureCount",
               "value": "3"
+            },
+            {
+              "key": "ImageDeprecationState",
+              "value": "Active"
+            }
+          ],
+          "systemLabel": "",
+          "description": "",
+          "commandHistory": null
+        },
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "azure",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "regionList": [
+            "common"
+          ],
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "uid": "d7k8lctq1uu3ogn5gg30",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "azure-australiacentral",
+          "infraType": "",
+          "fetchedTime": "2026.04.22 08:45:39 Wed",
+          "creationDate": "",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "osDiskType": "default",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Location",
+              "value": "australiacentral"
+            },
+            {
+              "key": "Publisher",
+              "value": "Canonical"
+            },
+            {
+              "key": "Offer",
+              "value": "0001-com-ubuntu-server-jammy-daily"
+            },
+            {
+              "key": "SKU",
+              "value": "22_04-daily-lts-gen2"
+            },
+            {
+              "key": "Version",
+              "value": "22.04.202604160"
+            },
+            {
+              "key": "ID",
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202604160"
+            },
+            {
+              "key": "HyperVGeneration",
+              "value": "V2"
+            },
+            {
+              "key": "Features",
+              "value": "SecurityType=TrustedLaunchSupported, IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, NVMe, IsHibernateSupported=True"
+            },
+            {
+              "key": "FeatureCount",
+              "value": "4"
             },
             {
               "key": "ImageDeprecationState",
@@ -4817,7 +4823,7 @@
 {
   "resourceType": "infra",
   "id": "my02-infra101",
-  "uid": "tbd81fd366aji65qtg7s9g",
+  "uid": "tbd85cf3epr9ha6omvqjbg",
   "name": "my02-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -4845,7 +4851,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my02-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd81fd366aji65qtg7s9g"
+    "sys.uid": "tbd85cf3epr9ha6omvqjbg"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -4854,9 +4860,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd81fd3e6aji65qtg7sag",
-      "cspResourceName": "tbd81fd3e6aji65qtg7sag",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag",
+      "uid": "tbd85cf3epr9ha6omvqjcg",
+      "cspResourceName": "tbd85cf3epr9ha6omvqjcg",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
       "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -4870,16 +4876,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:45:45",
+      "createdTime": "2026-05-18 08:03:14",
       "label": {
-        "createdBy": "tbd81fd3e6aji65qtg7sag",
-        "keypair": "tbd81fcu66aji65qtg7s7g",
-        "publicip": "tbd81fd3e6aji65qtg7sag-6948-PublicIP",
+        "createdBy": "tbd85cf3epr9ha6omvqjcg",
+        "keypair": "tbd85cf06pr9ha6omvqj3g",
+        "publicip": "tbd85cf3epr9ha6omvqjcg-42454-PublicIP",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-12 09:45:45",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag",
-        "sys.cspResourceName": "tbd81fd3e6aji65qtg7sag",
+        "sys.createdTime": "2026-05-18 08:03:14",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
+        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjcg",
         "sys.id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -4888,20 +4894,20 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd81fd3e6aji65qtg7sag",
+        "sys.uid": "tbd85cf3epr9ha6omvqjcg",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "20.214.4.247",
+      "publicIP": "20.214.25.229",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.5",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
-      "rootDiskSize": 50,
+      "rootDiskSize": 30,
       "RootDeviceName": "Not visible in Azure",
       "connectionName": "azure-koreasouth",
       "connectionConfig": {
@@ -4937,32 +4943,32 @@
         "memoryGiB": 3.90625,
         "costPerHour": 0.0432
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-      "networkInterface": "tbd81fd3e6aji65qtg7sag-97625-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+      "networkInterface": "tbd85cf3epr9ha6omvqjcg-39198-VNic",
       "securityGroupIds": [
         "my02-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOlhZnTKot5CpvRf0YzyGcCOMZuXeAMAgdZPJBjMssWEV3mgDw0DIAaZL1vj8YsjarGo8/mGHmt0/jtU0XI2DU0=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL0VTwP0mj+c6VjV8msgi3Q9eibNRewPMT54DUhTIpAg1Sht7ha22G1ufqkYptq1cFE80rR711dScHPLLhmJ+q8=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:NLSKcyS77IrfjQOPBXWdHjfqLW8dVJipgwWxHgZQYe0",
-        "firstUsedAt": "2026-05-12T09:45:55Z"
+        "fingerprint": "SHA256:L+I1/Qhho+5MTJJQUC536mZqODIvIydVP6vJjVbdai0",
+        "firstUsedAt": "2026-05-18T08:03:23Z"
       },
       "commandStatus": [
         {
@@ -4970,11 +4976,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:45:55Z",
-          "completedTime": "2026-05-12T09:45:59Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-05-18T08:03:23Z",
+          "completedTime": "2026-05-18T08:03:26Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fd3e6aji65qtg7sag 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4985,11 +4991,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7sag-97625-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7sag,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7sag_OsDisk_1_8475ebb7b2fc4065a10ea9965259015e,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7sag_OsDisk_1_8475ebb7b2fc4065a10ea9965259015e,osType:Linux}},timeCreated:2026-05-12T09:44:53.6437916Z,vmId:1b543ee0-8c3c-44e9-9d8b-573c0e3fc6c9}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjcg-39198-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjcg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,osType:Linux}},timeCreated:2026-05-18T08:02:26.9394222Z,vmId:66b1ceb1-9da8-497a-ab77-8e1d40b4f26c}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd81fd3e6aji65qtg7sag,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7sag-6948-PublicIP}"
+          "value": "{createdBy:tbd85cf3epr9ha6omvqjcg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjcg-42454-PublicIP}"
         },
         {
           "key": "Etag",
@@ -4997,11 +5003,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg"
         },
         {
           "key": "Name",
-          "value": "tbd81fd3e6aji65qtg7sag"
+          "value": "tbd85cf3epr9ha6omvqjcg"
         },
         {
           "key": "Type",
@@ -5012,9 +5018,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd81fd3e6aji65qtg7scg",
-      "cspResourceName": "tbd81fd3e6aji65qtg7scg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg",
+      "uid": "tbd85cf3epr9ha6omvqjeg",
+      "cspResourceName": "tbd85cf3epr9ha6omvqjeg",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
       "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -5028,16 +5034,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:45:48",
+      "createdTime": "2026-05-18 08:03:17",
       "label": {
-        "createdBy": "tbd81fd3e6aji65qtg7scg",
-        "keypair": "tbd81fcu66aji65qtg7s7g",
-        "publicip": "tbd81fd3e6aji65qtg7scg-43856-PublicIP",
+        "createdBy": "tbd85cf3epr9ha6omvqjeg",
+        "keypair": "tbd85cf06pr9ha6omvqj3g",
+        "publicip": "tbd85cf3epr9ha6omvqjeg-83151-PublicIP",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-12 09:45:48",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg",
-        "sys.cspResourceName": "tbd81fd3e6aji65qtg7scg",
+        "sys.createdTime": "2026-05-18 08:03:17",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
+        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjeg",
         "sys.id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -5046,20 +5052,20 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd81fd3e6aji65qtg7scg",
+        "sys.uid": "tbd85cf3epr9ha6omvqjeg",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "52.231.199.161",
+      "publicIP": "20.214.26.6",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.6",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
-      "rootDiskSize": 50,
+      "rootDiskSize": 30,
       "RootDeviceName": "Not visible in Azure",
       "connectionName": "azure-koreasouth",
       "connectionConfig": {
@@ -5096,7 +5102,7 @@
         "costPerHour": 0.0865
       },
       "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
       "image": {
         "resourceType": "image",
         "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
@@ -5105,22 +5111,22 @@
         "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-      "networkInterface": "tbd81fd3e6aji65qtg7scg-38274-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+      "networkInterface": "tbd85cf3epr9ha6omvqjeg-47871-VNic",
       "securityGroupIds": [
         "my02-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGNC3nphY/v0+xM4rigF6rS6/BryTA6wUKcYifFO+GrlgOg05dR7/deJP4WKbiryKR++SIuzGvpIHF7XfWkCxbs=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEjxGVDmlxPviCew7MPsxQCg/SbRH0g1LPINkzdzqnLKnu1r1BVcN2sOxPrrm4d3ektW4i1wjM5H3IyYVNdYIXM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:Y2gaNklAb4QHPPMwKNRhTABm2kr7c8p0/zvEwSdvNKU",
-        "firstUsedAt": "2026-05-12T09:45:58Z"
+        "fingerprint": "SHA256:kXaggWkouCHVkByZEeZ7WbredHOydMu4PhHCk95sdGA",
+        "firstUsedAt": "2026-05-18T08:03:25Z"
       },
       "commandStatus": [
         {
@@ -5128,11 +5134,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:45:55Z",
-          "completedTime": "2026-05-12T09:46:00Z",
-          "elapsedTime": 5,
+          "startedTime": "2026-05-18T08:03:23Z",
+          "completedTime": "2026-05-18T08:03:27Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fd3e6aji65qtg7scg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -5143,11 +5149,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7scg-38274-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7scg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7scg_OsDisk_1_9fca1cfb0b9a4d3ead6e5403bc3b9dac,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7scg_OsDisk_1_9fca1cfb0b9a4d3ead6e5403bc3b9dac,osType:Linux}},timeCreated:2026-05-12T09:44:57.9968299Z,vmId:5e905251-d043-46c4-814e-489b8c8fe657}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjeg-47871-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjeg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,osType:Linux}},timeCreated:2026-05-18T08:02:28.9784295Z,vmId:85838c4c-38c3-4641-9333-9b5b9ab4769a}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd81fd3e6aji65qtg7scg,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7scg-43856-PublicIP}"
+          "value": "{createdBy:tbd85cf3epr9ha6omvqjeg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjeg-83151-PublicIP}"
         },
         {
           "key": "Etag",
@@ -5155,11 +5161,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg"
         },
         {
           "key": "Name",
-          "value": "tbd81fd3e6aji65qtg7scg"
+          "value": "tbd85cf3epr9ha6omvqjeg"
         },
         {
           "key": "Type",
@@ -5170,9 +5176,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd81fd3e6aji65qtg7sbg",
-      "cspResourceName": "tbd81fd3e6aji65qtg7sbg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg",
+      "uid": "tbd85cf3epr9ha6omvqjdg",
+      "cspResourceName": "tbd85cf3epr9ha6omvqjdg",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
       "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -5186,16 +5192,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:45:47",
+      "createdTime": "2026-05-18 08:03:15",
       "label": {
-        "createdBy": "tbd81fd3e6aji65qtg7sbg",
-        "keypair": "tbd81fcu66aji65qtg7s7g",
-        "publicip": "tbd81fd3e6aji65qtg7sbg-88014-PublicIP",
+        "createdBy": "tbd85cf3epr9ha6omvqjdg",
+        "keypair": "tbd85cf06pr9ha6omvqj3g",
+        "publicip": "tbd85cf3epr9ha6omvqjdg-86268-PublicIP",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-12 09:45:47",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg",
-        "sys.cspResourceName": "tbd81fd3e6aji65qtg7sbg",
+        "sys.createdTime": "2026-05-18 08:03:15",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
+        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjdg",
         "sys.id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -5204,20 +5210,20 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd81fd3e6aji65qtg7sbg",
+        "sys.uid": "tbd85cf3epr9ha6omvqjdg",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "52.231.199.157",
+      "publicIP": "52.231.195.68",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.5",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
-      "rootDiskSize": 50,
+      "rootDiskSize": 30,
       "RootDeviceName": "Not visible in Azure",
       "connectionName": "azure-koreasouth",
       "connectionConfig": {
@@ -5253,32 +5259,32 @@
         "memoryGiB": 15.625,
         "costPerHour": 0.173
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-      "networkInterface": "tbd81fd3e6aji65qtg7sbg-96100-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+      "networkInterface": "tbd85cf3epr9ha6omvqjdg-3065-VNic",
       "securityGroupIds": [
         "my02-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAN6J4eynmqAFw1iIOLTlcDd2Nj3VXVk/ntLQad0HFdZmLHM1XlpHkgbQBQ0ZbT7WdXlCNwjQFUTJUz2Peu6tt8=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTNwiwA06iMy3QoeSkT4pJXpOsH22Jn6+LnZ+ak239UDz03i5xCcIOmCYDASX7JMLHv1NfehWWjviZjXQOCm0A=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:oURuT7phD9rhemFegoCfIhW9JIwJd97nUZcaLxVND60",
-        "firstUsedAt": "2026-05-12T09:45:58Z"
+        "fingerprint": "SHA256:zSgb3/NtuvOcCa3S2XoWo/Kj3Tpb4B15i3wLbr896JA",
+        "firstUsedAt": "2026-05-18T08:03:25Z"
       },
       "commandStatus": [
         {
@@ -5286,11 +5292,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:45:55Z",
-          "completedTime": "2026-05-12T09:46:00Z",
+          "startedTime": "2026-05-18T08:03:23Z",
+          "completedTime": "2026-05-18T08:03:28Z",
           "elapsedTime": 5,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fd3e6aji65qtg7sbg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -5301,11 +5307,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7sbg-96100-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7sbg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7sbg_OsDisk_1_aef0e02e4b6a4ebca659642181e7ee12,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7sbg_OsDisk_1_aef0e02e4b6a4ebca659642181e7ee12,osType:Linux}},timeCreated:2026-05-12T09:44:57.0636694Z,vmId:7f4cdcdf-b136-45ae-8898-b261faa81b51}"
+          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjdg-3065-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjdg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,osType:Linux}},timeCreated:2026-05-18T08:02:27.2996702Z,vmId:9f82564d-bc46-434c-955e-4e8a0c6ad147}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd81fd3e6aji65qtg7sbg,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7sbg-88014-PublicIP}"
+          "value": "{createdBy:tbd85cf3epr9ha6omvqjdg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjdg-86268-PublicIP}"
         },
         {
           "key": "Etag",
@@ -5313,11 +5319,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg"
         },
         {
           "key": "Name",
-          "value": "tbd81fd3e6aji65qtg7sbg"
+          "value": "tbd85cf3epr9ha6omvqjdg"
         },
         {
           "key": "Type",
@@ -5338,12 +5344,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "20.214.4.247",
+        "nodeIp": "20.214.25.229",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fd3e6aji65qtg7sag 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -5353,12 +5359,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "52.231.199.161",
+        "nodeIp": "20.214.26.6",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fd3e6aji65qtg7scg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -5368,12 +5374,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "52.231.199.157",
+        "nodeIp": "52.231.195.68",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fd3e6aji65qtg7sbg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -5409,7 +5415,7 @@
     {
       "resourceType": "infra",
       "id": "my01-infra101",
-      "uid": "tbd81fctu6aji65qtg7s2g",
+      "uid": "tbd85cevepr9ha6omvqit0",
       "name": "my01-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -5437,7 +5443,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my01-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd81fctu6aji65qtg7s2g"
+        "sys.uid": "tbd85cevepr9ha6omvqit0"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5446,9 +5452,9 @@
         {
           "resourceType": "node",
           "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd81fctu6aji65qtg7s3g",
-          "cspResourceName": "tbd81fctu6aji65qtg7s3g",
-          "cspResourceId": "i-0951db77036789be7",
+          "uid": "tbd85cevepr9ha6omvqiu0",
+          "cspResourceName": "tbd85cevepr9ha6omvqiu0",
+          "cspResourceId": "i-05cc436e2832ffd93",
           "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -5462,14 +5468,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:44:47",
+          "createdTime": "2026-05-18 08:02:29",
           "label": {
-            "Name": "tbd81fctu6aji65qtg7s3g",
+            "Name": "tbd85cevepr9ha6omvqiu0",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-12 09:44:47",
-            "sys.cspResourceId": "i-0951db77036789be7",
-            "sys.cspResourceName": "tbd81fctu6aji65qtg7s3g",
+            "sys.createdTime": "2026-05-18 08:02:29",
+            "sys.cspResourceId": "i-05cc436e2832ffd93",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
             "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5478,7 +5484,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd81fctu6aji65qtg7s3g",
+            "sys.uid": "tbd85cevepr9ha6omvqiu0",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5486,13 +5492,13 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "43.203.118.191",
+          "publicIP": "43.203.239.151",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.221",
-          "privateDNS": "ip-10-0-1-221.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.41",
+          "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
           "connectionName": "aws-ap-northeast-2",
           "connectionConfig": {
@@ -5543,22 +5549,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-03418b1c97bcb7bb0",
+          "cspVNetId": "vpc-07e218262146e7003",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0e40174384d5575ff",
-          "networkInterface": "eni-attach-015d05102e00d5423",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-04753091ce5855ac2",
           "securityGroupIds": [
             "my01-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd81fcs66aji65qtg7s0g",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMTCLbkv5mpN3rODVz7y/91K05G7O+Xdi/lajmxBMXj2gKUBjIq5vvtQL6zkmW76hKyt5/fAYnFnNnaVzTsCL44=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:Q1MQ+W69Z/sEU8y0ct5FT3JPvnyQX4KOzS4GPmo7UMc",
-            "firstUsedAt": "2026-05-12T09:44:56Z"
+            "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
+            "firstUsedAt": "2026-05-18T08:02:39Z"
           },
           "commandStatus": [
             {
@@ -5566,11 +5572,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:44:55Z",
-              "completedTime": "2026-05-12T09:44:58Z",
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
               "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-221 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5585,7 +5591,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-12T09:44:25Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-03efa0d6f0567f705}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
             },
             {
               "key": "BootMode",
@@ -5597,7 +5603,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "FFCD8649-19EE-4627-81E5-C849E26E75B9"
+              "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
             },
             {
               "key": "CpuOptions",
@@ -5629,7 +5635,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0951db77036789be7"
+              "value": "i-05cc436e2832ffd93"
             },
             {
               "key": "InstanceType",
@@ -5637,11 +5643,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd81fcs66aji65qtg7s0g"
+              "value": "tbd85cetmpr9ha6omvqiog"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-12T09:44:24Z"
+              "value": "2026-05-18T08:02:08Z"
             },
             {
               "key": "MetadataOptions",
@@ -5653,7 +5659,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.118.191},Attachment:{AttachTime:2026-05-12T09:44:24Z,AttachmentId:eni-attach-015d05102e00d5423,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0df249c4f598c135c,GroupName:tbd81fcse6aji65qtg7s10}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:6a:7a:ff:02:23,NetworkInterfaceId:eni-0e23cf5cf082e7929,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.221,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.118.191},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.221}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0e40174384d5575ff,VpcId:vpc-03418b1c97bcb7bb0}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
             },
             {
               "key": "Placement",
@@ -5661,15 +5667,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-221.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.221"
+              "value": "10.0.1.41"
             },
             {
               "key": "PublicIpAddress",
-              "value": "43.203.118.191"
+              "value": "43.203.239.151"
             },
             {
               "key": "RootDeviceName",
@@ -5681,7 +5687,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-0df249c4f598c135c,GroupName:tbd81fcse6aji65qtg7s10}"
+              "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
             },
             {
               "key": "SourceDestCheck",
@@ -5693,11 +5699,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0e40174384d5575ff"
+              "value": "subnet-0695096ac3c17916f"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd81fctu6aji65qtg7s3g}"
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
             },
             {
               "key": "VirtualizationType",
@@ -5705,16 +5711,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-03418b1c97bcb7bb0"
+              "value": "vpc-07e218262146e7003"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd81fctu6aji65qtg7s5g",
-          "cspResourceName": "tbd81fctu6aji65qtg7s5g",
-          "cspResourceId": "i-0e4676d603cfb7af7",
+          "uid": "tbd85cevepr9ha6omvqj00",
+          "cspResourceName": "tbd85cevepr9ha6omvqj00",
+          "cspResourceId": "i-055c3be58ba3b717a",
           "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5728,14 +5734,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:44:49",
+          "createdTime": "2026-05-18 08:02:31",
           "label": {
-            "Name": "tbd81fctu6aji65qtg7s5g",
+            "Name": "tbd85cevepr9ha6omvqj00",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-12 09:44:49",
-            "sys.cspResourceId": "i-0e4676d603cfb7af7",
-            "sys.cspResourceName": "tbd81fctu6aji65qtg7s5g",
+            "sys.createdTime": "2026-05-18 08:02:31",
+            "sys.cspResourceId": "i-055c3be58ba3b717a",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
             "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5744,7 +5750,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd81fctu6aji65qtg7s5g",
+            "sys.uid": "tbd85cevepr9ha6omvqj00",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5752,13 +5758,13 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "3.38.94.194",
+          "publicIP": "13.124.168.73",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.193",
-          "privateDNS": "ip-10-0-1-193.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.46",
+          "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
           "connectionName": "aws-ap-northeast-2",
           "connectionConfig": {
@@ -5809,34 +5815,35 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-03418b1c97bcb7bb0",
+          "cspVNetId": "vpc-07e218262146e7003",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0e40174384d5575ff",
-          "networkInterface": "eni-attach-07537aa2a55e39358",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-0512107afc0efe575",
           "securityGroupIds": [
             "my01-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd81fcs66aji65qtg7s0g",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBHwzgi4IZgpbMDZPgXLWdcBDd/jtIJrfTBl06XnJd+JVDbQbW7E9T4BN9h/YYZAQT995HFdjkTTuiVVgLDUCnc=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:8DCFGUDqCdW+VXKPkvD16/aaD0h1iupZHGlKlrsphXE",
-            "firstUsedAt": "2026-05-12T09:44:56Z"
+            "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
+            "firstUsedAt": "2026-05-18T08:02:39Z"
           },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Failed",
-              "startedTime": "2026-05-12T09:44:55Z",
-              "completedTime": "2026-05-12T09:45:14Z",
-              "elapsedTime": 19,
-              "resultSummary": "Command execution failed",
-              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
+              "status": "Completed",
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
             }
           ],
           "addtionalDetails": [
@@ -5850,7 +5857,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-12T09:44:29Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-04425355d7c4126e6}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
             },
             {
               "key": "BootMode",
@@ -5862,7 +5869,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "1FBED08A-500E-4330-A49E-EB55E9C8010C"
+              "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
             },
             {
               "key": "CpuOptions",
@@ -5894,7 +5901,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0e4676d603cfb7af7"
+              "value": "i-055c3be58ba3b717a"
             },
             {
               "key": "InstanceType",
@@ -5902,11 +5909,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd81fcs66aji65qtg7s0g"
+              "value": "tbd85cetmpr9ha6omvqiog"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-12T09:44:29Z"
+              "value": "2026-05-18T08:02:08Z"
             },
             {
               "key": "MetadataOptions",
@@ -5918,7 +5925,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.94.194},Attachment:{AttachTime:2026-05-12T09:44:29Z,AttachmentId:eni-attach-07537aa2a55e39358,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-07dddf2bbd13b61bb,GroupName:tbd81fcte6aji65qtg7s20}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:b8:c1:16:63:29,NetworkInterfaceId:eni-020186ae30aa051cd,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.193,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.94.194},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.193}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0e40174384d5575ff,VpcId:vpc-03418b1c97bcb7bb0}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
             },
             {
               "key": "Placement",
@@ -5926,15 +5933,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-193.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.193"
+              "value": "10.0.1.46"
             },
             {
               "key": "PublicIpAddress",
-              "value": "3.38.94.194"
+              "value": "13.124.168.73"
             },
             {
               "key": "RootDeviceName",
@@ -5946,7 +5953,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-07dddf2bbd13b61bb,GroupName:tbd81fcte6aji65qtg7s20}"
+              "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
             },
             {
               "key": "SourceDestCheck",
@@ -5958,11 +5965,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0e40174384d5575ff"
+              "value": "subnet-0695096ac3c17916f"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd81fctu6aji65qtg7s5g}"
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
             },
             {
               "key": "VirtualizationType",
@@ -5970,16 +5977,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-03418b1c97bcb7bb0"
+              "value": "vpc-07e218262146e7003"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd81fctu6aji65qtg7s4g",
-          "cspResourceName": "tbd81fctu6aji65qtg7s4g",
-          "cspResourceId": "i-0bfdfe83fdd3bd1d6",
+          "uid": "tbd85cevepr9ha6omvqiv0",
+          "cspResourceName": "tbd85cevepr9ha6omvqiv0",
+          "cspResourceId": "i-0fa2d84cd0c6e08bb",
           "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5993,14 +6000,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:44:46",
+          "createdTime": "2026-05-18 08:02:28",
           "label": {
-            "Name": "tbd81fctu6aji65qtg7s4g",
+            "Name": "tbd85cevepr9ha6omvqiv0",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-12 09:44:46",
-            "sys.cspResourceId": "i-0bfdfe83fdd3bd1d6",
-            "sys.cspResourceName": "tbd81fctu6aji65qtg7s4g",
+            "sys.createdTime": "2026-05-18 08:02:28",
+            "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
+            "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
             "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -6009,7 +6016,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd81fctu6aji65qtg7s4g",
+            "sys.uid": "tbd85cevepr9ha6omvqiv0",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6017,13 +6024,13 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "3.36.99.199",
+          "publicIP": "52.78.166.174",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.174",
-          "privateDNS": "ip-10-0-1-174.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.204",
+          "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
           "connectionName": "aws-ap-northeast-2",
           "connectionConfig": {
@@ -6074,22 +6081,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-03418b1c97bcb7bb0",
+          "cspVNetId": "vpc-07e218262146e7003",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0e40174384d5575ff",
-          "networkInterface": "eni-attach-07760d189c761c505",
+          "cspSubnetId": "subnet-0695096ac3c17916f",
+          "networkInterface": "eni-attach-0dacfd07e29c82162",
           "securityGroupIds": [
             "my01-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd81fcs66aji65qtg7s0g",
+          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBH3tBbd6R8+4iT1y1lp+1W8vcxSluVVqO7KG8cTazIsy2v3zEI+9fWte5DLnYyhHS7ZHoXQvgN+qPmfIXCeH8l0=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:Lugdl/PqgyoITxlK6SrXaAe3qwm1yusTEDe28CHQmtY",
-            "firstUsedAt": "2026-05-12T09:44:55Z"
+            "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
+            "firstUsedAt": "2026-05-18T08:02:37Z"
           },
           "commandStatus": [
             {
@@ -6097,11 +6104,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:44:55Z",
-              "completedTime": "2026-05-12T09:44:57Z",
-              "elapsedTime": 2,
+              "startedTime": "2026-05-18T08:02:37Z",
+              "completedTime": "2026-05-18T08:02:40Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-174 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -6116,7 +6123,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-12T09:44:28Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0772b3222158e12f4}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
             },
             {
               "key": "BootMode",
@@ -6128,7 +6135,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "88EF160F-F24C-439B-8CD6-D4326CC7CCB4"
+              "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
             },
             {
               "key": "CpuOptions",
@@ -6160,7 +6167,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0bfdfe83fdd3bd1d6"
+              "value": "i-0fa2d84cd0c6e08bb"
             },
             {
               "key": "InstanceType",
@@ -6168,11 +6175,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd81fcs66aji65qtg7s0g"
+              "value": "tbd85cetmpr9ha6omvqiog"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-12T09:44:27Z"
+              "value": "2026-05-18T08:02:07Z"
             },
             {
               "key": "MetadataOptions",
@@ -6184,7 +6191,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.99.199},Attachment:{AttachTime:2026-05-12T09:44:27Z,AttachmentId:eni-attach-07760d189c761c505,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-095f9ab3806e7754b,GroupName:tbd81fcsu6aji65qtg7s1g}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:b9:0a:1b:3a:01,NetworkInterfaceId:eni-0b320aca826247e1d,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.174,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.36.99.199},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.174}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0e40174384d5575ff,VpcId:vpc-03418b1c97bcb7bb0}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
             },
             {
               "key": "Placement",
@@ -6192,15 +6199,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-174.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.174"
+              "value": "10.0.1.204"
             },
             {
               "key": "PublicIpAddress",
-              "value": "3.36.99.199"
+              "value": "52.78.166.174"
             },
             {
               "key": "RootDeviceName",
@@ -6212,7 +6219,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-095f9ab3806e7754b,GroupName:tbd81fcsu6aji65qtg7s1g}"
+              "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
             },
             {
               "key": "SourceDestCheck",
@@ -6224,11 +6231,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0e40174384d5575ff"
+              "value": "subnet-0695096ac3c17916f"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd81fctu6aji65qtg7s4g}"
+              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
             },
             {
               "key": "VirtualizationType",
@@ -6236,7 +6243,7 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-03418b1c97bcb7bb0"
+              "value": "vpc-07e218262146e7003"
             }
           ]
         }
@@ -6253,12 +6260,12 @@
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "3.36.99.199",
+            "nodeIp": "52.78.166.174",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-174 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6268,12 +6275,12 @@
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "43.203.118.191",
+            "nodeIp": "43.203.239.151",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-221 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6283,12 +6290,16 @@
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "3.38.94.194",
+            "nodeIp": "13.124.168.73",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {},
-            "stderr": {},
+            "stdout": {
+              "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
             "err": null
           }
         ]
@@ -6297,7 +6308,7 @@
     {
       "resourceType": "infra",
       "id": "my02-infra101",
-      "uid": "tbd81fd366aji65qtg7s9g",
+      "uid": "tbd85cf3epr9ha6omvqjbg",
       "name": "my02-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -6325,7 +6336,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my02-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd81fd366aji65qtg7s9g"
+        "sys.uid": "tbd85cf3epr9ha6omvqjbg"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -6334,9 +6345,9 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd81fd3e6aji65qtg7sag",
-          "cspResourceName": "tbd81fd3e6aji65qtg7sag",
-          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag",
+          "uid": "tbd85cf3epr9ha6omvqjcg",
+          "cspResourceName": "tbd85cf3epr9ha6omvqjcg",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
           "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -6350,16 +6361,16 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:45:45",
+          "createdTime": "2026-05-18 08:03:14",
           "label": {
-            "createdBy": "tbd81fd3e6aji65qtg7sag",
-            "keypair": "tbd81fcu66aji65qtg7s7g",
-            "publicip": "tbd81fd3e6aji65qtg7sag-6948-PublicIP",
+            "createdBy": "tbd85cf3epr9ha6omvqjcg",
+            "keypair": "tbd85cf06pr9ha6omvqj3g",
+            "publicip": "tbd85cf3epr9ha6omvqjcg-42454-PublicIP",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "azure-koreasouth",
-            "sys.createdTime": "2026-05-12 09:45:45",
-            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag",
-            "sys.cspResourceName": "tbd81fd3e6aji65qtg7sag",
+            "sys.createdTime": "2026-05-18 08:03:14",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
+            "sys.cspResourceName": "tbd85cf3epr9ha6omvqjcg",
             "sys.id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my02-infra101",
             "sys.labelType": "node",
@@ -6368,20 +6379,20 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my02-subnet-01",
-            "sys.uid": "tbd81fd3e6aji65qtg7sag",
+            "sys.uid": "tbd85cf3epr9ha6omvqjcg",
             "sys.vNetId": "my02-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
           "region": {
             "region": "koreasouth"
           },
-          "publicIP": "20.214.4.247",
+          "publicIP": "20.214.25.229",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.4",
+          "privateIP": "10.0.1.5",
           "privateDNS": "",
           "rootDiskType": "PremiumSSD",
-          "rootDiskSize": 50,
+          "rootDiskSize": 30,
           "RootDeviceName": "Not visible in Azure",
           "connectionName": "azure-koreasouth",
           "connectionConfig": {
@@ -6417,32 +6428,32 @@
             "memoryGiB": 3.90625,
             "costPerHour": 0.0432
           },
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
           "image": {
             "resourceType": "image",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
           },
           "vNetId": "my02-vnet-01",
-          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
           "subnetId": "my02-subnet-01",
-          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-          "networkInterface": "tbd81fd3e6aji65qtg7sag-97625-VNic",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+          "networkInterface": "tbd85cf3epr9ha6omvqjcg-39198-VNic",
           "securityGroupIds": [
             "my02-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my02-sshkey-01",
-          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOlhZnTKot5CpvRf0YzyGcCOMZuXeAMAgdZPJBjMssWEV3mgDw0DIAaZL1vj8YsjarGo8/mGHmt0/jtU0XI2DU0=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL0VTwP0mj+c6VjV8msgi3Q9eibNRewPMT54DUhTIpAg1Sht7ha22G1ufqkYptq1cFE80rR711dScHPLLhmJ+q8=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:NLSKcyS77IrfjQOPBXWdHjfqLW8dVJipgwWxHgZQYe0",
-            "firstUsedAt": "2026-05-12T09:45:55Z"
+            "fingerprint": "SHA256:L+I1/Qhho+5MTJJQUC536mZqODIvIydVP6vJjVbdai0",
+            "firstUsedAt": "2026-05-18T08:03:23Z"
           },
           "commandStatus": [
             {
@@ -6450,11 +6461,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:45:55Z",
-              "completedTime": "2026-05-12T09:45:59Z",
-              "elapsedTime": 4,
+              "startedTime": "2026-05-18T08:03:23Z",
+              "completedTime": "2026-05-18T08:03:26Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81fd3e6aji65qtg7sag 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -6465,11 +6476,11 @@
             },
             {
               "key": "Properties",
-              "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7sag-97625-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7sag,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7sag_OsDisk_1_8475ebb7b2fc4065a10ea9965259015e,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7sag_OsDisk_1_8475ebb7b2fc4065a10ea9965259015e,osType:Linux}},timeCreated:2026-05-12T09:44:53.6437916Z,vmId:1b543ee0-8c3c-44e9-9d8b-573c0e3fc6c9}"
+              "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjcg-39198-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjcg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,osType:Linux}},timeCreated:2026-05-18T08:02:26.9394222Z,vmId:66b1ceb1-9da8-497a-ab77-8e1d40b4f26c}"
             },
             {
               "key": "Tags",
-              "value": "{createdBy:tbd81fd3e6aji65qtg7sag,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7sag-6948-PublicIP}"
+              "value": "{createdBy:tbd85cf3epr9ha6omvqjcg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjcg-42454-PublicIP}"
             },
             {
               "key": "Etag",
@@ -6477,11 +6488,11 @@
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg"
             },
             {
               "key": "Name",
-              "value": "tbd81fd3e6aji65qtg7sag"
+              "value": "tbd85cf3epr9ha6omvqjcg"
             },
             {
               "key": "Type",
@@ -6492,9 +6503,9 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd81fd3e6aji65qtg7scg",
-          "cspResourceName": "tbd81fd3e6aji65qtg7scg",
-          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg",
+          "uid": "tbd85cf3epr9ha6omvqjeg",
+          "cspResourceName": "tbd85cf3epr9ha6omvqjeg",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
           "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -6508,16 +6519,16 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:45:48",
+          "createdTime": "2026-05-18 08:03:17",
           "label": {
-            "createdBy": "tbd81fd3e6aji65qtg7scg",
-            "keypair": "tbd81fcu66aji65qtg7s7g",
-            "publicip": "tbd81fd3e6aji65qtg7scg-43856-PublicIP",
+            "createdBy": "tbd85cf3epr9ha6omvqjeg",
+            "keypair": "tbd85cf06pr9ha6omvqj3g",
+            "publicip": "tbd85cf3epr9ha6omvqjeg-83151-PublicIP",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "azure-koreasouth",
-            "sys.createdTime": "2026-05-12 09:45:48",
-            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg",
-            "sys.cspResourceName": "tbd81fd3e6aji65qtg7scg",
+            "sys.createdTime": "2026-05-18 08:03:17",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
+            "sys.cspResourceName": "tbd85cf3epr9ha6omvqjeg",
             "sys.id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my02-infra101",
             "sys.labelType": "node",
@@ -6526,20 +6537,20 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my02-subnet-01",
-            "sys.uid": "tbd81fd3e6aji65qtg7scg",
+            "sys.uid": "tbd85cf3epr9ha6omvqjeg",
             "sys.vNetId": "my02-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
           "region": {
             "region": "koreasouth"
           },
-          "publicIP": "52.231.199.161",
+          "publicIP": "20.214.26.6",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.6",
           "privateDNS": "",
           "rootDiskType": "PremiumSSD",
-          "rootDiskSize": 50,
+          "rootDiskSize": 30,
           "RootDeviceName": "Not visible in Azure",
           "connectionName": "azure-koreasouth",
           "connectionConfig": {
@@ -6576,7 +6587,7 @@
             "costPerHour": 0.0865
           },
           "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
           "image": {
             "resourceType": "image",
             "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
@@ -6585,22 +6596,22 @@
             "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
           },
           "vNetId": "my02-vnet-01",
-          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
           "subnetId": "my02-subnet-01",
-          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-          "networkInterface": "tbd81fd3e6aji65qtg7scg-38274-VNic",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+          "networkInterface": "tbd85cf3epr9ha6omvqjeg-47871-VNic",
           "securityGroupIds": [
             "my02-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my02-sshkey-01",
-          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGNC3nphY/v0+xM4rigF6rS6/BryTA6wUKcYifFO+GrlgOg05dR7/deJP4WKbiryKR++SIuzGvpIHF7XfWkCxbs=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEjxGVDmlxPviCew7MPsxQCg/SbRH0g1LPINkzdzqnLKnu1r1BVcN2sOxPrrm4d3ektW4i1wjM5H3IyYVNdYIXM=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:Y2gaNklAb4QHPPMwKNRhTABm2kr7c8p0/zvEwSdvNKU",
-            "firstUsedAt": "2026-05-12T09:45:58Z"
+            "fingerprint": "SHA256:kXaggWkouCHVkByZEeZ7WbredHOydMu4PhHCk95sdGA",
+            "firstUsedAt": "2026-05-18T08:03:25Z"
           },
           "commandStatus": [
             {
@@ -6608,11 +6619,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:45:55Z",
-              "completedTime": "2026-05-12T09:46:00Z",
-              "elapsedTime": 5,
+              "startedTime": "2026-05-18T08:03:23Z",
+              "completedTime": "2026-05-18T08:03:27Z",
+              "elapsedTime": 4,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81fd3e6aji65qtg7scg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -6623,11 +6634,11 @@
             },
             {
               "key": "Properties",
-              "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7scg-38274-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7scg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7scg_OsDisk_1_9fca1cfb0b9a4d3ead6e5403bc3b9dac,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7scg_OsDisk_1_9fca1cfb0b9a4d3ead6e5403bc3b9dac,osType:Linux}},timeCreated:2026-05-12T09:44:57.9968299Z,vmId:5e905251-d043-46c4-814e-489b8c8fe657}"
+              "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjeg-47871-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjeg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,osType:Linux}},timeCreated:2026-05-18T08:02:28.9784295Z,vmId:85838c4c-38c3-4641-9333-9b5b9ab4769a}"
             },
             {
               "key": "Tags",
-              "value": "{createdBy:tbd81fd3e6aji65qtg7scg,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7scg-43856-PublicIP}"
+              "value": "{createdBy:tbd85cf3epr9ha6omvqjeg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjeg-83151-PublicIP}"
             },
             {
               "key": "Etag",
@@ -6635,11 +6646,11 @@
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg"
             },
             {
               "key": "Name",
-              "value": "tbd81fd3e6aji65qtg7scg"
+              "value": "tbd85cf3epr9ha6omvqjeg"
             },
             {
               "key": "Type",
@@ -6650,9 +6661,9 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd81fd3e6aji65qtg7sbg",
-          "cspResourceName": "tbd81fd3e6aji65qtg7sbg",
-          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg",
+          "uid": "tbd85cf3epr9ha6omvqjdg",
+          "cspResourceName": "tbd85cf3epr9ha6omvqjdg",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
           "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -6666,16 +6677,16 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:45:47",
+          "createdTime": "2026-05-18 08:03:15",
           "label": {
-            "createdBy": "tbd81fd3e6aji65qtg7sbg",
-            "keypair": "tbd81fcu66aji65qtg7s7g",
-            "publicip": "tbd81fd3e6aji65qtg7sbg-88014-PublicIP",
+            "createdBy": "tbd85cf3epr9ha6omvqjdg",
+            "keypair": "tbd85cf06pr9ha6omvqj3g",
+            "publicip": "tbd85cf3epr9ha6omvqjdg-86268-PublicIP",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "azure-koreasouth",
-            "sys.createdTime": "2026-05-12 09:45:47",
-            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg",
-            "sys.cspResourceName": "tbd81fd3e6aji65qtg7sbg",
+            "sys.createdTime": "2026-05-18 08:03:15",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
+            "sys.cspResourceName": "tbd85cf3epr9ha6omvqjdg",
             "sys.id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my02-infra101",
             "sys.labelType": "node",
@@ -6684,20 +6695,20 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my02-subnet-01",
-            "sys.uid": "tbd81fd3e6aji65qtg7sbg",
+            "sys.uid": "tbd85cf3epr9ha6omvqjdg",
             "sys.vNetId": "my02-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
           "region": {
             "region": "koreasouth"
           },
-          "publicIP": "52.231.199.157",
+          "publicIP": "52.231.195.68",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.5",
+          "privateIP": "10.0.1.4",
           "privateDNS": "",
           "rootDiskType": "PremiumSSD",
-          "rootDiskSize": 50,
+          "rootDiskSize": 30,
           "RootDeviceName": "Not visible in Azure",
           "connectionName": "azure-koreasouth",
           "connectionConfig": {
@@ -6733,32 +6744,32 @@
             "memoryGiB": 15.625,
             "costPerHour": 0.173
           },
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
           "image": {
             "resourceType": "image",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
           },
           "vNetId": "my02-vnet-01",
-          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
           "subnetId": "my02-subnet-01",
-          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-          "networkInterface": "tbd81fd3e6aji65qtg7sbg-96100-VNic",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+          "networkInterface": "tbd85cf3epr9ha6omvqjdg-3065-VNic",
           "securityGroupIds": [
             "my02-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my02-sshkey-01",
-          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAN6J4eynmqAFw1iIOLTlcDd2Nj3VXVk/ntLQad0HFdZmLHM1XlpHkgbQBQ0ZbT7WdXlCNwjQFUTJUz2Peu6tt8=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTNwiwA06iMy3QoeSkT4pJXpOsH22Jn6+LnZ+ak239UDz03i5xCcIOmCYDASX7JMLHv1NfehWWjviZjXQOCm0A=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:oURuT7phD9rhemFegoCfIhW9JIwJd97nUZcaLxVND60",
-            "firstUsedAt": "2026-05-12T09:45:58Z"
+            "fingerprint": "SHA256:zSgb3/NtuvOcCa3S2XoWo/Kj3Tpb4B15i3wLbr896JA",
+            "firstUsedAt": "2026-05-18T08:03:25Z"
           },
           "commandStatus": [
             {
@@ -6766,11 +6777,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:45:55Z",
-              "completedTime": "2026-05-12T09:46:00Z",
+              "startedTime": "2026-05-18T08:03:23Z",
+              "completedTime": "2026-05-18T08:03:28Z",
               "elapsedTime": 5,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81fd3e6aji65qtg7sbg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -6781,11 +6792,11 @@
             },
             {
               "key": "Properties",
-              "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7sbg-96100-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7sbg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7sbg_OsDisk_1_aef0e02e4b6a4ebca659642181e7ee12,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7sbg_OsDisk_1_aef0e02e4b6a4ebca659642181e7ee12,osType:Linux}},timeCreated:2026-05-12T09:44:57.0636694Z,vmId:7f4cdcdf-b136-45ae-8898-b261faa81b51}"
+              "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjdg-3065-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjdg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,osType:Linux}},timeCreated:2026-05-18T08:02:27.2996702Z,vmId:9f82564d-bc46-434c-955e-4e8a0c6ad147}"
             },
             {
               "key": "Tags",
-              "value": "{createdBy:tbd81fd3e6aji65qtg7sbg,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7sbg-88014-PublicIP}"
+              "value": "{createdBy:tbd85cf3epr9ha6omvqjdg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjdg-86268-PublicIP}"
             },
             {
               "key": "Etag",
@@ -6793,11 +6804,11 @@
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg"
             },
             {
               "key": "Name",
-              "value": "tbd81fd3e6aji65qtg7sbg"
+              "value": "tbd85cf3epr9ha6omvqjdg"
             },
             {
               "key": "Type",
@@ -6818,12 +6829,12 @@
           {
             "infraId": "my02-infra101",
             "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "20.214.4.247",
+            "nodeIp": "20.214.25.229",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81fd3e6aji65qtg7sag 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6833,12 +6844,12 @@
           {
             "infraId": "my02-infra101",
             "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "52.231.199.161",
+            "nodeIp": "20.214.26.6",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81fd3e6aji65qtg7scg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6848,12 +6859,1211 @@
           {
             "infraId": "my02-infra101",
             "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "52.231.199.157",
+            "nodeIp": "52.231.195.68",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81fd3e6aji65qtg7sbg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": "infra",
+      "id": "my04-infra101",
+      "uid": "tbd85cf1upr9ha6omvqj60",
+      "name": "my04-infra101",
+      "status": "Running:3 (R:3/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 0,
+        "countRunning": 3,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "None",
+      "targetAction": "None",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my04-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my04-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbd85cf1upr9ha6omvqj60"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbd85cf1upr9ha6omvqj70",
+          "cspResourceName": "tbd85cf1upr9ha6omvqj70",
+          "cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
+          "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-05-18 08:02:47",
+          "label": {
+            "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.connectionName": "alibaba-ap-northeast-2",
+            "sys.createdTime": "2026-05-18 08:02:47",
+            "sys.cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
+            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj70",
+            "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.infraId": "my04-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.subnetId": "my04-subnet-01",
+            "sys.uid": "tbd85cf1upr9ha6omvqj70",
+            "sys.vNetId": "my04-vnet-01"
+          },
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "47.80.240.250",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.15",
+          "privateDNS": "",
+          "rootDiskType": "cloud_essd",
+          "rootDiskSize": 40,
+          "RootDeviceName": "/dev/xvda",
+          "connectionName": "alibaba-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "alibaba-ap-northeast-2",
+            "providerName": "alibaba",
+            "driverName": "alibaba-driver-v1.0.so",
+            "credentialName": "alibaba",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "alibaba-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "South Korea (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
+          "cspSpecName": "ecs.e-c1m1.large",
+          "spec": {
+            "cspSpecName": "ecs.e-c1m1.large",
+            "vCPU": 2,
+            "memoryGiB": 2,
+            "costPerHour": 0.0178
+          },
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Ubuntu  22.04 64 bit"
+          },
+          "vNetId": "my04-vnet-01",
+          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
+          "subnetId": "my04-subnet-01",
+          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+          "networkInterface": "eni-mj7ctm2infbmnn6uucox",
+          "securityGroupIds": [
+            "my04-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my04-sshkey-01",
+          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
+          "nodeUserName": "cb-user",
+          "nodeUserPassword": "upb!t1$1fd8c5A",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIxjgydAuYGlPu0chuI8q9j7hzoY0Rq4M/6ULrhSpcsPA78KSE4g2MEgG2KnC/Y9kaOYioaIMVk355QCS+/2JM=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:ElR8y8aTDUmfc8Kf9iCIhXjocBPKZg5jjX79lSxer8U",
+            "firstUsedAt": "2026-05-18T08:02:56Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-05-18T08:02:55Z",
+              "completedTime": "2026-05-18T08:02:57Z",
+              "elapsedTime": 2,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "ImageId",
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
+            },
+            {
+              "key": "InstanceType",
+              "value": "ecs.e-c1m1.large"
+            },
+            {
+              "key": "DeviceAvailable",
+              "value": "true"
+            },
+            {
+              "key": "InstanceNetworkType",
+              "value": "vpc"
+            },
+            {
+              "key": "LocalStorageAmount",
+              "value": "0"
+            },
+            {
+              "key": "IsSpot",
+              "value": "false"
+            },
+            {
+              "key": "InstanceChargeType",
+              "value": "PostPaid"
+            },
+            {
+              "key": "InstanceName",
+              "value": "tbd85cf1upr9ha6omvqj70"
+            },
+            {
+              "key": "DeploymentSetGroupNo",
+              "value": "0"
+            },
+            {
+              "key": "GPUAmount",
+              "value": "0"
+            },
+            {
+              "key": "Connected",
+              "value": "false"
+            },
+            {
+              "key": "InvocationCount",
+              "value": "0"
+            },
+            {
+              "key": "StartTime",
+              "value": "2026-05-18T08:02Z"
+            },
+            {
+              "key": "ZoneId",
+              "value": "ap-northeast-2a"
+            },
+            {
+              "key": "InternetMaxBandwidthIn",
+              "value": "200"
+            },
+            {
+              "key": "InternetChargeType",
+              "value": "PayByBandwidth"
+            },
+            {
+              "key": "HostName",
+              "value": "iZmj7ctm2infbmnn6vq0exZ"
+            },
+            {
+              "key": "Status",
+              "value": "Running"
+            },
+            {
+              "key": "CPU",
+              "value": "0"
+            },
+            {
+              "key": "Cpu",
+              "value": "2"
+            },
+            {
+              "key": "SpotPriceLimit",
+              "value": "0.00"
+            },
+            {
+              "key": "OSName",
+              "value": "Ubuntu  22.04 64位"
+            },
+            {
+              "key": "InstanceOwnerId",
+              "value": "0"
+            },
+            {
+              "key": "OSNameEn",
+              "value": "Ubuntu  22.04 64 bit"
+            },
+            {
+              "key": "SerialNumber",
+              "value": "13344c44-f69b-4fdb-bc04-e9e4756fde66"
+            },
+            {
+              "key": "RegionId",
+              "value": "ap-northeast-2"
+            },
+            {
+              "key": "IoOptimized",
+              "value": "true"
+            },
+            {
+              "key": "InternetMaxBandwidthOut",
+              "value": "5"
+            },
+            {
+              "key": "InstanceTypeFamily",
+              "value": "ecs.e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-mj7ctm2infbmnn6vq0ex"
+            },
+            {
+              "key": "Recyclable",
+              "value": "false"
+            },
+            {
+              "key": "ExpiredTime",
+              "value": "2099-12-31T15:59Z"
+            },
+            {
+              "key": "OSType",
+              "value": "linux"
+            },
+            {
+              "key": "Memory",
+              "value": "2048"
+            },
+            {
+              "key": "CreationTime",
+              "value": "2026-05-18T08:02Z"
+            },
+            {
+              "key": "KeyPairName",
+              "value": "tbd85ceuupr9ha6omvqisg"
+            },
+            {
+              "key": "LocalStorageCapacity",
+              "value": "0"
+            },
+            {
+              "key": "StoppedMode",
+              "value": "Not-applicable"
+            },
+            {
+              "key": "SpotStrategy",
+              "value": "NoSpot"
+            },
+            {
+              "key": "SpotDuration",
+              "value": "0"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "SecurityGroupIds",
+              "value": "{SecurityGroupId:[sg-mj75hai0hn9b26o6u0lu]}"
+            },
+            {
+              "key": "InnerIpAddress",
+              "value": "{IpAddress:[]}"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "{IpAddress:[47.80.240.250]}"
+            },
+            {
+              "key": "RdmaIpAddress",
+              "value": "{IpAddress:null}"
+            },
+            {
+              "key": "DedicatedHostAttribute",
+              "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+            },
+            {
+              "key": "EcsCapacityReservationAttr",
+              "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:1,CoreFactor:0,Numa:ON,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "DedicatedInstanceAttribute",
+              "value": "{Affinity:,Tenancy:}"
+            },
+            {
+              "key": "PrivateDnsNameOptions",
+              "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+            },
+            {
+              "key": "AdditionalInfo",
+              "value": "{EnableHighDensityMode:false}"
+            },
+            {
+              "key": "ImageOptions",
+              "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+            },
+            {
+              "key": "EipAddress",
+              "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+            },
+            {
+              "key": "VpcAttributes",
+              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.15]}}"
+            },
+            {
+              "key": "Tags",
+              "value": "{Tag:null}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:30,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7ctm2infbmnn6uucox,PrimaryIpAddress:10.0.1.15,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.15,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+            },
+            {
+              "key": "OperationLocks",
+              "value": "{LockReason:[]}"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd85cf1upr9ha6omvqj90",
+          "cspResourceName": "tbd85cf1upr9ha6omvqj90",
+          "cspResourceId": "i-mj70qfjkj53k1lfmwem5",
+          "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-05-18 08:02:47",
+          "label": {
+            "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.connectionName": "alibaba-ap-northeast-2",
+            "sys.createdTime": "2026-05-18 08:02:47",
+            "sys.cspResourceId": "i-mj70qfjkj53k1lfmwem5",
+            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj90",
+            "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.infraId": "my04-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.subnetId": "my04-subnet-01",
+            "sys.uid": "tbd85cf1upr9ha6omvqj90",
+            "sys.vNetId": "my04-vnet-01"
+          },
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "8.220.222.227",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.17",
+          "privateDNS": "",
+          "rootDiskType": "cloud_essd",
+          "rootDiskSize": 40,
+          "RootDeviceName": "/dev/xvda",
+          "connectionName": "alibaba-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "alibaba-ap-northeast-2",
+            "providerName": "alibaba",
+            "driverName": "alibaba-driver-v1.0.so",
+            "credentialName": "alibaba",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "alibaba-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "South Korea (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
+          "cspSpecName": "ecs.e-c1m4.large",
+          "spec": {
+            "cspSpecName": "ecs.e-c1m4.large",
+            "vCPU": 2,
+            "memoryGiB": 8,
+            "costPerHour": 0.0791
+          },
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Ubuntu  22.04 64 bit"
+          },
+          "vNetId": "my04-vnet-01",
+          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
+          "subnetId": "my04-subnet-01",
+          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+          "networkInterface": "eni-mj70qfjkj53k1lfk3g4v",
+          "securityGroupIds": [
+            "my04-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my04-sshkey-01",
+          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
+          "nodeUserName": "cb-user",
+          "nodeUserPassword": "1bc15$udf8pAt!",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjpJO+iCEU9UWWxdK8tLAyQm+wo3x/MrYpIbM/i6AEC/aXL7gIArd+gJWLDbG4U7beYUDeqNCYoNaQ84LkntQ4=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:CN3Vr5UeDqGvqf+08il0YBKW/Q92T5KR3JBAFnULA/I",
+            "firstUsedAt": "2026-05-18T08:02:56Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-05-18T08:02:55Z",
+              "completedTime": "2026-05-18T08:02:57Z",
+              "elapsedTime": 2,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "ImageId",
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
+            },
+            {
+              "key": "InstanceType",
+              "value": "ecs.e-c1m4.large"
+            },
+            {
+              "key": "DeviceAvailable",
+              "value": "true"
+            },
+            {
+              "key": "InstanceNetworkType",
+              "value": "vpc"
+            },
+            {
+              "key": "LocalStorageAmount",
+              "value": "0"
+            },
+            {
+              "key": "IsSpot",
+              "value": "false"
+            },
+            {
+              "key": "InstanceChargeType",
+              "value": "PostPaid"
+            },
+            {
+              "key": "InstanceName",
+              "value": "tbd85cf1upr9ha6omvqj90"
+            },
+            {
+              "key": "DeploymentSetGroupNo",
+              "value": "0"
+            },
+            {
+              "key": "GPUAmount",
+              "value": "0"
+            },
+            {
+              "key": "Connected",
+              "value": "false"
+            },
+            {
+              "key": "InvocationCount",
+              "value": "0"
+            },
+            {
+              "key": "StartTime",
+              "value": "2026-05-18T08:02Z"
+            },
+            {
+              "key": "ZoneId",
+              "value": "ap-northeast-2a"
+            },
+            {
+              "key": "InternetMaxBandwidthIn",
+              "value": "400"
+            },
+            {
+              "key": "InternetChargeType",
+              "value": "PayByBandwidth"
+            },
+            {
+              "key": "HostName",
+              "value": "iZmj70qfjkj53k1lfmwem5Z"
+            },
+            {
+              "key": "Status",
+              "value": "Running"
+            },
+            {
+              "key": "CPU",
+              "value": "0"
+            },
+            {
+              "key": "Cpu",
+              "value": "2"
+            },
+            {
+              "key": "SpotPriceLimit",
+              "value": "0.00"
+            },
+            {
+              "key": "OSName",
+              "value": "Ubuntu  22.04 64位"
+            },
+            {
+              "key": "InstanceOwnerId",
+              "value": "0"
+            },
+            {
+              "key": "OSNameEn",
+              "value": "Ubuntu  22.04 64 bit"
+            },
+            {
+              "key": "SerialNumber",
+              "value": "59a11a5d-1a8e-4b85-8c4f-4e84016912bd"
+            },
+            {
+              "key": "RegionId",
+              "value": "ap-northeast-2"
+            },
+            {
+              "key": "IoOptimized",
+              "value": "true"
+            },
+            {
+              "key": "InternetMaxBandwidthOut",
+              "value": "5"
+            },
+            {
+              "key": "InstanceTypeFamily",
+              "value": "ecs.e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-mj70qfjkj53k1lfmwem5"
+            },
+            {
+              "key": "Recyclable",
+              "value": "false"
+            },
+            {
+              "key": "ExpiredTime",
+              "value": "2099-12-31T15:59Z"
+            },
+            {
+              "key": "OSType",
+              "value": "linux"
+            },
+            {
+              "key": "Memory",
+              "value": "8192"
+            },
+            {
+              "key": "CreationTime",
+              "value": "2026-05-18T08:02Z"
+            },
+            {
+              "key": "KeyPairName",
+              "value": "tbd85ceuupr9ha6omvqisg"
+            },
+            {
+              "key": "LocalStorageCapacity",
+              "value": "0"
+            },
+            {
+              "key": "StoppedMode",
+              "value": "Not-applicable"
+            },
+            {
+              "key": "SpotStrategy",
+              "value": "NoSpot"
+            },
+            {
+              "key": "SpotDuration",
+              "value": "0"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "SecurityGroupIds",
+              "value": "{SecurityGroupId:[sg-mj78vtpurhkjrhyd2zt7]}"
+            },
+            {
+              "key": "InnerIpAddress",
+              "value": "{IpAddress:[]}"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "{IpAddress:[8.220.222.227]}"
+            },
+            {
+              "key": "RdmaIpAddress",
+              "value": "{IpAddress:null}"
+            },
+            {
+              "key": "DedicatedHostAttribute",
+              "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+            },
+            {
+              "key": "EcsCapacityReservationAttr",
+              "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:1,CoreFactor:0,Numa:ON,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "DedicatedInstanceAttribute",
+              "value": "{Affinity:,Tenancy:}"
+            },
+            {
+              "key": "PrivateDnsNameOptions",
+              "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+            },
+            {
+              "key": "AdditionalInfo",
+              "value": "{EnableHighDensityMode:false}"
+            },
+            {
+              "key": "ImageOptions",
+              "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+            },
+            {
+              "key": "EipAddress",
+              "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+            },
+            {
+              "key": "VpcAttributes",
+              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.17]}}"
+            },
+            {
+              "key": "Tags",
+              "value": "{Tag:null}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:32,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70qfjkj53k1lfk3g4v,PrimaryIpAddress:10.0.1.17,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.17,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+            },
+            {
+              "key": "OperationLocks",
+              "value": "{LockReason:[]}"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbd85cf1upr9ha6omvqj80",
+          "cspResourceName": "tbd85cf1upr9ha6omvqj80",
+          "cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
+          "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-05-18 08:02:47",
+          "label": {
+            "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.connectionName": "alibaba-ap-northeast-2",
+            "sys.createdTime": "2026-05-18 08:02:47",
+            "sys.cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
+            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj80",
+            "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.infraId": "my04-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.subnetId": "my04-subnet-01",
+            "sys.uid": "tbd85cf1upr9ha6omvqj80",
+            "sys.vNetId": "my04-vnet-01"
+          },
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "47.80.57.53",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.16",
+          "privateDNS": "",
+          "rootDiskType": "cloud_essd",
+          "rootDiskSize": 40,
+          "RootDeviceName": "/dev/xvda",
+          "connectionName": "alibaba-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "alibaba-ap-northeast-2",
+            "providerName": "alibaba",
+            "driverName": "alibaba-driver-v1.0.so",
+            "credentialName": "alibaba",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "alibaba-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "South Korea (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
+          "cspSpecName": "ecs.e-c1m4.xlarge",
+          "spec": {
+            "cspSpecName": "ecs.e-c1m4.xlarge",
+            "vCPU": 4,
+            "memoryGiB": 16,
+            "costPerHour": 0.1582
+          },
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Ubuntu  22.04 64 bit"
+          },
+          "vNetId": "my04-vnet-01",
+          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
+          "subnetId": "my04-subnet-01",
+          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
+          "networkInterface": "eni-mj7bmodw2wgq13tslyzg",
+          "securityGroupIds": [
+            "my04-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my04-sshkey-01",
+          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
+          "nodeUserName": "cb-user",
+          "nodeUserPassword": "$dA5bucp!f1t81",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIoOQ2gvfcNkTlNvuqkusRt8H2qhBA89swB2tyZNTyPQI6IG5Rq30BzABy4uD/mVN5T1FFu4vaI+o5kEgApc87Q=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:Y6GQw48WwR78o9JdeZKtnxMOFr9e5MIESK+ZhUdpvPM",
+            "firstUsedAt": "2026-05-18T08:02:55Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-05-18T08:02:55Z",
+              "completedTime": "2026-05-18T08:02:56Z",
+              "elapsedTime": 1,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "ImageId",
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
+            },
+            {
+              "key": "InstanceType",
+              "value": "ecs.e-c1m4.xlarge"
+            },
+            {
+              "key": "DeviceAvailable",
+              "value": "true"
+            },
+            {
+              "key": "InstanceNetworkType",
+              "value": "vpc"
+            },
+            {
+              "key": "LocalStorageAmount",
+              "value": "0"
+            },
+            {
+              "key": "IsSpot",
+              "value": "false"
+            },
+            {
+              "key": "InstanceChargeType",
+              "value": "PostPaid"
+            },
+            {
+              "key": "InstanceName",
+              "value": "tbd85cf1upr9ha6omvqj80"
+            },
+            {
+              "key": "DeploymentSetGroupNo",
+              "value": "0"
+            },
+            {
+              "key": "GPUAmount",
+              "value": "0"
+            },
+            {
+              "key": "Connected",
+              "value": "false"
+            },
+            {
+              "key": "InvocationCount",
+              "value": "0"
+            },
+            {
+              "key": "StartTime",
+              "value": "2026-05-18T08:02Z"
+            },
+            {
+              "key": "ZoneId",
+              "value": "ap-northeast-2a"
+            },
+            {
+              "key": "InternetMaxBandwidthIn",
+              "value": "800"
+            },
+            {
+              "key": "InternetChargeType",
+              "value": "PayByBandwidth"
+            },
+            {
+              "key": "HostName",
+              "value": "iZmj7bmodw2wgq13tm2g8jZ"
+            },
+            {
+              "key": "Status",
+              "value": "Running"
+            },
+            {
+              "key": "CPU",
+              "value": "0"
+            },
+            {
+              "key": "Cpu",
+              "value": "4"
+            },
+            {
+              "key": "SpotPriceLimit",
+              "value": "0.00"
+            },
+            {
+              "key": "OSName",
+              "value": "Ubuntu  22.04 64位"
+            },
+            {
+              "key": "InstanceOwnerId",
+              "value": "0"
+            },
+            {
+              "key": "OSNameEn",
+              "value": "Ubuntu  22.04 64 bit"
+            },
+            {
+              "key": "SerialNumber",
+              "value": "3e72e546-fbd2-4921-a2ff-d588c6c712fc"
+            },
+            {
+              "key": "RegionId",
+              "value": "ap-northeast-2"
+            },
+            {
+              "key": "IoOptimized",
+              "value": "true"
+            },
+            {
+              "key": "InternetMaxBandwidthOut",
+              "value": "5"
+            },
+            {
+              "key": "InstanceTypeFamily",
+              "value": "ecs.e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-mj7bmodw2wgq13tm2g8j"
+            },
+            {
+              "key": "Recyclable",
+              "value": "false"
+            },
+            {
+              "key": "ExpiredTime",
+              "value": "2099-12-31T15:59Z"
+            },
+            {
+              "key": "OSType",
+              "value": "linux"
+            },
+            {
+              "key": "Memory",
+              "value": "16384"
+            },
+            {
+              "key": "CreationTime",
+              "value": "2026-05-18T08:02Z"
+            },
+            {
+              "key": "KeyPairName",
+              "value": "tbd85ceuupr9ha6omvqisg"
+            },
+            {
+              "key": "LocalStorageCapacity",
+              "value": "0"
+            },
+            {
+              "key": "StoppedMode",
+              "value": "Not-applicable"
+            },
+            {
+              "key": "SpotStrategy",
+              "value": "NoSpot"
+            },
+            {
+              "key": "SpotDuration",
+              "value": "0"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "SecurityGroupIds",
+              "value": "{SecurityGroupId:[sg-mj71whg4s0wud8qlexce]}"
+            },
+            {
+              "key": "InnerIpAddress",
+              "value": "{IpAddress:[]}"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "{IpAddress:[47.80.57.53]}"
+            },
+            {
+              "key": "RdmaIpAddress",
+              "value": "{IpAddress:null}"
+            },
+            {
+              "key": "DedicatedHostAttribute",
+              "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+            },
+            {
+              "key": "EcsCapacityReservationAttr",
+              "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:2,CoreFactor:0,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "DedicatedInstanceAttribute",
+              "value": "{Affinity:,Tenancy:}"
+            },
+            {
+              "key": "PrivateDnsNameOptions",
+              "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+            },
+            {
+              "key": "AdditionalInfo",
+              "value": "{EnableHighDensityMode:false}"
+            },
+            {
+              "key": "ImageOptions",
+              "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+            },
+            {
+              "key": "EipAddress",
+              "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+            },
+            {
+              "key": "VpcAttributes",
+              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.16]}}"
+            },
+            {
+              "key": "Tags",
+              "value": "{Tag:null}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:31,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq13tslyzg,PrimaryIpAddress:10.0.1.16,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.16,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+            },
+            {
+              "key": "OperationLocks",
+              "value": "{LockReason:[]}"
+            }
+          ]
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": [
+          {
+            "infraId": "my04-infra101",
+            "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "47.80.57.53",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my04-infra101",
+            "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "47.80.240.250",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my04-infra101",
+            "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "8.220.222.227",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6888,7 +8098,8 @@
 {
   "idList": [
     "my01-infra101",
-    "my02-infra101"
+    "my02-infra101",
+    "my04-infra101"
   ]
 }
 ```
@@ -6917,7 +8128,7 @@
 {
   "resourceType": "infra",
   "id": "my02-infra101",
-  "uid": "tbd81fd366aji65qtg7s9g",
+  "uid": "tbd85cf3epr9ha6omvqjbg",
   "name": "my02-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -6945,7 +8156,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my02-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd81fd366aji65qtg7s9g"
+    "sys.uid": "tbd85cf3epr9ha6omvqjbg"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -6954,9 +8165,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd81fd3e6aji65qtg7sag",
-      "cspResourceName": "tbd81fd3e6aji65qtg7sag",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag",
+      "uid": "tbd85cf3epr9ha6omvqjcg",
+      "cspResourceName": "tbd85cf3epr9ha6omvqjcg",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
       "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -6970,16 +8181,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:45:45",
+      "createdTime": "2026-05-18 08:03:14",
       "label": {
-        "createdBy": "tbd81fd3e6aji65qtg7sag",
-        "keypair": "tbd81fcu66aji65qtg7s7g",
-        "publicip": "tbd81fd3e6aji65qtg7sag-6948-PublicIP",
+        "createdBy": "tbd85cf3epr9ha6omvqjcg",
+        "keypair": "tbd85cf06pr9ha6omvqj3g",
+        "publicip": "tbd85cf3epr9ha6omvqjcg-42454-PublicIP",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-12 09:45:45",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag",
-        "sys.cspResourceName": "tbd81fd3e6aji65qtg7sag",
+        "sys.createdTime": "2026-05-18 08:03:14",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
+        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjcg",
         "sys.id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -6988,20 +8199,20 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd81fd3e6aji65qtg7sag",
+        "sys.uid": "tbd85cf3epr9ha6omvqjcg",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "20.214.4.247",
+      "publicIP": "20.214.25.229",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.5",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
-      "rootDiskSize": 50,
+      "rootDiskSize": 30,
       "RootDeviceName": "Not visible in Azure",
       "connectionName": "azure-koreasouth",
       "connectionConfig": {
@@ -7037,32 +8248,32 @@
         "memoryGiB": 3.90625,
         "costPerHour": 0.0432
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-      "networkInterface": "tbd81fd3e6aji65qtg7sag-97625-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+      "networkInterface": "tbd85cf3epr9ha6omvqjcg-39198-VNic",
       "securityGroupIds": [
         "my02-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOlhZnTKot5CpvRf0YzyGcCOMZuXeAMAgdZPJBjMssWEV3mgDw0DIAaZL1vj8YsjarGo8/mGHmt0/jtU0XI2DU0=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL0VTwP0mj+c6VjV8msgi3Q9eibNRewPMT54DUhTIpAg1Sht7ha22G1ufqkYptq1cFE80rR711dScHPLLhmJ+q8=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:NLSKcyS77IrfjQOPBXWdHjfqLW8dVJipgwWxHgZQYe0",
-        "firstUsedAt": "2026-05-12T09:45:55Z"
+        "fingerprint": "SHA256:L+I1/Qhho+5MTJJQUC536mZqODIvIydVP6vJjVbdai0",
+        "firstUsedAt": "2026-05-18T08:03:23Z"
       },
       "commandStatus": [
         {
@@ -7070,11 +8281,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:45:55Z",
-          "completedTime": "2026-05-12T09:45:59Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-05-18T08:03:23Z",
+          "completedTime": "2026-05-18T08:03:26Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fd3e6aji65qtg7sag 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -7085,11 +8296,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7sag-97625-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7sag,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7sag_OsDisk_1_8475ebb7b2fc4065a10ea9965259015e,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7sag_OsDisk_1_8475ebb7b2fc4065a10ea9965259015e,osType:Linux}},timeCreated:2026-05-12T09:44:53.6437916Z,vmId:1b543ee0-8c3c-44e9-9d8b-573c0e3fc6c9}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjcg-39198-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjcg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,osType:Linux}},timeCreated:2026-05-18T08:02:26.9394222Z,vmId:66b1ceb1-9da8-497a-ab77-8e1d40b4f26c}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd81fd3e6aji65qtg7sag,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7sag-6948-PublicIP}"
+          "value": "{createdBy:tbd85cf3epr9ha6omvqjcg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjcg-42454-PublicIP}"
         },
         {
           "key": "Etag",
@@ -7097,11 +8308,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg"
         },
         {
           "key": "Name",
-          "value": "tbd81fd3e6aji65qtg7sag"
+          "value": "tbd85cf3epr9ha6omvqjcg"
         },
         {
           "key": "Type",
@@ -7112,9 +8323,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd81fd3e6aji65qtg7scg",
-      "cspResourceName": "tbd81fd3e6aji65qtg7scg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg",
+      "uid": "tbd85cf3epr9ha6omvqjeg",
+      "cspResourceName": "tbd85cf3epr9ha6omvqjeg",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
       "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -7128,16 +8339,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:45:48",
+      "createdTime": "2026-05-18 08:03:17",
       "label": {
-        "createdBy": "tbd81fd3e6aji65qtg7scg",
-        "keypair": "tbd81fcu66aji65qtg7s7g",
-        "publicip": "tbd81fd3e6aji65qtg7scg-43856-PublicIP",
+        "createdBy": "tbd85cf3epr9ha6omvqjeg",
+        "keypair": "tbd85cf06pr9ha6omvqj3g",
+        "publicip": "tbd85cf3epr9ha6omvqjeg-83151-PublicIP",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-12 09:45:48",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg",
-        "sys.cspResourceName": "tbd81fd3e6aji65qtg7scg",
+        "sys.createdTime": "2026-05-18 08:03:17",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
+        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjeg",
         "sys.id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -7146,20 +8357,20 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd81fd3e6aji65qtg7scg",
+        "sys.uid": "tbd85cf3epr9ha6omvqjeg",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "52.231.199.161",
+      "publicIP": "20.214.26.6",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.6",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
-      "rootDiskSize": 50,
+      "rootDiskSize": 30,
       "RootDeviceName": "Not visible in Azure",
       "connectionName": "azure-koreasouth",
       "connectionConfig": {
@@ -7196,7 +8407,7 @@
         "costPerHour": 0.0865
       },
       "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
       "image": {
         "resourceType": "image",
         "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
@@ -7205,22 +8416,22 @@
         "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-      "networkInterface": "tbd81fd3e6aji65qtg7scg-38274-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+      "networkInterface": "tbd85cf3epr9ha6omvqjeg-47871-VNic",
       "securityGroupIds": [
         "my02-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGNC3nphY/v0+xM4rigF6rS6/BryTA6wUKcYifFO+GrlgOg05dR7/deJP4WKbiryKR++SIuzGvpIHF7XfWkCxbs=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEjxGVDmlxPviCew7MPsxQCg/SbRH0g1LPINkzdzqnLKnu1r1BVcN2sOxPrrm4d3ektW4i1wjM5H3IyYVNdYIXM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:Y2gaNklAb4QHPPMwKNRhTABm2kr7c8p0/zvEwSdvNKU",
-        "firstUsedAt": "2026-05-12T09:45:58Z"
+        "fingerprint": "SHA256:kXaggWkouCHVkByZEeZ7WbredHOydMu4PhHCk95sdGA",
+        "firstUsedAt": "2026-05-18T08:03:25Z"
       },
       "commandStatus": [
         {
@@ -7228,11 +8439,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:45:55Z",
-          "completedTime": "2026-05-12T09:46:00Z",
-          "elapsedTime": 5,
+          "startedTime": "2026-05-18T08:03:23Z",
+          "completedTime": "2026-05-18T08:03:27Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fd3e6aji65qtg7scg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -7243,11 +8454,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7scg-38274-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7scg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7scg_OsDisk_1_9fca1cfb0b9a4d3ead6e5403bc3b9dac,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7scg_OsDisk_1_9fca1cfb0b9a4d3ead6e5403bc3b9dac,osType:Linux}},timeCreated:2026-05-12T09:44:57.9968299Z,vmId:5e905251-d043-46c4-814e-489b8c8fe657}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjeg-47871-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjeg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,osType:Linux}},timeCreated:2026-05-18T08:02:28.9784295Z,vmId:85838c4c-38c3-4641-9333-9b5b9ab4769a}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd81fd3e6aji65qtg7scg,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7scg-43856-PublicIP}"
+          "value": "{createdBy:tbd85cf3epr9ha6omvqjeg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjeg-83151-PublicIP}"
         },
         {
           "key": "Etag",
@@ -7255,11 +8466,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg"
         },
         {
           "key": "Name",
-          "value": "tbd81fd3e6aji65qtg7scg"
+          "value": "tbd85cf3epr9ha6omvqjeg"
         },
         {
           "key": "Type",
@@ -7270,9 +8481,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd81fd3e6aji65qtg7sbg",
-      "cspResourceName": "tbd81fd3e6aji65qtg7sbg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg",
+      "uid": "tbd85cf3epr9ha6omvqjdg",
+      "cspResourceName": "tbd85cf3epr9ha6omvqjdg",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
       "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -7286,16 +8497,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:45:47",
+      "createdTime": "2026-05-18 08:03:15",
       "label": {
-        "createdBy": "tbd81fd3e6aji65qtg7sbg",
-        "keypair": "tbd81fcu66aji65qtg7s7g",
-        "publicip": "tbd81fd3e6aji65qtg7sbg-88014-PublicIP",
+        "createdBy": "tbd85cf3epr9ha6omvqjdg",
+        "keypair": "tbd85cf06pr9ha6omvqj3g",
+        "publicip": "tbd85cf3epr9ha6omvqjdg-86268-PublicIP",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-12 09:45:47",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg",
-        "sys.cspResourceName": "tbd81fd3e6aji65qtg7sbg",
+        "sys.createdTime": "2026-05-18 08:03:15",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
+        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjdg",
         "sys.id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -7304,20 +8515,20 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd81fd3e6aji65qtg7sbg",
+        "sys.uid": "tbd85cf3epr9ha6omvqjdg",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "52.231.199.157",
+      "publicIP": "52.231.195.68",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.5",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
-      "rootDiskSize": 50,
+      "rootDiskSize": 30,
       "RootDeviceName": "Not visible in Azure",
       "connectionName": "azure-koreasouth",
       "connectionConfig": {
@@ -7353,32 +8564,32 @@
         "memoryGiB": 15.625,
         "costPerHour": 0.173
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0",
-      "networkInterface": "tbd81fd3e6aji65qtg7sbg-96100-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
+      "networkInterface": "tbd85cf3epr9ha6omvqjdg-3065-VNic",
       "securityGroupIds": [
         "my02-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAN6J4eynmqAFw1iIOLTlcDd2Nj3VXVk/ntLQad0HFdZmLHM1XlpHkgbQBQ0ZbT7WdXlCNwjQFUTJUz2Peu6tt8=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTNwiwA06iMy3QoeSkT4pJXpOsH22Jn6+LnZ+ak239UDz03i5xCcIOmCYDASX7JMLHv1NfehWWjviZjXQOCm0A=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:oURuT7phD9rhemFegoCfIhW9JIwJd97nUZcaLxVND60",
-        "firstUsedAt": "2026-05-12T09:45:58Z"
+        "fingerprint": "SHA256:zSgb3/NtuvOcCa3S2XoWo/Kj3Tpb4B15i3wLbr896JA",
+        "firstUsedAt": "2026-05-18T08:03:25Z"
       },
       "commandStatus": [
         {
@@ -7386,11 +8597,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:45:55Z",
-          "completedTime": "2026-05-12T09:46:00Z",
+          "startedTime": "2026-05-18T08:03:23Z",
+          "completedTime": "2026-05-18T08:03:28Z",
           "elapsedTime": 5,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fd3e6aji65qtg7sbg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -7401,11 +8612,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd81fd3e6aji65qtg7sbg-96100-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd81fd3e6aji65qtg7sbg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUkSh+Hm49mSp1aeExqrCuh1wK6S64rPm4ONnlNHe088Sxf6kcgqyR5b+poXYPT2iUjyQBqWdiIqhHCd1iTxz0h0y92l8DmRS00ez9QV6IB3CV1ZKiBdP3s2S5btgEEDIVbnzmKoMg9yU67MtZE3ER9ePK4HzT/Ps0DNMbsyseEILG7q1kGauxvySBoaHb7x+Dai/879pIFLN2tHfYzakdAsnze1iH1NEzbnx+cfJb+X0q2EWU0cnjGJpGxCOsJ2jq4UuS7/mSBxQzPxZE0a34pBf3d6Jut8lrS/NMiWSrnAIX6ZHrYOrx1aJhbdkp2OXaYZyIrxUtlHxS75UlNjPAkTmVBrpySw5oeiRq6Y6Qxj7+tfQ+xrOQr2NtTqlKcYo+bfvYo81P0s0q8+Z9h4a06U+I+lqLvQ8zPbCpqeI2r+49moYdQK3lok2PhbkIDXoBp+NacfhIKQMJW0VZ74kdmolI9edR9ZlTyWvXMIM4jA4WSuDhGU0FDaGJzJzRAHwXj0EZNy37R+M9v54rYdcaZzqmnoFwQ+6hPF3FD4anG1yhI5Z+gIvs3aZ64HEeKrNOZEXR1pLmg17N8o2QNZyKenjm0LPIPpfYxRhJEzYoVte4ZiVqbJj+MSoNd7ReAYhesL8iSUFw85QyDZdq5O1tQokGL4RqU2/nV7fhpiSPcw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202604160,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202604160},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:50,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd81fd3e6aji65qtg7sbg_OsDisk_1_aef0e02e4b6a4ebca659642181e7ee12,storageAccountType:Premium_LRS},name:tbd81fd3e6aji65qtg7sbg_OsDisk_1_aef0e02e4b6a4ebca659642181e7ee12,osType:Linux}},timeCreated:2026-05-12T09:44:57.0636694Z,vmId:7f4cdcdf-b136-45ae-8898-b261faa81b51}"
+          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjdg-3065-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjdg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,osType:Linux}},timeCreated:2026-05-18T08:02:27.2996702Z,vmId:9f82564d-bc46-434c-955e-4e8a0c6ad147}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd81fd3e6aji65qtg7sbg,keypair:tbd81fcu66aji65qtg7s7g,publicip:tbd81fd3e6aji65qtg7sbg-88014-PublicIP}"
+          "value": "{createdBy:tbd85cf3epr9ha6omvqjdg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjdg-86268-PublicIP}"
         },
         {
           "key": "Etag",
@@ -7413,11 +8624,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg"
         },
         {
           "key": "Name",
-          "value": "tbd81fd3e6aji65qtg7sbg"
+          "value": "tbd85cf3epr9ha6omvqjdg"
         },
         {
           "key": "Type",
@@ -7438,12 +8649,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "20.214.4.247",
+        "nodeIp": "20.214.25.229",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fd3e6aji65qtg7sag 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7453,12 +8664,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "52.231.199.161",
+        "nodeIp": "20.214.26.6",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fd3e6aji65qtg7scg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7468,12 +8679,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "52.231.199.157",
+        "nodeIp": "52.231.195.68",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fd3e6aji65qtg7sbg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7531,8 +8742,8 @@
       "command": "uname -a",
       "nodeGroup": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux tbd81fd3e6aji65qtg7sag 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "20.214.4.247",
+      "output": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "20.214.25.229",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -7543,8 +8754,8 @@
       "command": "uname -a",
       "nodeGroup": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux tbd81fd3e6aji65qtg7scg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "52.231.199.161",
+      "output": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "20.214.26.6",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -7555,8 +8766,8 @@
       "command": "uname -a",
       "nodeGroup": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux tbd81fd3e6aji65qtg7sbg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "52.231.199.157",
+      "output": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "52.231.195.68",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -7586,7 +8797,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-12 09:46:42
+**Generated At:** 2026-05-18 08:04:01
 
 **Namespace:** mig01
 
@@ -7614,24 +8825,24 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| Standard_B4as_v2 | 4 | 15.6 | - | x86_64 |  | $0.1730 | 1 |
 | Standard_B2als_v2 | 2 | 3.9 | - | x86_64 |  | $0.0432 | 1 |
 | Standard_B2as_v2 | 2 | 7.8 | - | x86_64 |  | $0.0865 | 1 |
-| Standard_B4as_v2 | 4 | 15.6 | - | x86_64 |  | $0.1730 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 2 |
+| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.4.247<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.199.161<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.199.157<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.25.229<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.26.6<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.195.68<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
 
 
 ## Network Resources
@@ -7643,7 +8854,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-vnet-01 |
-| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug |
+| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | azure-koreasouth |
 | **Subnet Count** | 1 |
@@ -7652,7 +8863,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0 | 10.0.1.0/24 |  |
+| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -7661,7 +8872,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g |  |  |
+| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  |  |
 
 ### Security Groups
 
@@ -7670,7 +8881,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-01 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fcvm6aji65qtg7s80 |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -7698,7 +8909,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-02 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd0u6aji65qtg7s8g |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7731,7 +8942,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-03 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd1u6aji65qtg7s90 |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7806,7 +9017,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-12 09:46:48*
+*Report generated: 2026-05-18 08:04:07*
 
 ---
 
@@ -7835,7 +9046,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B4as_v2, Standard_B2als_v2, Standard_B2as_v2 |
+| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B2as_v2, Standard_B4as_v2, Standard_B2als_v2 |
 | 3 | **VM OS Image** | 2 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my02-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my02-vnet-01) |
@@ -7850,9 +9061,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sag<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7scg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd81fd3e6aji65qtg7sbg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7874,9 +9085,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 | 2 | my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -7886,7 +9097,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-01
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fcvm6aji65qtg7s80 | **VNet:** my02-vnet-01 | **Rules:** 14
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g | **VNet:** my02-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7914,7 +9125,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-02
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd0u6aji65qtg7s8g | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7947,7 +9158,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-03
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd81fd1u6aji65qtg7s90 | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7988,13 +9199,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug | 10.0.0.0/21 |
+| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd81fcrm6aji65qtg7rug/subnets/tbd81fcrm6aji65qtg7rv0 | 10.0.1.0/24 | my02-vnet-01 |
+| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 | my02-vnet-01 |
 
 ### Source Network Information
 
@@ -8036,7 +9247,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd81fcu66aji65qtg7s7g |  | Used by all 3 VMs |
+| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-gcp.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-gcp.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5
+- CM-Beetle: imdl/v0.1.5+ (c574040)
 - cm-model: unknown
 - CB-Tumblebug: vunknown
 - CB-Spider: vunknown
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 12, 2026
-- Test Time: 18:43:59 KST
-- Test Execution: 2026-05-12 18:43:59 KST
+- Test Date: May 18, 2026
+- Test Time: 17:01:39 KST
+- Test Execution: 2026-05-18 17:01:39 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 1.665s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 6m30.826s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 36ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 13ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 14.596s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 7m1.616s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 26ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 5ms | Pass |
 | 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 21ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 6.133s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.295s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 6m49.606s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.257s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.286s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 7m18.663s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 14m45.307808128s
+**Total Duration**: 15m57.052183758s
 
-*Test executed on May 12, 2026 at 18:43:59 KST (2026-05-12 18:43:59 KST) using CM-Beetle automated test CLI*
+*Test executed on May 18, 2026 at 17:01:39 KST (2026-05-18 17:01:39 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1974,7 +1974,7 @@
               "sg-01"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -1993,7 +1993,7 @@
               "sg-02"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -2012,7 +2012,7 @@
               "sg-03"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           }
         ],
@@ -2780,7 +2780,7 @@
               "sg-01"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -2799,7 +2799,7 @@
               "sg-02"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           },
           {
@@ -2818,7 +2818,7 @@
               "sg-03"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskSize": 50,
+            "rootDiskSize": 10,
             "dataDiskIds": null
           }
         ],
@@ -3840,7 +3840,7 @@
 {
   "resourceType": "infra",
   "id": "my03-infra101",
-  "uid": "tbd81ffbe6aji65qtg7sng",
+  "uid": "tbd85chgupr9ha6omvqjqg",
   "name": "my03-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -3868,7 +3868,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my03-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd81ffbe6aji65qtg7sng"
+    "sys.uid": "tbd85chgupr9ha6omvqjqg"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -3877,9 +3877,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd81ffbm6aji65qtg7sog",
-      "cspResourceName": "tbd81ffbm6aji65qtg7sog",
-      "cspResourceId": "tbd81ffbm6aji65qtg7sog",
+      "uid": "tbd85chgupr9ha6omvqjrg",
+      "cspResourceName": "tbd85chgupr9ha6omvqjrg",
+      "cspResourceId": "tbd85chgupr9ha6omvqjrg",
       "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -3893,14 +3893,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:21",
+      "createdTime": "2026-05-18 08:08:17",
       "label": {
-        "keypair": "tbd81fd466aji65qtg7sfg",
+        "keypair": "tbd85cf76pr9ha6omvqjgg",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-12 09:50:21",
-        "sys.cspResourceId": "tbd81ffbm6aji65qtg7sog",
-        "sys.cspResourceName": "tbd81ffbm6aji65qtg7sog",
+        "sys.createdTime": "2026-05-18 08:08:17",
+        "sys.cspResourceId": "tbd85chgupr9ha6omvqjrg",
+        "sys.cspResourceName": "tbd85chgupr9ha6omvqjrg",
         "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -3909,7 +3909,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd81ffbm6aji65qtg7sog",
+        "sys.uid": "tbd85chgupr9ha6omvqjrg",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -3917,13 +3917,13 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.158.204.63",
+      "publicIP": "34.47.88.87",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.2",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "persistent-disk-0",
       "connectionName": "gcp-asia-northeast3",
       "connectionConfig": {
@@ -3973,22 +3973,22 @@
         "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+      "cspVNetId": "tbd85cevepr9ha6omvqj20",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDWs1O67lTqjywhyfSy0DUdVXjKbOCkG2p+cNK0kF3Advcia+KV9kocOB0cYy3lgsP7ab6KX69IQiCQSz6gxnVg=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBTyrjHSxt6qZWbQxMqqRCjxDmjtrH2Dnopziy9PbQzxGqw76v+iZm/EYFqx+pxvqaTUNBU++J92lq0WuBr7i68=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:ydA9WCTdI4uR0AvkDzBhqUY7arK9CdwHq1KBOsfkJvk",
-        "firstUsedAt": "2026-05-12T09:50:38Z"
+        "fingerprint": "SHA256:Epg/2q2Z05YyN084hOeTw4hNiR7NjcMSq43lf/yocK4",
+        "firstUsedAt": "2026-05-18T08:08:32Z"
       },
       "commandStatus": [
         {
@@ -3996,11 +3996,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:50:38Z",
-          "completedTime": "2026-05-12T09:50:41Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-05-18T08:08:29Z",
+          "completedTime": "2026-05-18T08:08:33Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4015,7 +4015,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-12T02:49:40.967-07:00"
+          "value": "2026-05-18T01:07:34.217-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -4027,15 +4027,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sog,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjrg,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "Ze1M2KRQWjk="
+          "value": "9VP4LLWbIfc="
         },
         {
           "key": "Id",
-          "value": "1593969242543180123"
+          "value": "485614543392175657"
         },
         {
           "key": "Kind",
@@ -4043,15 +4043,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "iFKnnqnIM2k="
+          "value": "K4XUyTdV-uk="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-12T02:49:48.192-07:00"
+          "value": "2026-05-18T01:07:42.548-07:00"
         },
         {
           "key": "MachineType",
@@ -4059,15 +4059,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd81ffbm6aji65qtg7sog"
+          "value": "tbd85chgupr9ha6omvqjrg"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.204.63,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:sB9z5QTR24w=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.47.88.87,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:ihh_BNv7Hgc=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
         },
         {
           "key": "ResourceStatus",
@@ -4087,7 +4087,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sog"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjrg"
         },
         {
           "key": "ServiceAccounts",
@@ -4111,7 +4111,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:wF4QnTxJsgg=,items:[tbd81fd466aji65qtg7sg0]}"
+          "value": "{fingerprint:VTjLFnAOyhg=,items:[tbd85cf7epr9ha6omvqjh0]}"
         },
         {
           "key": "Zone",
@@ -4122,9 +4122,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd81ffbm6aji65qtg7sqg",
-      "cspResourceName": "tbd81ffbm6aji65qtg7sqg",
-      "cspResourceId": "tbd81ffbm6aji65qtg7sqg",
+      "uid": "tbd85chgupr9ha6omvqjtg",
+      "cspResourceName": "tbd85chgupr9ha6omvqjtg",
+      "cspResourceId": "tbd85chgupr9ha6omvqjtg",
       "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -4138,14 +4138,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:23",
+      "createdTime": "2026-05-18 08:08:19",
       "label": {
-        "keypair": "tbd81fd466aji65qtg7sfg",
+        "keypair": "tbd85cf76pr9ha6omvqjgg",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-12 09:50:23",
-        "sys.cspResourceId": "tbd81ffbm6aji65qtg7sqg",
-        "sys.cspResourceName": "tbd81ffbm6aji65qtg7sqg",
+        "sys.createdTime": "2026-05-18 08:08:19",
+        "sys.cspResourceId": "tbd85chgupr9ha6omvqjtg",
+        "sys.cspResourceName": "tbd85chgupr9ha6omvqjtg",
         "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -4154,7 +4154,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd81ffbm6aji65qtg7sqg",
+        "sys.uid": "tbd85chgupr9ha6omvqjtg",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -4162,13 +4162,13 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.50.35.103",
+      "publicIP": "34.64.234.91",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "persistent-disk-0",
       "connectionName": "gcp-asia-northeast3",
       "connectionConfig": {
@@ -4218,22 +4218,22 @@
         "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+      "cspVNetId": "tbd85cevepr9ha6omvqj20",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMrtQtDUiUdG1oCzNSF23wNYT9yks/U+HQFM4H8KtWmOJGvHechJow2MM8+ls8Mj14sRKYWxH0DNMkkqnSjkCuA=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGvD1KU1+ZJdf79GZ9H34PziLBJYb01WxzgNS5tWz0GeOpGg8L88IGpPqPfqdXKb5bROJbby0KOvfhdVCVUmLQM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:ojW1rp6jU49KfmomGDmh3nQeYrjbF3VL5yVCcZ+c6e4",
-        "firstUsedAt": "2026-05-12T09:50:40Z"
+        "fingerprint": "SHA256:DYAWOOMoPbZPyNgE6XOiqkS7jz5oAKe042rekh/h+a0",
+        "firstUsedAt": "2026-05-18T08:08:29Z"
       },
       "commandStatus": [
         {
@@ -4241,11 +4241,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:50:38Z",
-          "completedTime": "2026-05-12T09:50:42Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-05-18T08:08:29Z",
+          "completedTime": "2026-05-18T08:08:32Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4260,7 +4260,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-12T02:49:42.582-07:00"
+          "value": "2026-05-18T01:07:35.886-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -4272,15 +4272,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sqg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjtg,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "RwAIYtShgo4="
+          "value": "DWOIQhWVgNc="
         },
         {
           "key": "Id",
-          "value": "7260017217573439834"
+          "value": "1272312304157292072"
         },
         {
           "key": "Kind",
@@ -4288,15 +4288,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "iFKnnqnIM2k="
+          "value": "K4XUyTdV-uk="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-12T02:49:49.584-07:00"
+          "value": "2026-05-18T01:07:42.684-07:00"
         },
         {
           "key": "MachineType",
@@ -4304,15 +4304,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd81ffbm6aji65qtg7sqg"
+          "value": "tbd85chgupr9ha6omvqjtg"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.50.35.103,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lFDLiG6yO5c=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.234.91,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:eL5WeVK8vho=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
         },
         {
           "key": "ResourceStatus",
@@ -4332,7 +4332,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sqg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjtg"
         },
         {
           "key": "ServiceAccounts",
@@ -4356,7 +4356,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:__A_yY_oPbY=,items:[tbd81feh66aji65qtg7sn0]}"
+          "value": "{fingerprint:AiAynOHHwpk=,items:[tbd85cgkmpr9ha6omvqjkg]}"
         },
         {
           "key": "Zone",
@@ -4367,9 +4367,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd81ffbm6aji65qtg7spg",
-      "cspResourceName": "tbd81ffbm6aji65qtg7spg",
-      "cspResourceId": "tbd81ffbm6aji65qtg7spg",
+      "uid": "tbd85chgupr9ha6omvqjsg",
+      "cspResourceName": "tbd85chgupr9ha6omvqjsg",
+      "cspResourceId": "tbd85chgupr9ha6omvqjsg",
       "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4383,14 +4383,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:29",
+      "createdTime": "2026-05-18 08:08:17",
       "label": {
-        "keypair": "tbd81fd466aji65qtg7sfg",
+        "keypair": "tbd85cf76pr9ha6omvqjgg",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-12 09:50:29",
-        "sys.cspResourceId": "tbd81ffbm6aji65qtg7spg",
-        "sys.cspResourceName": "tbd81ffbm6aji65qtg7spg",
+        "sys.createdTime": "2026-05-18 08:08:17",
+        "sys.cspResourceId": "tbd85chgupr9ha6omvqjsg",
+        "sys.cspResourceName": "tbd85chgupr9ha6omvqjsg",
         "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -4399,7 +4399,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd81ffbm6aji65qtg7spg",
+        "sys.uid": "tbd85chgupr9ha6omvqjsg",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -4407,13 +4407,13 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.171.230",
+      "publicIP": "34.64.135.175",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.3",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "persistent-disk-0",
       "connectionName": "gcp-asia-northeast3",
       "connectionConfig": {
@@ -4463,22 +4463,22 @@
         "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+      "cspVNetId": "tbd85cevepr9ha6omvqj20",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA/tQZO3ieBWPUMFX+hYHM27DS/eAoZostdcDvydt+4hTFJL9NwBs2DC2MUshKS1C57DGaLeOSnC5fzHdoMFkEQ=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI/QnYwHOlz6TT2SILbnQJKkPJsNlnr8GTuR0+y0rv+tXXMbYs1SIKMw1M8Q1VVNZyJfvqytUW8Pk/1tpGi6xa4=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:AbCogiVk5uz+GX63WbpqC+BrJ6788SV+zEOMIcHYaVk",
-        "firstUsedAt": "2026-05-12T09:50:40Z"
+        "fingerprint": "SHA256:aEf3AqgSAOIliyJaPgDKOhdH5uP8vR/tFTEZIp+gcMw",
+        "firstUsedAt": "2026-05-18T08:08:32Z"
       },
       "commandStatus": [
         {
@@ -4486,11 +4486,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:50:38Z",
-          "completedTime": "2026-05-12T09:50:41Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-05-18T08:08:29Z",
+          "completedTime": "2026-05-18T08:08:33Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4505,7 +4505,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-12T02:49:42.308-07:00"
+          "value": "2026-05-18T01:07:35.010-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -4517,15 +4517,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7spg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjsg,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "cE_0TgthpVs="
+          "value": "HMqjE_xTr3c="
         },
         {
           "key": "Id",
-          "value": "8588388900726065497"
+          "value": "4838453238055794217"
         },
         {
           "key": "Kind",
@@ -4533,15 +4533,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "iFKnnqnIM2k="
+          "value": "K4XUyTdV-uk="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-12T02:49:53.483-07:00"
+          "value": "2026-05-18T01:07:43.230-07:00"
         },
         {
           "key": "MachineType",
@@ -4549,15 +4549,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd81ffbm6aji65qtg7spg"
+          "value": "tbd85chgupr9ha6omvqjsg"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.171.230,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:N1qJzSGLvnY=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.135.175,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:aInRVIK88Rw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
         },
         {
           "key": "ResourceStatus",
@@ -4577,7 +4577,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7spg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjsg"
         },
         {
           "key": "ServiceAccounts",
@@ -4601,7 +4601,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:Y3tH5grMsBg=,items:[tbd81fdnm6aji65qtg7sh0]}"
+          "value": "{fingerprint:iDI4EcKiK68=,items:[tbd85cfrepr9ha6omvqjhg]}"
         },
         {
           "key": "Zone",
@@ -4621,13 +4621,13 @@
     "results": [
       {
         "infraId": "my03-infra101",
-        "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "34.158.204.63",
+        "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "34.64.234.91",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4637,12 +4637,12 @@
       {
         "infraId": "my03-infra101",
         "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "34.64.171.230",
+        "nodeIp": "34.64.135.175",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4651,13 +4651,13 @@
       },
       {
         "infraId": "my03-infra101",
-        "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "34.50.35.103",
+        "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "34.47.88.87",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4693,7 +4693,7 @@
     {
       "resourceType": "infra",
       "id": "my03-infra101",
-      "uid": "tbd81ffbe6aji65qtg7sng",
+      "uid": "tbd85chgupr9ha6omvqjqg",
       "name": "my03-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -4721,7 +4721,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my03-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd81ffbe6aji65qtg7sng"
+        "sys.uid": "tbd85chgupr9ha6omvqjqg"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -4730,9 +4730,9 @@
         {
           "resourceType": "node",
           "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd81ffbm6aji65qtg7sog",
-          "cspResourceName": "tbd81ffbm6aji65qtg7sog",
-          "cspResourceId": "tbd81ffbm6aji65qtg7sog",
+          "uid": "tbd85chgupr9ha6omvqjrg",
+          "cspResourceName": "tbd85chgupr9ha6omvqjrg",
+          "cspResourceId": "tbd85chgupr9ha6omvqjrg",
           "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -4746,14 +4746,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:50:21",
+          "createdTime": "2026-05-18 08:08:17",
           "label": {
-            "keypair": "tbd81fd466aji65qtg7sfg",
+            "keypair": "tbd85cf76pr9ha6omvqjgg",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-12 09:50:21",
-            "sys.cspResourceId": "tbd81ffbm6aji65qtg7sog",
-            "sys.cspResourceName": "tbd81ffbm6aji65qtg7sog",
+            "sys.createdTime": "2026-05-18 08:08:17",
+            "sys.cspResourceId": "tbd85chgupr9ha6omvqjrg",
+            "sys.cspResourceName": "tbd85chgupr9ha6omvqjrg",
             "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my03-infra101",
             "sys.labelType": "node",
@@ -4762,7 +4762,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd81ffbm6aji65qtg7sog",
+            "sys.uid": "tbd85chgupr9ha6omvqjrg",
             "sys.vNetId": "my03-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -4770,13 +4770,13 @@
             "region": "asia-northeast3",
             "zone": "asia-northeast3-a"
           },
-          "publicIP": "34.158.204.63",
+          "publicIP": "34.47.88.87",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.2",
           "privateDNS": "",
           "rootDiskType": "pd-standard",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "persistent-disk-0",
           "connectionName": "gcp-asia-northeast3",
           "connectionConfig": {
@@ -4826,22 +4826,22 @@
             "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
           },
           "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+          "cspVNetId": "tbd85cevepr9ha6omvqj20",
           "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+          "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
           "networkInterface": "nic0",
           "securityGroupIds": [
             "my03-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+          "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDWs1O67lTqjywhyfSy0DUdVXjKbOCkG2p+cNK0kF3Advcia+KV9kocOB0cYy3lgsP7ab6KX69IQiCQSz6gxnVg=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBTyrjHSxt6qZWbQxMqqRCjxDmjtrH2Dnopziy9PbQzxGqw76v+iZm/EYFqx+pxvqaTUNBU++J92lq0WuBr7i68=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:ydA9WCTdI4uR0AvkDzBhqUY7arK9CdwHq1KBOsfkJvk",
-            "firstUsedAt": "2026-05-12T09:50:38Z"
+            "fingerprint": "SHA256:Epg/2q2Z05YyN084hOeTw4hNiR7NjcMSq43lf/yocK4",
+            "firstUsedAt": "2026-05-18T08:08:32Z"
           },
           "commandStatus": [
             {
@@ -4849,11 +4849,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:50:38Z",
-              "completedTime": "2026-05-12T09:50:41Z",
-              "elapsedTime": 3,
+              "startedTime": "2026-05-18T08:08:29Z",
+              "completedTime": "2026-05-18T08:08:33Z",
+              "elapsedTime": 4,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -4868,7 +4868,7 @@
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-05-12T02:49:40.967-07:00"
+              "value": "2026-05-18T01:07:34.217-07:00"
             },
             {
               "key": "DeletionProtection",
@@ -4880,15 +4880,15 @@
             },
             {
               "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sog,type:PERSISTENT}"
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjrg,type:PERSISTENT}"
             },
             {
               "key": "Fingerprint",
-              "value": "Ze1M2KRQWjk="
+              "value": "9VP4LLWbIfc="
             },
             {
               "key": "Id",
-              "value": "1593969242543180123"
+              "value": "485614543392175657"
             },
             {
               "key": "Kind",
@@ -4896,15 +4896,15 @@
             },
             {
               "key": "LabelFingerprint",
-              "value": "iFKnnqnIM2k="
+              "value": "K4XUyTdV-uk="
             },
             {
               "key": "Labels",
-              "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+              "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
             },
             {
               "key": "LastStartTimestamp",
-              "value": "2026-05-12T02:49:48.192-07:00"
+              "value": "2026-05-18T01:07:42.548-07:00"
             },
             {
               "key": "MachineType",
@@ -4912,15 +4912,15 @@
             },
             {
               "key": "Metadata",
-              "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+              "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
             },
             {
               "key": "Name",
-              "value": "tbd81ffbm6aji65qtg7sog"
+              "value": "tbd85chgupr9ha6omvqjrg"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.204.63,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:sB9z5QTR24w=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.47.88.87,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:ihh_BNv7Hgc=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
             },
             {
               "key": "ResourceStatus",
@@ -4940,7 +4940,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sog"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjrg"
             },
             {
               "key": "ServiceAccounts",
@@ -4964,7 +4964,7 @@
             },
             {
               "key": "Tags",
-              "value": "{fingerprint:wF4QnTxJsgg=,items:[tbd81fd466aji65qtg7sg0]}"
+              "value": "{fingerprint:VTjLFnAOyhg=,items:[tbd85cf7epr9ha6omvqjh0]}"
             },
             {
               "key": "Zone",
@@ -4975,9 +4975,9 @@
         {
           "resourceType": "node",
           "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd81ffbm6aji65qtg7sqg",
-          "cspResourceName": "tbd81ffbm6aji65qtg7sqg",
-          "cspResourceId": "tbd81ffbm6aji65qtg7sqg",
+          "uid": "tbd85chgupr9ha6omvqjtg",
+          "cspResourceName": "tbd85chgupr9ha6omvqjtg",
+          "cspResourceId": "tbd85chgupr9ha6omvqjtg",
           "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -4991,14 +4991,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:50:23",
+          "createdTime": "2026-05-18 08:08:19",
           "label": {
-            "keypair": "tbd81fd466aji65qtg7sfg",
+            "keypair": "tbd85cf76pr9ha6omvqjgg",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-12 09:50:23",
-            "sys.cspResourceId": "tbd81ffbm6aji65qtg7sqg",
-            "sys.cspResourceName": "tbd81ffbm6aji65qtg7sqg",
+            "sys.createdTime": "2026-05-18 08:08:19",
+            "sys.cspResourceId": "tbd85chgupr9ha6omvqjtg",
+            "sys.cspResourceName": "tbd85chgupr9ha6omvqjtg",
             "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my03-infra101",
             "sys.labelType": "node",
@@ -5007,7 +5007,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd81ffbm6aji65qtg7sqg",
+            "sys.uid": "tbd85chgupr9ha6omvqjtg",
             "sys.vNetId": "my03-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -5015,13 +5015,13 @@
             "region": "asia-northeast3",
             "zone": "asia-northeast3-a"
           },
-          "publicIP": "34.50.35.103",
+          "publicIP": "34.64.234.91",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.4",
           "privateDNS": "",
           "rootDiskType": "pd-standard",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "persistent-disk-0",
           "connectionName": "gcp-asia-northeast3",
           "connectionConfig": {
@@ -5071,22 +5071,22 @@
             "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
           },
           "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+          "cspVNetId": "tbd85cevepr9ha6omvqj20",
           "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+          "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
           "networkInterface": "nic0",
           "securityGroupIds": [
             "my03-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+          "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMrtQtDUiUdG1oCzNSF23wNYT9yks/U+HQFM4H8KtWmOJGvHechJow2MM8+ls8Mj14sRKYWxH0DNMkkqnSjkCuA=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGvD1KU1+ZJdf79GZ9H34PziLBJYb01WxzgNS5tWz0GeOpGg8L88IGpPqPfqdXKb5bROJbby0KOvfhdVCVUmLQM=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:ojW1rp6jU49KfmomGDmh3nQeYrjbF3VL5yVCcZ+c6e4",
-            "firstUsedAt": "2026-05-12T09:50:40Z"
+            "fingerprint": "SHA256:DYAWOOMoPbZPyNgE6XOiqkS7jz5oAKe042rekh/h+a0",
+            "firstUsedAt": "2026-05-18T08:08:29Z"
           },
           "commandStatus": [
             {
@@ -5094,11 +5094,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:50:38Z",
-              "completedTime": "2026-05-12T09:50:42Z",
-              "elapsedTime": 4,
+              "startedTime": "2026-05-18T08:08:29Z",
+              "completedTime": "2026-05-18T08:08:32Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5113,7 +5113,7 @@
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-05-12T02:49:42.582-07:00"
+              "value": "2026-05-18T01:07:35.886-07:00"
             },
             {
               "key": "DeletionProtection",
@@ -5125,15 +5125,15 @@
             },
             {
               "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sqg,type:PERSISTENT}"
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjtg,type:PERSISTENT}"
             },
             {
               "key": "Fingerprint",
-              "value": "RwAIYtShgo4="
+              "value": "DWOIQhWVgNc="
             },
             {
               "key": "Id",
-              "value": "7260017217573439834"
+              "value": "1272312304157292072"
             },
             {
               "key": "Kind",
@@ -5141,15 +5141,15 @@
             },
             {
               "key": "LabelFingerprint",
-              "value": "iFKnnqnIM2k="
+              "value": "K4XUyTdV-uk="
             },
             {
               "key": "Labels",
-              "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+              "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
             },
             {
               "key": "LastStartTimestamp",
-              "value": "2026-05-12T02:49:49.584-07:00"
+              "value": "2026-05-18T01:07:42.684-07:00"
             },
             {
               "key": "MachineType",
@@ -5157,15 +5157,15 @@
             },
             {
               "key": "Metadata",
-              "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+              "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
             },
             {
               "key": "Name",
-              "value": "tbd81ffbm6aji65qtg7sqg"
+              "value": "tbd85chgupr9ha6omvqjtg"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.50.35.103,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lFDLiG6yO5c=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.234.91,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:eL5WeVK8vho=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
             },
             {
               "key": "ResourceStatus",
@@ -5185,7 +5185,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sqg"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjtg"
             },
             {
               "key": "ServiceAccounts",
@@ -5209,7 +5209,7 @@
             },
             {
               "key": "Tags",
-              "value": "{fingerprint:__A_yY_oPbY=,items:[tbd81feh66aji65qtg7sn0]}"
+              "value": "{fingerprint:AiAynOHHwpk=,items:[tbd85cgkmpr9ha6omvqjkg]}"
             },
             {
               "key": "Zone",
@@ -5220,9 +5220,9 @@
         {
           "resourceType": "node",
           "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd81ffbm6aji65qtg7spg",
-          "cspResourceName": "tbd81ffbm6aji65qtg7spg",
-          "cspResourceId": "tbd81ffbm6aji65qtg7spg",
+          "uid": "tbd85chgupr9ha6omvqjsg",
+          "cspResourceName": "tbd85chgupr9ha6omvqjsg",
+          "cspResourceId": "tbd85chgupr9ha6omvqjsg",
           "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5236,14 +5236,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:50:29",
+          "createdTime": "2026-05-18 08:08:17",
           "label": {
-            "keypair": "tbd81fd466aji65qtg7sfg",
+            "keypair": "tbd85cf76pr9ha6omvqjgg",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-12 09:50:29",
-            "sys.cspResourceId": "tbd81ffbm6aji65qtg7spg",
-            "sys.cspResourceName": "tbd81ffbm6aji65qtg7spg",
+            "sys.createdTime": "2026-05-18 08:08:17",
+            "sys.cspResourceId": "tbd85chgupr9ha6omvqjsg",
+            "sys.cspResourceName": "tbd85chgupr9ha6omvqjsg",
             "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my03-infra101",
             "sys.labelType": "node",
@@ -5252,7 +5252,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd81ffbm6aji65qtg7spg",
+            "sys.uid": "tbd85chgupr9ha6omvqjsg",
             "sys.vNetId": "my03-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -5260,13 +5260,13 @@
             "region": "asia-northeast3",
             "zone": "asia-northeast3-a"
           },
-          "publicIP": "34.64.171.230",
+          "publicIP": "34.64.135.175",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.3",
           "privateDNS": "",
           "rootDiskType": "pd-standard",
-          "rootDiskSize": 50,
+          "rootDiskSize": 10,
           "RootDeviceName": "persistent-disk-0",
           "connectionName": "gcp-asia-northeast3",
           "connectionConfig": {
@@ -5316,22 +5316,22 @@
             "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
           },
           "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+          "cspVNetId": "tbd85cevepr9ha6omvqj20",
           "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+          "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
           "networkInterface": "nic0",
           "securityGroupIds": [
             "my03-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+          "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA/tQZO3ieBWPUMFX+hYHM27DS/eAoZostdcDvydt+4hTFJL9NwBs2DC2MUshKS1C57DGaLeOSnC5fzHdoMFkEQ=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI/QnYwHOlz6TT2SILbnQJKkPJsNlnr8GTuR0+y0rv+tXXMbYs1SIKMw1M8Q1VVNZyJfvqytUW8Pk/1tpGi6xa4=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:AbCogiVk5uz+GX63WbpqC+BrJ6788SV+zEOMIcHYaVk",
-            "firstUsedAt": "2026-05-12T09:50:40Z"
+            "fingerprint": "SHA256:aEf3AqgSAOIliyJaPgDKOhdH5uP8vR/tFTEZIp+gcMw",
+            "firstUsedAt": "2026-05-18T08:08:32Z"
           },
           "commandStatus": [
             {
@@ -5339,11 +5339,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:50:38Z",
-              "completedTime": "2026-05-12T09:50:41Z",
-              "elapsedTime": 3,
+              "startedTime": "2026-05-18T08:08:29Z",
+              "completedTime": "2026-05-18T08:08:33Z",
+              "elapsedTime": 4,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5358,7 +5358,7 @@
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-05-12T02:49:42.308-07:00"
+              "value": "2026-05-18T01:07:35.010-07:00"
             },
             {
               "key": "DeletionProtection",
@@ -5370,15 +5370,15 @@
             },
             {
               "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7spg,type:PERSISTENT}"
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjsg,type:PERSISTENT}"
             },
             {
               "key": "Fingerprint",
-              "value": "cE_0TgthpVs="
+              "value": "HMqjE_xTr3c="
             },
             {
               "key": "Id",
-              "value": "8588388900726065497"
+              "value": "4838453238055794217"
             },
             {
               "key": "Kind",
@@ -5386,15 +5386,15 @@
             },
             {
               "key": "LabelFingerprint",
-              "value": "iFKnnqnIM2k="
+              "value": "K4XUyTdV-uk="
             },
             {
               "key": "Labels",
-              "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+              "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
             },
             {
               "key": "LastStartTimestamp",
-              "value": "2026-05-12T02:49:53.483-07:00"
+              "value": "2026-05-18T01:07:43.230-07:00"
             },
             {
               "key": "MachineType",
@@ -5402,15 +5402,15 @@
             },
             {
               "key": "Metadata",
-              "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+              "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
             },
             {
               "key": "Name",
-              "value": "tbd81ffbm6aji65qtg7spg"
+              "value": "tbd85chgupr9ha6omvqjsg"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.171.230,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:N1qJzSGLvnY=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.135.175,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:aInRVIK88Rw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
             },
             {
               "key": "ResourceStatus",
@@ -5430,7 +5430,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7spg"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjsg"
             },
             {
               "key": "ServiceAccounts",
@@ -5454,7 +5454,7 @@
             },
             {
               "key": "Tags",
-              "value": "{fingerprint:Y3tH5grMsBg=,items:[tbd81fdnm6aji65qtg7sh0]}"
+              "value": "{fingerprint:iDI4EcKiK68=,items:[tbd85cfrepr9ha6omvqjhg]}"
             },
             {
               "key": "Zone",
@@ -5474,13 +5474,13 @@
         "results": [
           {
             "infraId": "my03-infra101",
-            "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "34.158.204.63",
+            "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "34.64.234.91",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5490,12 +5490,12 @@
           {
             "infraId": "my03-infra101",
             "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "34.64.171.230",
+            "nodeIp": "34.64.135.175",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5504,13 +5504,13 @@
           },
           {
             "infraId": "my03-infra101",
-            "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "34.50.35.103",
+            "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "34.47.88.87",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5522,9 +5522,9 @@
     },
     {
       "resourceType": "infra",
-      "id": "my04-infra101",
-      "uid": "tbd81fe7e6aji65qtg7si0",
-      "name": "my04-infra101",
+      "id": "my08-infra101",
+      "uid": "tbd85ch6epr9ha6omvqjlg",
+      "name": "my08-infra101",
       "status": "Creating:3 (R:0/3)",
       "statusCount": {
         "countTotal": 3,
@@ -5546,12 +5546,12 @@
       "configureCloudAdaptiveNetwork": "",
       "label": {
         "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
-        "sys.id": "my04-infra101",
+        "sys.id": "my08-infra101",
         "sys.labelType": "infra",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-infra101",
+        "sys.name": "my08-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd81fe7e6aji65qtg7si0"
+        "sys.uid": "tbd85ch6epr9ha6omvqjlg"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5559,10 +5559,10 @@
       "node": [
         {
           "resourceType": "node",
-          "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd81fe7m6aji65qtg7sj0",
-          "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbd85ch6epr9ha6omvqjmg",
+          "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
             "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
             "latitude": 37.4754,
@@ -5625,24 +5625,24 @@
           "image": {
             "osType": ""
           },
-          "vNetId": "my04-vnet-01",
+          "vNetId": "my08-vnet-01",
           "cspVNetId": "",
-          "subnetId": "my04-subnet-01",
+          "subnetId": "my08-subnet-01",
           "cspSubnetId": "",
           "networkInterface": "",
           "securityGroupIds": [
-            "my04-sg-01"
+            "my08-sg-01"
           ],
           "dataDiskIds": null,
-          "sshKeyId": "my04-sshkey-01",
+          "sshKeyId": "my08-sshkey-01",
           "cspSshKeyId": ""
         },
         {
           "resourceType": "node",
-          "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd81fe7m6aji65qtg7sl0",
-          "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd85ch6epr9ha6omvqjog",
+          "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
             "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
             "latitude": 37.4754,
@@ -5705,24 +5705,24 @@
           "image": {
             "osType": ""
           },
-          "vNetId": "my04-vnet-01",
+          "vNetId": "my08-vnet-01",
           "cspVNetId": "",
-          "subnetId": "my04-subnet-01",
+          "subnetId": "my08-subnet-01",
           "cspSubnetId": "",
           "networkInterface": "",
           "securityGroupIds": [
-            "my04-sg-03"
+            "my08-sg-03"
           ],
           "dataDiskIds": null,
-          "sshKeyId": "my04-sshkey-01",
+          "sshKeyId": "my08-sshkey-01",
           "cspSshKeyId": ""
         },
         {
           "resourceType": "node",
-          "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd81fe7m6aji65qtg7sk0",
-          "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbd85ch6epr9ha6omvqjng",
+          "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
             "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
             "latitude": 37.4754,
@@ -5785,16 +5785,16 @@
           "image": {
             "osType": ""
           },
-          "vNetId": "my04-vnet-01",
+          "vNetId": "my08-vnet-01",
           "cspVNetId": "",
-          "subnetId": "my04-subnet-01",
+          "subnetId": "my08-subnet-01",
           "cspSubnetId": "",
           "networkInterface": "",
           "securityGroupIds": [
-            "my04-sg-02"
+            "my08-sg-02"
           ],
           "dataDiskIds": null,
-          "sshKeyId": "my04-sshkey-01",
+          "sshKeyId": "my08-sshkey-01",
           "cspSshKeyId": ""
         }
       ],
@@ -5834,7 +5834,7 @@
 {
   "idList": [
     "my03-infra101",
-    "my04-infra101"
+    "my08-infra101"
   ]
 }
 ```
@@ -5863,7 +5863,7 @@
 {
   "resourceType": "infra",
   "id": "my03-infra101",
-  "uid": "tbd81ffbe6aji65qtg7sng",
+  "uid": "tbd85chgupr9ha6omvqjqg",
   "name": "my03-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -5891,7 +5891,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my03-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd81ffbe6aji65qtg7sng"
+    "sys.uid": "tbd85chgupr9ha6omvqjqg"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -5900,9 +5900,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd81ffbm6aji65qtg7sog",
-      "cspResourceName": "tbd81ffbm6aji65qtg7sog",
-      "cspResourceId": "tbd81ffbm6aji65qtg7sog",
+      "uid": "tbd85chgupr9ha6omvqjrg",
+      "cspResourceName": "tbd85chgupr9ha6omvqjrg",
+      "cspResourceId": "tbd85chgupr9ha6omvqjrg",
       "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -5916,14 +5916,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:21",
+      "createdTime": "2026-05-18 08:08:17",
       "label": {
-        "keypair": "tbd81fd466aji65qtg7sfg",
+        "keypair": "tbd85cf76pr9ha6omvqjgg",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-12 09:50:21",
-        "sys.cspResourceId": "tbd81ffbm6aji65qtg7sog",
-        "sys.cspResourceName": "tbd81ffbm6aji65qtg7sog",
+        "sys.createdTime": "2026-05-18 08:08:17",
+        "sys.cspResourceId": "tbd85chgupr9ha6omvqjrg",
+        "sys.cspResourceName": "tbd85chgupr9ha6omvqjrg",
         "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -5932,7 +5932,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd81ffbm6aji65qtg7sog",
+        "sys.uid": "tbd85chgupr9ha6omvqjrg",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -5940,13 +5940,13 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.158.204.63",
+      "publicIP": "34.47.88.87",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.2",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "persistent-disk-0",
       "connectionName": "gcp-asia-northeast3",
       "connectionConfig": {
@@ -5996,22 +5996,22 @@
         "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+      "cspVNetId": "tbd85cevepr9ha6omvqj20",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDWs1O67lTqjywhyfSy0DUdVXjKbOCkG2p+cNK0kF3Advcia+KV9kocOB0cYy3lgsP7ab6KX69IQiCQSz6gxnVg=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBTyrjHSxt6qZWbQxMqqRCjxDmjtrH2Dnopziy9PbQzxGqw76v+iZm/EYFqx+pxvqaTUNBU++J92lq0WuBr7i68=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:ydA9WCTdI4uR0AvkDzBhqUY7arK9CdwHq1KBOsfkJvk",
-        "firstUsedAt": "2026-05-12T09:50:38Z"
+        "fingerprint": "SHA256:Epg/2q2Z05YyN084hOeTw4hNiR7NjcMSq43lf/yocK4",
+        "firstUsedAt": "2026-05-18T08:08:32Z"
       },
       "commandStatus": [
         {
@@ -6019,11 +6019,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:50:38Z",
-          "completedTime": "2026-05-12T09:50:41Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-05-18T08:08:29Z",
+          "completedTime": "2026-05-18T08:08:33Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6038,7 +6038,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-12T02:49:40.967-07:00"
+          "value": "2026-05-18T01:07:34.217-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -6050,15 +6050,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sog,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjrg,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "Ze1M2KRQWjk="
+          "value": "9VP4LLWbIfc="
         },
         {
           "key": "Id",
-          "value": "1593969242543180123"
+          "value": "485614543392175657"
         },
         {
           "key": "Kind",
@@ -6066,15 +6066,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "iFKnnqnIM2k="
+          "value": "K4XUyTdV-uk="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-12T02:49:48.192-07:00"
+          "value": "2026-05-18T01:07:42.548-07:00"
         },
         {
           "key": "MachineType",
@@ -6082,15 +6082,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd81ffbm6aji65qtg7sog"
+          "value": "tbd85chgupr9ha6omvqjrg"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.204.63,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:sB9z5QTR24w=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.47.88.87,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:ihh_BNv7Hgc=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
         },
         {
           "key": "ResourceStatus",
@@ -6110,7 +6110,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sog"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjrg"
         },
         {
           "key": "ServiceAccounts",
@@ -6134,7 +6134,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:wF4QnTxJsgg=,items:[tbd81fd466aji65qtg7sg0]}"
+          "value": "{fingerprint:VTjLFnAOyhg=,items:[tbd85cf7epr9ha6omvqjh0]}"
         },
         {
           "key": "Zone",
@@ -6145,9 +6145,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd81ffbm6aji65qtg7sqg",
-      "cspResourceName": "tbd81ffbm6aji65qtg7sqg",
-      "cspResourceId": "tbd81ffbm6aji65qtg7sqg",
+      "uid": "tbd85chgupr9ha6omvqjtg",
+      "cspResourceName": "tbd85chgupr9ha6omvqjtg",
+      "cspResourceId": "tbd85chgupr9ha6omvqjtg",
       "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6161,14 +6161,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:23",
+      "createdTime": "2026-05-18 08:08:19",
       "label": {
-        "keypair": "tbd81fd466aji65qtg7sfg",
+        "keypair": "tbd85cf76pr9ha6omvqjgg",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-12 09:50:23",
-        "sys.cspResourceId": "tbd81ffbm6aji65qtg7sqg",
-        "sys.cspResourceName": "tbd81ffbm6aji65qtg7sqg",
+        "sys.createdTime": "2026-05-18 08:08:19",
+        "sys.cspResourceId": "tbd85chgupr9ha6omvqjtg",
+        "sys.cspResourceName": "tbd85chgupr9ha6omvqjtg",
         "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -6177,7 +6177,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd81ffbm6aji65qtg7sqg",
+        "sys.uid": "tbd85chgupr9ha6omvqjtg",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -6185,13 +6185,13 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.50.35.103",
+      "publicIP": "34.64.234.91",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "persistent-disk-0",
       "connectionName": "gcp-asia-northeast3",
       "connectionConfig": {
@@ -6241,22 +6241,22 @@
         "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+      "cspVNetId": "tbd85cevepr9ha6omvqj20",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMrtQtDUiUdG1oCzNSF23wNYT9yks/U+HQFM4H8KtWmOJGvHechJow2MM8+ls8Mj14sRKYWxH0DNMkkqnSjkCuA=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGvD1KU1+ZJdf79GZ9H34PziLBJYb01WxzgNS5tWz0GeOpGg8L88IGpPqPfqdXKb5bROJbby0KOvfhdVCVUmLQM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:ojW1rp6jU49KfmomGDmh3nQeYrjbF3VL5yVCcZ+c6e4",
-        "firstUsedAt": "2026-05-12T09:50:40Z"
+        "fingerprint": "SHA256:DYAWOOMoPbZPyNgE6XOiqkS7jz5oAKe042rekh/h+a0",
+        "firstUsedAt": "2026-05-18T08:08:29Z"
       },
       "commandStatus": [
         {
@@ -6264,11 +6264,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:50:38Z",
-          "completedTime": "2026-05-12T09:50:42Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-05-18T08:08:29Z",
+          "completedTime": "2026-05-18T08:08:32Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6283,7 +6283,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-12T02:49:42.582-07:00"
+          "value": "2026-05-18T01:07:35.886-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -6295,15 +6295,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sqg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjtg,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "RwAIYtShgo4="
+          "value": "DWOIQhWVgNc="
         },
         {
           "key": "Id",
-          "value": "7260017217573439834"
+          "value": "1272312304157292072"
         },
         {
           "key": "Kind",
@@ -6311,15 +6311,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "iFKnnqnIM2k="
+          "value": "K4XUyTdV-uk="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-12T02:49:49.584-07:00"
+          "value": "2026-05-18T01:07:42.684-07:00"
         },
         {
           "key": "MachineType",
@@ -6327,15 +6327,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd81ffbm6aji65qtg7sqg"
+          "value": "tbd85chgupr9ha6omvqjtg"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.50.35.103,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lFDLiG6yO5c=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.234.91,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:eL5WeVK8vho=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
         },
         {
           "key": "ResourceStatus",
@@ -6355,7 +6355,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sqg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjtg"
         },
         {
           "key": "ServiceAccounts",
@@ -6379,7 +6379,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:__A_yY_oPbY=,items:[tbd81feh66aji65qtg7sn0]}"
+          "value": "{fingerprint:AiAynOHHwpk=,items:[tbd85cgkmpr9ha6omvqjkg]}"
         },
         {
           "key": "Zone",
@@ -6390,9 +6390,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd81ffbm6aji65qtg7spg",
-      "cspResourceName": "tbd81ffbm6aji65qtg7spg",
-      "cspResourceId": "tbd81ffbm6aji65qtg7spg",
+      "uid": "tbd85chgupr9ha6omvqjsg",
+      "cspResourceName": "tbd85chgupr9ha6omvqjsg",
+      "cspResourceId": "tbd85chgupr9ha6omvqjsg",
       "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -6406,14 +6406,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:29",
+      "createdTime": "2026-05-18 08:08:17",
       "label": {
-        "keypair": "tbd81fd466aji65qtg7sfg",
+        "keypair": "tbd85cf76pr9ha6omvqjgg",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-12 09:50:29",
-        "sys.cspResourceId": "tbd81ffbm6aji65qtg7spg",
-        "sys.cspResourceName": "tbd81ffbm6aji65qtg7spg",
+        "sys.createdTime": "2026-05-18 08:08:17",
+        "sys.cspResourceId": "tbd85chgupr9ha6omvqjsg",
+        "sys.cspResourceName": "tbd85chgupr9ha6omvqjsg",
         "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -6422,7 +6422,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd81ffbm6aji65qtg7spg",
+        "sys.uid": "tbd85chgupr9ha6omvqjsg",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -6430,13 +6430,13 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.171.230",
+      "publicIP": "34.64.135.175",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.3",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
-      "rootDiskSize": 50,
+      "rootDiskSize": 10,
       "RootDeviceName": "persistent-disk-0",
       "connectionName": "gcp-asia-northeast3",
       "connectionConfig": {
@@ -6486,22 +6486,22 @@
         "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
+      "cspVNetId": "tbd85cevepr9ha6omvqj20",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
+      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
+      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA/tQZO3ieBWPUMFX+hYHM27DS/eAoZostdcDvydt+4hTFJL9NwBs2DC2MUshKS1C57DGaLeOSnC5fzHdoMFkEQ=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI/QnYwHOlz6TT2SILbnQJKkPJsNlnr8GTuR0+y0rv+tXXMbYs1SIKMw1M8Q1VVNZyJfvqytUW8Pk/1tpGi6xa4=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:AbCogiVk5uz+GX63WbpqC+BrJ6788SV+zEOMIcHYaVk",
-        "firstUsedAt": "2026-05-12T09:50:40Z"
+        "fingerprint": "SHA256:aEf3AqgSAOIliyJaPgDKOhdH5uP8vR/tFTEZIp+gcMw",
+        "firstUsedAt": "2026-05-18T08:08:32Z"
       },
       "commandStatus": [
         {
@@ -6509,11 +6509,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:50:38Z",
-          "completedTime": "2026-05-12T09:50:41Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-05-18T08:08:29Z",
+          "completedTime": "2026-05-18T08:08:33Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6528,7 +6528,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-12T02:49:42.308-07:00"
+          "value": "2026-05-18T01:07:35.010-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -6540,15 +6540,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7spg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjsg,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "cE_0TgthpVs="
+          "value": "HMqjE_xTr3c="
         },
         {
           "key": "Id",
-          "value": "8588388900726065497"
+          "value": "4838453238055794217"
         },
         {
           "key": "Kind",
@@ -6556,15 +6556,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "iFKnnqnIM2k="
+          "value": "K4XUyTdV-uk="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd81fd466aji65qtg7sfg}"
+          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-12T02:49:53.483-07:00"
+          "value": "2026-05-18T01:07:43.230-07:00"
         },
         {
           "key": "MachineType",
@@ -6572,15 +6572,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd81ffbm6aji65qtg7spg"
+          "value": "tbd85chgupr9ha6omvqjsg"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.171.230,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:N1qJzSGLvnY=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.135.175,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:aInRVIK88Rw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
         },
         {
           "key": "ResourceStatus",
@@ -6600,7 +6600,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7spg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjsg"
         },
         {
           "key": "ServiceAccounts",
@@ -6624,7 +6624,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:Y3tH5grMsBg=,items:[tbd81fdnm6aji65qtg7sh0]}"
+          "value": "{fingerprint:iDI4EcKiK68=,items:[tbd85cfrepr9ha6omvqjhg]}"
         },
         {
           "key": "Zone",
@@ -6644,13 +6644,13 @@
     "results": [
       {
         "infraId": "my03-infra101",
-        "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "34.158.204.63",
+        "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "34.64.234.91",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6660,12 +6660,12 @@
       {
         "infraId": "my03-infra101",
         "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "34.64.171.230",
+        "nodeIp": "34.64.135.175",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6674,13 +6674,13 @@
       },
       {
         "infraId": "my03-infra101",
-        "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "34.50.35.103",
+        "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "34.47.88.87",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6738,8 +6738,8 @@
       "command": "uname -a",
       "nodeGroup": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "34.158.204.63",
+      "output": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "34.47.88.87",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -6750,8 +6750,8 @@
       "command": "uname -a",
       "nodeGroup": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "34.50.35.103",
+      "output": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "34.64.234.91",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -6762,8 +6762,8 @@
       "command": "uname -a",
       "nodeGroup": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "34.64.171.230",
+      "output": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "34.64.135.175",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -6793,7 +6793,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-12 09:51:20
+**Generated At:** 2026-05-18 08:09:08
 
 **Namespace:** mig01
 
@@ -6821,9 +6821,9 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
-| e2-highcpu-2 | 2 | 2.0 | - | x86_64 |  | $0.0635 | 1 |
 | e2-standard-2 | 2 | 7.8 | - | x86_64 |  | $0.0860 | 1 |
 | e2-standard-4 | 4 | 15.6 | - | x86_64 |  | $0.1719 | 1 |
+| e2-highcpu-2 | 2 | 2.0 | - | x86_64 |  | $0.0635 | 1 |
 
 ### VM Images
 
@@ -6835,9 +6835,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tbd81ffbm6aji65qtg7sog | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.158.204.63<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tbd81ffbm6aji65qtg7sqg | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.50.35.103<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbd81ffbm6aji65qtg7spg | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.171.230<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tbd85chgupr9ha6omvqjrg | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.47.88.87<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tbd85chgupr9ha6omvqjtg | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.234.91<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbd85chgupr9ha6omvqjsg | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.135.175<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
 
 
 ## Network Resources
@@ -6849,7 +6849,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-vnet-01 |
-| **CSP VNet ID** | tbd81fcrm6aji65qtg7rtg |
+| **CSP VNet ID** | tbd85cevepr9ha6omvqj20 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | gcp-asia-northeast3 |
 | **Subnet Count** | 1 |
@@ -6858,7 +6858,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my03-subnet-01 | tbd81fcrm6aji65qtg7ru0 | 10.0.1.0/24 |  |
+| my03-subnet-01 | tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -6867,7 +6867,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my03-sshkey-01 | tbd81fd466aji65qtg7sfg |  |  |
+| my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  |  |
 
 ### Security Groups
 
@@ -6876,7 +6876,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-01 |
-| **CSP Security Group ID** | tbd81fd466aji65qtg7sg0 |
+| **CSP Security Group ID** | tbd85cf7epr9ha6omvqjh0 |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -6904,7 +6904,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-02 |
-| **CSP Security Group ID** | tbd81fdnm6aji65qtg7sh0 |
+| **CSP Security Group ID** | tbd85cfrepr9ha6omvqjhg |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -6937,7 +6937,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-03 |
-| **CSP Security Group ID** | tbd81feh66aji65qtg7sn0 |
+| **CSP Security Group ID** | tbd85cgkmpr9ha6omvqjkg |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7012,7 +7012,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-12 09:51:25*
+*Report generated: 2026-05-18 08:09:10*
 
 ---
 
@@ -7056,9 +7056,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tbd81ffbm6aji65qtg7sog<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tbd81ffbm6aji65qtg7sqg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbd81ffbm6aji65qtg7spg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tbd85chgupr9ha6omvqjrg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tbd85chgupr9ha6omvqjtg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbd85chgupr9ha6omvqjsg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7092,7 +7092,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-01
 
-**CSP ID:** tbd81fd466aji65qtg7sg0 | **VNet:** my03-vnet-01 | **Rules:** 14
+**CSP ID:** tbd85cf7epr9ha6omvqjh0 | **VNet:** my03-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7120,7 +7120,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-02
 
-**CSP ID:** tbd81fdnm6aji65qtg7sh0 | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbd85cfrepr9ha6omvqjhg | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7153,7 +7153,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-03
 
-**CSP ID:** tbd81feh66aji65qtg7sn0 | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbd85cgkmpr9ha6omvqjkg | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7194,13 +7194,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my03-vnet-01<br>**ID:** tbd81fcrm6aji65qtg7rtg | 10.0.0.0/21 |
+| 1 | **Name:** my03-vnet-01<br>**ID:** tbd85cevepr9ha6omvqj20 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my03-subnet-01<br>**ID:** tbd81fcrm6aji65qtg7ru0 | 10.0.1.0/24 | my03-vnet-01 |
+| 1 | **Name:** my03-subnet-01<br>**ID:** tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 | my03-vnet-01 |
 
 ### Source Network Information
 
@@ -7242,7 +7242,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my03-sshkey-01 | tbd81fd466aji65qtg7sfg |  | Used by all 3 VMs |
+| 1 | my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-ncp.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-ncp.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5
+- CM-Beetle: imdl/v0.1.5+ (c574040)
 - cm-model: unknown
 - CB-Tumblebug: vunknown
 - CB-Spider: vunknown
@@ -17,9 +17,9 @@
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 12, 2026
-- Test Time: 18:44:02 KST
-- Test Execution: 2026-05-12 18:44:02 KST
+- Test Date: May 18, 2026
+- Test Time: 17:01:42 KST
+- Test Execution: 2026-05-18 17:01:42 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 381ms | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 7m16.002s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 41ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 4ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 14ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 2m24.067s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 7m33.995s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 18ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 3ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 12ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.915s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.379s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 2m14.42s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.252s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.253s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 2m12.229s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 10m55.069505288s
+**Total Duration**: 13m34.78116931s
 
-*Test executed on May 12, 2026 at 18:44:02 KST (2026-05-12 18:44:02 KST) using CM-Beetle automated test CLI*
+*Test executed on May 18, 2026 at 17:01:42 KST (2026-05-18 17:01:42 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -3730,9 +3730,9 @@
 ```json
 {
   "resourceType": "infra",
-  "id": "my04-infra101",
-  "uid": "tbd81fe7e6aji65qtg7si0",
-  "name": "my04-infra101",
+  "id": "my08-infra101",
+  "uid": "tbd85ch6epr9ha6omvqjlg",
+  "name": "my08-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
     "countTotal": 3,
@@ -3754,12 +3754,12 @@
   "configureCloudAdaptiveNetwork": "",
   "label": {
     "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
-    "sys.id": "my04-infra101",
+    "sys.id": "my08-infra101",
     "sys.labelType": "infra",
     "sys.manager": "cb-tumblebug",
-    "sys.name": "my04-infra101",
+    "sys.name": "my08-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd81fe7e6aji65qtg7si0"
+    "sys.uid": "tbd85ch6epr9ha6omvqjlg"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -3767,12 +3767,12 @@
   "node": [
     {
       "resourceType": "node",
-      "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd81fe7m6aji65qtg7sj0",
-      "cspResourceName": "tbd81fe7m6aji65qtg7sj0",
-      "cspResourceId": "138234481",
-      "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+      "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+      "uid": "tbd85ch6epr9ha6omvqjmg",
+      "cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+      "cspResourceId": "138993641",
+      "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+      "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -3784,33 +3784,33 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:51:22",
+      "createdTime": "2026-05-18 08:10:58",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-12 09:51:22",
-        "sys.cspResourceId": "138234481",
-        "sys.cspResourceName": "tbd81fe7m6aji65qtg7sj0",
-        "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "sys.infraId": "my04-infra101",
+        "sys.createdTime": "2026-05-18 08:10:58",
+        "sys.cspResourceId": "138993641",
+        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+        "sys.id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "sys.name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.namespace": "mig01",
-        "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
-        "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd81fe7m6aji65qtg7sj0",
-        "sys.vNetId": "my04-vnet-01"
+        "sys.nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
+        "sys.subnetId": "my08-subnet-01",
+        "sys.uid": "tbd85ch6epr9ha6omvqjmg",
+        "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=50.0% Image=75.0%",
       "region": {
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.19.173",
+      "publicIP": "223.130.156.82",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.8",
+      "privateIP": "10.0.1.7",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -3861,23 +3861,23 @@
         "osArchitecture": "x86_64",
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
-      "vNetId": "my04-vnet-01",
-      "cspVNetId": "138792",
-      "subnetId": "my04-subnet-01",
-      "cspSubnetId": "300131",
+      "vNetId": "my08-vnet-01",
+      "cspVNetId": "139135",
+      "subnetId": "my08-subnet-01",
+      "cspSubnetId": "300855",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "my04-sg-01"
+        "my08-sg-01"
       ],
       "dataDiskIds": null,
-      "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+      "sshKeyId": "my08-sshkey-01",
+      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-12T09:51:28Z"
+        "firstUsedAt": "2026-05-18T08:11:04Z"
       },
       "commandStatus": [
         {
@@ -3885,22 +3885,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:51:27Z",
-          "completedTime": "2026-05-12T09:51:28Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:11:03Z",
+          "completedTime": "2026-05-18T08:11:05Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fe7m6aji65qtg7sj0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138234481"
+          "value": "138993641"
         },
         {
           "key": "ServerName",
-          "value": "tbd81fe7m6aji65qtg7sj0"
+          "value": "tbd85ch6epr9ha6omvqjmg"
         },
         {
           "key": "CpuCount",
@@ -3916,7 +3916,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd81fd3e6aji65qtg7seg"
+          "value": "tbd85cg56pr9ha6omvqjj0"
         },
         {
           "key": "ServerInstanceStatus",
@@ -3932,11 +3932,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-12T18:47:18+0900"
+          "value": "2026-05-18T17:06:55+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-12T18:49:31+0900"
+          "value": "2026-05-18T17:09:13+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -3960,19 +3960,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "138792"
+          "value": "139135"
         },
         {
           "key": "SubnetNo",
-          "value": "300131"
+          "value": "300855"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5678079"
+          "value": "5694779"
         },
         {
           "key": "InitScriptNo",
-          "value": "170941"
+          "value": "171473"
         },
         {
           "key": "ServerInstanceType",
@@ -4002,12 +4002,12 @@
     },
     {
       "resourceType": "node",
-      "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd81fe7m6aji65qtg7sl0",
-      "cspResourceName": "tbd81fe7m6aji65qtg7sl0",
-      "cspResourceId": "138234474",
-      "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+      "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+      "uid": "tbd85ch6epr9ha6omvqjog",
+      "cspResourceName": "tbd85ch6epr9ha6omvqjog",
+      "cspResourceId": "138993649",
+      "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+      "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -4019,33 +4019,33 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:51:10",
+      "createdTime": "2026-05-18 08:10:58",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-12 09:51:10",
-        "sys.cspResourceId": "138234474",
-        "sys.cspResourceName": "tbd81fe7m6aji65qtg7sl0",
-        "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "sys.infraId": "my04-infra101",
+        "sys.createdTime": "2026-05-18 08:10:58",
+        "sys.cspResourceId": "138993649",
+        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjog",
+        "sys.id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "sys.name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.namespace": "mig01",
-        "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
-        "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd81fe7m6aji65qtg7sl0",
-        "sys.vNetId": "my04-vnet-01"
+        "sys.nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+        "sys.subnetId": "my08-subnet-01",
+        "sys.uid": "tbd85ch6epr9ha6omvqjog",
+        "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
       "region": {
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.20.23",
+      "publicIP": "101.79.20.97",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.7",
+      "privateIP": "10.0.1.8",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -4096,23 +4096,23 @@
         "osArchitecture": "x86_64",
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
-      "vNetId": "my04-vnet-01",
-      "cspVNetId": "138792",
-      "subnetId": "my04-subnet-01",
-      "cspSubnetId": "300131",
+      "vNetId": "my08-vnet-01",
+      "cspVNetId": "139135",
+      "subnetId": "my08-subnet-01",
+      "cspSubnetId": "300855",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "my04-sg-03"
+        "my08-sg-03"
       ],
       "dataDiskIds": null,
-      "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+      "sshKeyId": "my08-sshkey-01",
+      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-12T09:51:28Z"
+        "firstUsedAt": "2026-05-18T08:11:04Z"
       },
       "commandStatus": [
         {
@@ -4120,22 +4120,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:51:27Z",
-          "completedTime": "2026-05-12T09:51:28Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:11:03Z",
+          "completedTime": "2026-05-18T08:11:05Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fe7m6aji65qtg7sl0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138234474"
+          "value": "138993649"
         },
         {
           "key": "ServerName",
-          "value": "tbd81fe7m6aji65qtg7sl0"
+          "value": "tbd85ch6epr9ha6omvqjog"
         },
         {
           "key": "CpuCount",
@@ -4151,7 +4151,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd81fd3e6aji65qtg7seg"
+          "value": "tbd85cg56pr9ha6omvqjj0"
         },
         {
           "key": "ServerInstanceStatus",
@@ -4167,11 +4167,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-12T18:47:18+0900"
+          "value": "2026-05-18T17:06:58+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-12T18:49:31+0900"
+          "value": "2026-05-18T17:09:11+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -4195,19 +4195,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "138792"
+          "value": "139135"
         },
         {
           "key": "SubnetNo",
-          "value": "300131"
+          "value": "300855"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5678078"
+          "value": "5694780"
         },
         {
           "key": "InitScriptNo",
-          "value": "170940"
+          "value": "171474"
         },
         {
           "key": "ServerInstanceType",
@@ -4237,12 +4237,12 @@
     },
     {
       "resourceType": "node",
-      "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd81fe7m6aji65qtg7sk0",
-      "cspResourceName": "tbd81fe7m6aji65qtg7sk0",
-      "cspResourceId": "138234467",
-      "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+      "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+      "uid": "tbd85ch6epr9ha6omvqjng",
+      "cspResourceName": "tbd85ch6epr9ha6omvqjng",
+      "cspResourceId": "138993635",
+      "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+      "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -4254,30 +4254,30 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:58",
+      "createdTime": "2026-05-18 08:10:47",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-12 09:50:58",
-        "sys.cspResourceId": "138234467",
-        "sys.cspResourceName": "tbd81fe7m6aji65qtg7sk0",
-        "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "sys.infraId": "my04-infra101",
+        "sys.createdTime": "2026-05-18 08:10:47",
+        "sys.cspResourceId": "138993635",
+        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjng",
+        "sys.id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "sys.name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.namespace": "mig01",
-        "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
-        "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd81fe7m6aji65qtg7sk0",
-        "sys.vNetId": "my04-vnet-01"
+        "sys.nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+        "sys.subnetId": "my08-subnet-01",
+        "sys.uid": "tbd85ch6epr9ha6omvqjng",
+        "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
       "region": {
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.19.56",
+      "publicIP": "101.79.16.239",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.6",
@@ -4331,23 +4331,23 @@
         "osArchitecture": "x86_64",
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
-      "vNetId": "my04-vnet-01",
-      "cspVNetId": "138792",
-      "subnetId": "my04-subnet-01",
-      "cspSubnetId": "300131",
+      "vNetId": "my08-vnet-01",
+      "cspVNetId": "139135",
+      "subnetId": "my08-subnet-01",
+      "cspSubnetId": "300855",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "my04-sg-02"
+        "my08-sg-02"
       ],
       "dataDiskIds": null,
-      "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+      "sshKeyId": "my08-sshkey-01",
+      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-12T09:51:27Z"
+        "firstUsedAt": "2026-05-18T08:11:03Z"
       },
       "commandStatus": [
         {
@@ -4355,22 +4355,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:51:27Z",
-          "completedTime": "2026-05-12T09:51:28Z",
+          "startedTime": "2026-05-18T08:11:03Z",
+          "completedTime": "2026-05-18T08:11:04Z",
           "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fe7m6aji65qtg7sk0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138234467"
+          "value": "138993635"
         },
         {
           "key": "ServerName",
-          "value": "tbd81fe7m6aji65qtg7sk0"
+          "value": "tbd85ch6epr9ha6omvqjng"
         },
         {
           "key": "CpuCount",
@@ -4386,7 +4386,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd81fd3e6aji65qtg7seg"
+          "value": "tbd85cg56pr9ha6omvqjj0"
         },
         {
           "key": "ServerInstanceStatus",
@@ -4402,11 +4402,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-12T18:47:18+0900"
+          "value": "2026-05-18T17:06:54+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-12T18:49:23+0900"
+          "value": "2026-05-18T17:09:08+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -4430,19 +4430,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "138792"
+          "value": "139135"
         },
         {
           "key": "SubnetNo",
-          "value": "300131"
+          "value": "300855"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5678077"
+          "value": "5694778"
         },
         {
           "key": "InitScriptNo",
-          "value": "170939"
+          "value": "171472"
         },
         {
           "key": "ServerInstanceType",
@@ -4481,14 +4481,14 @@
   "postCommandResult": {
     "results": [
       {
-        "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "101.79.19.56",
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "101.79.16.239",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fe7m6aji65qtg7sk0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4496,14 +4496,14 @@
         "err": null
       },
       {
-        "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "101.79.20.23",
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "101.79.20.97",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fe7m6aji65qtg7sl0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4511,14 +4511,14 @@
         "err": null
       },
       {
-        "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "101.79.19.173",
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "223.130.156.82",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fe7m6aji65qtg7sj0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4553,9 +4553,9 @@
   "infra": [
     {
       "resourceType": "infra",
-      "id": "my03-infra101",
-      "uid": "tbd81ffbe6aji65qtg7sng",
-      "name": "my03-infra101",
+      "id": "my08-infra101",
+      "uid": "tbd85ch6epr9ha6omvqjlg",
+      "name": "my08-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
         "countTotal": 3,
@@ -4577,12 +4577,12 @@
       "configureCloudAdaptiveNetwork": "",
       "label": {
         "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
-        "sys.id": "my03-infra101",
+        "sys.id": "my08-infra101",
         "sys.labelType": "infra",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my03-infra101",
+        "sys.name": "my08-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd81ffbe6aji65qtg7sng"
+        "sys.uid": "tbd85ch6epr9ha6omvqjlg"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -4590,842 +4590,12 @@
       "node": [
         {
           "resourceType": "node",
-          "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd81ffbm6aji65qtg7sog",
-          "cspResourceName": "tbd81ffbm6aji65qtg7sog",
-          "cspResourceId": "tbd81ffbm6aji65qtg7sog",
-          "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
-          "location": {
-            "display": "South Korea (Seoul)",
-            "latitude": 37.2,
-            "longitude": 127
-          },
-          "status": "Running",
-          "targetStatus": "None",
-          "targetAction": "None",
-          "monAgentStatus": "notInstalled",
-          "networkAgentStatus": "notInstalled",
-          "systemMessage": "",
-          "createdTime": "2026-05-12 09:50:21",
-          "label": {
-            "keypair": "tbd81fd466aji65qtg7sfg",
-            "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
-            "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-12 09:50:21",
-            "sys.cspResourceId": "tbd81ffbm6aji65qtg7sog",
-            "sys.cspResourceName": "tbd81ffbm6aji65qtg7sog",
-            "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "sys.infraId": "my03-infra101",
-            "sys.labelType": "node",
-            "sys.manager": "cb-tumblebug",
-            "sys.name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "sys.namespace": "mig01",
-            "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
-            "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd81ffbm6aji65qtg7sog",
-            "sys.vNetId": "my03-vnet-01"
-          },
-          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
-          "region": {
-            "region": "asia-northeast3",
-            "zone": "asia-northeast3-a"
-          },
-          "publicIP": "34.158.204.63",
-          "sshPort": 22,
-          "publicDNS": "",
-          "privateIP": "10.0.1.2",
-          "privateDNS": "",
-          "rootDiskType": "pd-standard",
-          "rootDiskSize": 50,
-          "RootDeviceName": "persistent-disk-0",
-          "connectionName": "gcp-asia-northeast3",
-          "connectionConfig": {
-            "configName": "gcp-asia-northeast3",
-            "providerName": "gcp",
-            "driverName": "gcp-driver-v1.0.so",
-            "credentialName": "gcp",
-            "credentialHolder": "admin",
-            "regionZoneInfoName": "gcp-asia-northeast3",
-            "regionZoneInfo": {
-              "assignedRegion": "asia-northeast3",
-              "assignedZone": "asia-northeast3-a"
-            },
-            "regionDetail": {
-              "regionId": "asia-northeast3",
-              "regionName": "asia-northeast3",
-              "description": "Seoul South Korea",
-              "location": {
-                "display": "South Korea (Seoul)",
-                "latitude": 37.2,
-                "longitude": 127
-              },
-              "zones": [
-                "asia-northeast3-a",
-                "asia-northeast3-b",
-                "asia-northeast3-c"
-              ]
-            },
-            "regionRepresentative": true,
-            "verified": true
-          },
-          "specId": "gcp+asia-northeast3+e2-highcpu-2",
-          "cspSpecName": "e2-highcpu-2",
-          "spec": {
-            "cspSpecName": "e2-highcpu-2",
-            "vCPU": 2,
-            "memoryGiB": 1.953125,
-            "costPerHour": 0.063531
-          },
-          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "image": {
-            "resourceType": "image",
-            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-            "osType": "Ubuntu 22.04",
-            "osArchitecture": "x86_64",
-            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
-          },
-          "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
-          "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
-          "networkInterface": "nic0",
-          "securityGroupIds": [
-            "my03-sg-01"
-          ],
-          "dataDiskIds": null,
-          "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
-          "nodeUserName": "cb-user",
-          "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDWs1O67lTqjywhyfSy0DUdVXjKbOCkG2p+cNK0kF3Advcia+KV9kocOB0cYy3lgsP7ab6KX69IQiCQSz6gxnVg=",
-            "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:ydA9WCTdI4uR0AvkDzBhqUY7arK9CdwHq1KBOsfkJvk",
-            "firstUsedAt": "2026-05-12T09:50:38Z"
-          },
-          "commandStatus": [
-            {
-              "index": 1,
-              "commandRequested": "uname -a",
-              "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-05-12T09:50:38Z",
-              "completedTime": "2026-05-12T09:50:41Z",
-              "elapsedTime": 3,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
-            }
-          ],
-          "addtionalDetails": [
-            {
-              "key": "CanIpForward",
-              "value": "false"
-            },
-            {
-              "key": "CpuPlatform",
-              "value": "Intel Broadwell"
-            },
-            {
-              "key": "CreationTimestamp",
-              "value": "2026-05-12T02:49:40.967-07:00"
-            },
-            {
-              "key": "DeletionProtection",
-              "value": "false"
-            },
-            {
-              "key": "Description",
-              "value": "compute sample instance"
-            },
-            {
-              "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sog,type:PERSISTENT}"
-            },
-            {
-              "key": "Fingerprint",
-              "value": "Ze1M2KRQWjk="
-            },
-            {
-              "key": "Id",
-              "value": "1593969242543180123"
-            },
-            {
-              "key": "Kind",
-              "value": "compute#instance"
-            },
-            {
-              "key": "LabelFingerprint",
-              "value": "iFKnnqnIM2k="
-            },
-            {
-              "key": "Labels",
-              "value": "{keypair:tbd81fd466aji65qtg7sfg}"
-            },
-            {
-              "key": "LastStartTimestamp",
-              "value": "2026-05-12T02:49:48.192-07:00"
-            },
-            {
-              "key": "MachineType",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/machineTypes/e2-highcpu-2"
-            },
-            {
-              "key": "Metadata",
-              "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
-            },
-            {
-              "key": "Name",
-              "value": "tbd81ffbm6aji65qtg7sog"
-            },
-            {
-              "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.204.63,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:sB9z5QTR24w=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
-            },
-            {
-              "key": "ResourceStatus",
-              "value": "{effectiveInstanceMetadata:{vmDnsSettingMetadataValue:ZonalOnly}}"
-            },
-            {
-              "key": "SatisfiesPzi",
-              "value": "true"
-            },
-            {
-              "key": "SatisfiesPzs",
-              "value": "false"
-            },
-            {
-              "key": "Scheduling",
-              "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
-            },
-            {
-              "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sog"
-            },
-            {
-              "key": "ServiceAccounts",
-              "value": "{email:MASKED_EMAIL,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
-            },
-            {
-              "key": "ShieldedInstanceConfig",
-              "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
-            },
-            {
-              "key": "ShieldedInstanceIntegrityPolicy",
-              "value": "{updateAutoLearnPolicy:true}"
-            },
-            {
-              "key": "StartRestricted",
-              "value": "false"
-            },
-            {
-              "key": "Status",
-              "value": "RUNNING"
-            },
-            {
-              "key": "Tags",
-              "value": "{fingerprint:wF4QnTxJsgg=,items:[tbd81fd466aji65qtg7sg0]}"
-            },
-            {
-              "key": "Zone",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a"
-            }
-          ]
-        },
-        {
-          "resourceType": "node",
-          "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd81ffbm6aji65qtg7sqg",
-          "cspResourceName": "tbd81ffbm6aji65qtg7sqg",
-          "cspResourceId": "tbd81ffbm6aji65qtg7sqg",
-          "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
-          "location": {
-            "display": "South Korea (Seoul)",
-            "latitude": 37.2,
-            "longitude": 127
-          },
-          "status": "Running",
-          "targetStatus": "None",
-          "targetAction": "None",
-          "monAgentStatus": "notInstalled",
-          "networkAgentStatus": "notInstalled",
-          "systemMessage": "",
-          "createdTime": "2026-05-12 09:50:23",
-          "label": {
-            "keypair": "tbd81fd466aji65qtg7sfg",
-            "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
-            "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-12 09:50:23",
-            "sys.cspResourceId": "tbd81ffbm6aji65qtg7sqg",
-            "sys.cspResourceName": "tbd81ffbm6aji65qtg7sqg",
-            "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "sys.infraId": "my03-infra101",
-            "sys.labelType": "node",
-            "sys.manager": "cb-tumblebug",
-            "sys.name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "sys.namespace": "mig01",
-            "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
-            "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd81ffbm6aji65qtg7sqg",
-            "sys.vNetId": "my03-vnet-01"
-          },
-          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
-          "region": {
-            "region": "asia-northeast3",
-            "zone": "asia-northeast3-a"
-          },
-          "publicIP": "34.50.35.103",
-          "sshPort": 22,
-          "publicDNS": "",
-          "privateIP": "10.0.1.4",
-          "privateDNS": "",
-          "rootDiskType": "pd-standard",
-          "rootDiskSize": 50,
-          "RootDeviceName": "persistent-disk-0",
-          "connectionName": "gcp-asia-northeast3",
-          "connectionConfig": {
-            "configName": "gcp-asia-northeast3",
-            "providerName": "gcp",
-            "driverName": "gcp-driver-v1.0.so",
-            "credentialName": "gcp",
-            "credentialHolder": "admin",
-            "regionZoneInfoName": "gcp-asia-northeast3",
-            "regionZoneInfo": {
-              "assignedRegion": "asia-northeast3",
-              "assignedZone": "asia-northeast3-a"
-            },
-            "regionDetail": {
-              "regionId": "asia-northeast3",
-              "regionName": "asia-northeast3",
-              "description": "Seoul South Korea",
-              "location": {
-                "display": "South Korea (Seoul)",
-                "latitude": 37.2,
-                "longitude": 127
-              },
-              "zones": [
-                "asia-northeast3-a",
-                "asia-northeast3-b",
-                "asia-northeast3-c"
-              ]
-            },
-            "regionRepresentative": true,
-            "verified": true
-          },
-          "specId": "gcp+asia-northeast3+e2-standard-2",
-          "cspSpecName": "e2-standard-2",
-          "spec": {
-            "cspSpecName": "e2-standard-2",
-            "vCPU": 2,
-            "memoryGiB": 7.8125,
-            "costPerHour": 0.085966
-          },
-          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "image": {
-            "resourceType": "image",
-            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-            "osType": "Ubuntu 22.04",
-            "osArchitecture": "x86_64",
-            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
-          },
-          "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
-          "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
-          "networkInterface": "nic0",
-          "securityGroupIds": [
-            "my03-sg-03"
-          ],
-          "dataDiskIds": null,
-          "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
-          "nodeUserName": "cb-user",
-          "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMrtQtDUiUdG1oCzNSF23wNYT9yks/U+HQFM4H8KtWmOJGvHechJow2MM8+ls8Mj14sRKYWxH0DNMkkqnSjkCuA=",
-            "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:ojW1rp6jU49KfmomGDmh3nQeYrjbF3VL5yVCcZ+c6e4",
-            "firstUsedAt": "2026-05-12T09:50:40Z"
-          },
-          "commandStatus": [
-            {
-              "index": 1,
-              "commandRequested": "uname -a",
-              "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-05-12T09:50:38Z",
-              "completedTime": "2026-05-12T09:50:42Z",
-              "elapsedTime": 4,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
-            }
-          ],
-          "addtionalDetails": [
-            {
-              "key": "CanIpForward",
-              "value": "false"
-            },
-            {
-              "key": "CpuPlatform",
-              "value": "Intel Broadwell"
-            },
-            {
-              "key": "CreationTimestamp",
-              "value": "2026-05-12T02:49:42.582-07:00"
-            },
-            {
-              "key": "DeletionProtection",
-              "value": "false"
-            },
-            {
-              "key": "Description",
-              "value": "compute sample instance"
-            },
-            {
-              "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7sqg,type:PERSISTENT}"
-            },
-            {
-              "key": "Fingerprint",
-              "value": "RwAIYtShgo4="
-            },
-            {
-              "key": "Id",
-              "value": "7260017217573439834"
-            },
-            {
-              "key": "Kind",
-              "value": "compute#instance"
-            },
-            {
-              "key": "LabelFingerprint",
-              "value": "iFKnnqnIM2k="
-            },
-            {
-              "key": "Labels",
-              "value": "{keypair:tbd81fd466aji65qtg7sfg}"
-            },
-            {
-              "key": "LastStartTimestamp",
-              "value": "2026-05-12T02:49:49.584-07:00"
-            },
-            {
-              "key": "MachineType",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/machineTypes/e2-standard-2"
-            },
-            {
-              "key": "Metadata",
-              "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
-            },
-            {
-              "key": "Name",
-              "value": "tbd81ffbm6aji65qtg7sqg"
-            },
-            {
-              "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.50.35.103,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lFDLiG6yO5c=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
-            },
-            {
-              "key": "ResourceStatus",
-              "value": "{effectiveInstanceMetadata:{vmDnsSettingMetadataValue:ZonalOnly}}"
-            },
-            {
-              "key": "SatisfiesPzi",
-              "value": "true"
-            },
-            {
-              "key": "SatisfiesPzs",
-              "value": "false"
-            },
-            {
-              "key": "Scheduling",
-              "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
-            },
-            {
-              "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7sqg"
-            },
-            {
-              "key": "ServiceAccounts",
-              "value": "{email:MASKED_EMAIL,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
-            },
-            {
-              "key": "ShieldedInstanceConfig",
-              "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
-            },
-            {
-              "key": "ShieldedInstanceIntegrityPolicy",
-              "value": "{updateAutoLearnPolicy:true}"
-            },
-            {
-              "key": "StartRestricted",
-              "value": "false"
-            },
-            {
-              "key": "Status",
-              "value": "RUNNING"
-            },
-            {
-              "key": "Tags",
-              "value": "{fingerprint:__A_yY_oPbY=,items:[tbd81feh66aji65qtg7sn0]}"
-            },
-            {
-              "key": "Zone",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a"
-            }
-          ]
-        },
-        {
-          "resourceType": "node",
-          "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd81ffbm6aji65qtg7spg",
-          "cspResourceName": "tbd81ffbm6aji65qtg7spg",
-          "cspResourceId": "tbd81ffbm6aji65qtg7spg",
-          "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
-          "location": {
-            "display": "South Korea (Seoul)",
-            "latitude": 37.2,
-            "longitude": 127
-          },
-          "status": "Running",
-          "targetStatus": "None",
-          "targetAction": "None",
-          "monAgentStatus": "notInstalled",
-          "networkAgentStatus": "notInstalled",
-          "systemMessage": "",
-          "createdTime": "2026-05-12 09:50:29",
-          "label": {
-            "keypair": "tbd81fd466aji65qtg7sfg",
-            "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
-            "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-12 09:50:29",
-            "sys.cspResourceId": "tbd81ffbm6aji65qtg7spg",
-            "sys.cspResourceName": "tbd81ffbm6aji65qtg7spg",
-            "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "sys.infraId": "my03-infra101",
-            "sys.labelType": "node",
-            "sys.manager": "cb-tumblebug",
-            "sys.name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "sys.namespace": "mig01",
-            "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
-            "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd81ffbm6aji65qtg7spg",
-            "sys.vNetId": "my03-vnet-01"
-          },
-          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
-          "region": {
-            "region": "asia-northeast3",
-            "zone": "asia-northeast3-a"
-          },
-          "publicIP": "34.64.171.230",
-          "sshPort": 22,
-          "publicDNS": "",
-          "privateIP": "10.0.1.3",
-          "privateDNS": "",
-          "rootDiskType": "pd-standard",
-          "rootDiskSize": 50,
-          "RootDeviceName": "persistent-disk-0",
-          "connectionName": "gcp-asia-northeast3",
-          "connectionConfig": {
-            "configName": "gcp-asia-northeast3",
-            "providerName": "gcp",
-            "driverName": "gcp-driver-v1.0.so",
-            "credentialName": "gcp",
-            "credentialHolder": "admin",
-            "regionZoneInfoName": "gcp-asia-northeast3",
-            "regionZoneInfo": {
-              "assignedRegion": "asia-northeast3",
-              "assignedZone": "asia-northeast3-a"
-            },
-            "regionDetail": {
-              "regionId": "asia-northeast3",
-              "regionName": "asia-northeast3",
-              "description": "Seoul South Korea",
-              "location": {
-                "display": "South Korea (Seoul)",
-                "latitude": 37.2,
-                "longitude": 127
-              },
-              "zones": [
-                "asia-northeast3-a",
-                "asia-northeast3-b",
-                "asia-northeast3-c"
-              ]
-            },
-            "regionRepresentative": true,
-            "verified": true
-          },
-          "specId": "gcp+asia-northeast3+e2-standard-4",
-          "cspSpecName": "e2-standard-4",
-          "spec": {
-            "cspSpecName": "e2-standard-4",
-            "vCPU": 4,
-            "memoryGiB": 15.625,
-            "costPerHour": 0.171931
-          },
-          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "image": {
-            "resourceType": "image",
-            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-            "osType": "Ubuntu 22.04",
-            "osArchitecture": "x86_64",
-            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
-          },
-          "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd81fcrm6aji65qtg7rtg",
-          "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd81fcrm6aji65qtg7ru0",
-          "networkInterface": "nic0",
-          "securityGroupIds": [
-            "my03-sg-02"
-          ],
-          "dataDiskIds": null,
-          "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd81fd466aji65qtg7sfg",
-          "nodeUserName": "cb-user",
-          "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA/tQZO3ieBWPUMFX+hYHM27DS/eAoZostdcDvydt+4hTFJL9NwBs2DC2MUshKS1C57DGaLeOSnC5fzHdoMFkEQ=",
-            "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:AbCogiVk5uz+GX63WbpqC+BrJ6788SV+zEOMIcHYaVk",
-            "firstUsedAt": "2026-05-12T09:50:40Z"
-          },
-          "commandStatus": [
-            {
-              "index": 1,
-              "commandRequested": "uname -a",
-              "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-05-12T09:50:38Z",
-              "completedTime": "2026-05-12T09:50:41Z",
-              "elapsedTime": 3,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
-            }
-          ],
-          "addtionalDetails": [
-            {
-              "key": "CanIpForward",
-              "value": "false"
-            },
-            {
-              "key": "CpuPlatform",
-              "value": "Intel Broadwell"
-            },
-            {
-              "key": "CreationTimestamp",
-              "value": "2026-05-12T02:49:42.308-07:00"
-            },
-            {
-              "key": "DeletionProtection",
-              "value": "false"
-            },
-            {
-              "key": "Description",
-              "value": "compute sample instance"
-            },
-            {
-              "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:50,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd81ffbm6aji65qtg7spg,type:PERSISTENT}"
-            },
-            {
-              "key": "Fingerprint",
-              "value": "cE_0TgthpVs="
-            },
-            {
-              "key": "Id",
-              "value": "8588388900726065497"
-            },
-            {
-              "key": "Kind",
-              "value": "compute#instance"
-            },
-            {
-              "key": "LabelFingerprint",
-              "value": "iFKnnqnIM2k="
-            },
-            {
-              "key": "Labels",
-              "value": "{keypair:tbd81fd466aji65qtg7sfg}"
-            },
-            {
-              "key": "LastStartTimestamp",
-              "value": "2026-05-12T02:49:53.483-07:00"
-            },
-            {
-              "key": "MachineType",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/machineTypes/e2-standard-4"
-            },
-            {
-              "key": "Metadata",
-              "value": "{fingerprint:DhKU-Pa8YKE=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyVsgErpu0gFPitLeNhIXp/RVCVF0Hy5WpW2MIOXS19f40s0vp1Ulwyl9rTgZU4u0+QPr0kT5atZVuDirnjctHAhd4M+Qh2pU0W2VgB1Cl/nQ/E+ch5stLZ1p/CREIUOq7H/Il89tbIys11DdULFC8cuj7xMDcmNiU4lRcqRl3ZcUz5v6pIpPa1ap39m+VECADtDYRXWRUTYA64UmgkfsRlqN+B9uCQC3C4plaAlKAgpN6D16g65S+eN64M02UnJgf5LpvlhQphg3VkTtG1tl8yCCztqOjL+ofqIGCuxAaRZpLzs37DVFRNOJhYx+iQjU4raRSAazv89o+Q2ksLq/sLvkDuR4HUm5utPFwC6nluv9w7T2b5Zx2p1A38H8GTSKhJ9x1kDwV8iSPfuI+sqFqiaNlUI9aC3I1V26pLTk9CA8nwWiJdEXB9gJeYT4Yhan8DVIPtXVE5sd2o6DIJnKuACxsrlbkR2eY/OQEnv/jUX8PdVz6i86Xvi0Qo5yopXR9reQ6kfHSmbbuwyXMwP31M2h7QZfDR6hqndH1XSv4scbErfwmu7bh/rhtATxnLIfLjkA/KSszMEZ7i2xMp70bg2YrE52tio2pSRgvfnXvLyOn5YPy36hV8TAxcNoGydlHoN+HxnwCAcwP0qWP1MFYaHoipC1J59HZEmS1ha0/4Q== cb-user}],kind:compute#metadata}"
-            },
-            {
-              "key": "Name",
-              "value": "tbd81ffbm6aji65qtg7spg"
-            },
-            {
-              "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.171.230,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:N1qJzSGLvnY=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd81fcrm6aji65qtg7rtg,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd81fcrm6aji65qtg7ru0}"
-            },
-            {
-              "key": "ResourceStatus",
-              "value": "{effectiveInstanceMetadata:{vmDnsSettingMetadataValue:ZonalOnly}}"
-            },
-            {
-              "key": "SatisfiesPzi",
-              "value": "true"
-            },
-            {
-              "key": "SatisfiesPzs",
-              "value": "false"
-            },
-            {
-              "key": "Scheduling",
-              "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
-            },
-            {
-              "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd81ffbm6aji65qtg7spg"
-            },
-            {
-              "key": "ServiceAccounts",
-              "value": "{email:MASKED_EMAIL,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
-            },
-            {
-              "key": "ShieldedInstanceConfig",
-              "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
-            },
-            {
-              "key": "ShieldedInstanceIntegrityPolicy",
-              "value": "{updateAutoLearnPolicy:true}"
-            },
-            {
-              "key": "StartRestricted",
-              "value": "false"
-            },
-            {
-              "key": "Status",
-              "value": "RUNNING"
-            },
-            {
-              "key": "Tags",
-              "value": "{fingerprint:Y3tH5grMsBg=,items:[tbd81fdnm6aji65qtg7sh0]}"
-            },
-            {
-              "key": "Zone",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a"
-            }
-          ]
-        }
-      ],
-      "newNodeList": null,
-      "postCommand": {
-        "userName": "cb-user",
-        "command": [
-          "uname -a"
-        ]
-      },
-      "postCommandResult": {
-        "results": [
-          {
-            "infraId": "my03-infra101",
-            "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "34.158.204.63",
-            "command": {
-              "0": "uname -a"
-            },
-            "stdout": {
-              "0": "Linux tbd81ffbm6aji65qtg7sog 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
-            "err": null
-          },
-          {
-            "infraId": "my03-infra101",
-            "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "34.64.171.230",
-            "command": {
-              "0": "uname -a"
-            },
-            "stdout": {
-              "0": "Linux tbd81ffbm6aji65qtg7spg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
-            "err": null
-          },
-          {
-            "infraId": "my03-infra101",
-            "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "34.50.35.103",
-            "command": {
-              "0": "uname -a"
-            },
-            "stdout": {
-              "0": "Linux tbd81ffbm6aji65qtg7sqg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
-            "err": null
-          }
-        ]
-      }
-    },
-    {
-      "resourceType": "infra",
-      "id": "my04-infra101",
-      "uid": "tbd81fe7e6aji65qtg7si0",
-      "name": "my04-infra101",
-      "status": "Running:3 (R:3/3)",
-      "statusCount": {
-        "countTotal": 3,
-        "countCreating": 0,
-        "countRunning": 3,
-        "countFailed": 0,
-        "countSuspended": 0,
-        "countRebooting": 0,
-        "countTerminated": 0,
-        "countSuspending": 0,
-        "countResuming": 0,
-        "countTerminating": 0,
-        "countRegistering": 0,
-        "countUndefined": 0
-      },
-      "targetStatus": "None",
-      "targetAction": "None",
-      "installMonAgent": "",
-      "configureCloudAdaptiveNetwork": "",
-      "label": {
-        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
-        "sys.id": "my04-infra101",
-        "sys.labelType": "infra",
-        "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-infra101",
-        "sys.namespace": "mig01",
-        "sys.uid": "tbd81fe7e6aji65qtg7si0"
-      },
-      "systemLabel": "",
-      "systemMessage": null,
-      "description": "Recommended VMs comprising multi-cloud infrastructure",
-      "node": [
-        {
-          "resourceType": "node",
-          "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd81fe7m6aji65qtg7sj0",
-          "cspResourceName": "tbd81fe7m6aji65qtg7sj0",
-          "cspResourceId": "138234481",
-          "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbd85ch6epr9ha6omvqjmg",
+          "cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+          "cspResourceId": "138993641",
+          "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
             "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
             "latitude": 37.4754,
@@ -5437,33 +4607,33 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:51:22",
+          "createdTime": "2026-05-18 08:10:58",
           "label": {
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "ncp-kr",
-            "sys.createdTime": "2026-05-12 09:51:22",
-            "sys.cspResourceId": "138234481",
-            "sys.cspResourceName": "tbd81fe7m6aji65qtg7sj0",
-            "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "sys.infraId": "my04-infra101",
+            "sys.createdTime": "2026-05-18 08:10:58",
+            "sys.cspResourceId": "138993641",
+            "sys.cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+            "sys.id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.infraId": "my08-infra101",
             "sys.labelType": "node",
             "sys.manager": "cb-tumblebug",
-            "sys.name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.namespace": "mig01",
-            "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
-            "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd81fe7m6aji65qtg7sj0",
-            "sys.vNetId": "my04-vnet-01"
+            "sys.nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.subnetId": "my08-subnet-01",
+            "sys.uid": "tbd85ch6epr9ha6omvqjmg",
+            "sys.vNetId": "my08-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=50.0% Image=75.0%",
           "region": {
             "region": "KR",
             "zone": "KR-1"
           },
-          "publicIP": "101.79.19.173",
+          "publicIP": "223.130.156.82",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.8",
+          "privateIP": "10.0.1.7",
           "privateDNS": "",
           "rootDiskType": "HDD",
           "rootDiskSize": 50,
@@ -5514,23 +4684,23 @@
             "osArchitecture": "x86_64",
             "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
           },
-          "vNetId": "my04-vnet-01",
-          "cspVNetId": "138792",
-          "subnetId": "my04-subnet-01",
-          "cspSubnetId": "300131",
+          "vNetId": "my08-vnet-01",
+          "cspVNetId": "139135",
+          "subnetId": "my08-subnet-01",
+          "cspSubnetId": "300855",
           "networkInterface": "eth0",
           "securityGroupIds": [
-            "my04-sg-01"
+            "my08-sg-01"
           ],
           "dataDiskIds": null,
-          "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+          "sshKeyId": "my08-sshkey-01",
+          "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
             "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
             "keyType": "ecdsa-sha2-nistp256",
             "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-            "firstUsedAt": "2026-05-12T09:51:28Z"
+            "firstUsedAt": "2026-05-18T08:11:04Z"
           },
           "commandStatus": [
             {
@@ -5538,22 +4708,22 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:51:27Z",
-              "completedTime": "2026-05-12T09:51:28Z",
-              "elapsedTime": 1,
+              "startedTime": "2026-05-18T08:11:03Z",
+              "completedTime": "2026-05-18T08:11:05Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81fe7m6aji65qtg7sj0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
           "addtionalDetails": [
             {
               "key": "ServerInstanceNo",
-              "value": "138234481"
+              "value": "138993641"
             },
             {
               "key": "ServerName",
-              "value": "tbd81fe7m6aji65qtg7sj0"
+              "value": "tbd85ch6epr9ha6omvqjmg"
             },
             {
               "key": "CpuCount",
@@ -5569,7 +4739,7 @@
             },
             {
               "key": "LoginKeyName",
-              "value": "tbd81fd3e6aji65qtg7seg"
+              "value": "tbd85cg56pr9ha6omvqjj0"
             },
             {
               "key": "ServerInstanceStatus",
@@ -5585,11 +4755,11 @@
             },
             {
               "key": "CreateDate",
-              "value": "2026-05-12T18:47:18+0900"
+              "value": "2026-05-18T17:06:55+0900"
             },
             {
               "key": "Uptime",
-              "value": "2026-05-12T18:49:31+0900"
+              "value": "2026-05-18T17:09:13+0900"
             },
             {
               "key": "ServerImageProductCode",
@@ -5613,19 +4783,19 @@
             },
             {
               "key": "VpcNo",
-              "value": "138792"
+              "value": "139135"
             },
             {
               "key": "SubnetNo",
-              "value": "300131"
+              "value": "300855"
             },
             {
               "key": "NetworkInterfaceNoList",
-              "value": "5678079"
+              "value": "5694779"
             },
             {
               "key": "InitScriptNo",
-              "value": "170941"
+              "value": "171473"
             },
             {
               "key": "ServerInstanceType",
@@ -5655,12 +4825,12 @@
         },
         {
           "resourceType": "node",
-          "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd81fe7m6aji65qtg7sl0",
-          "cspResourceName": "tbd81fe7m6aji65qtg7sl0",
-          "cspResourceId": "138234474",
-          "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd85ch6epr9ha6omvqjog",
+          "cspResourceName": "tbd85ch6epr9ha6omvqjog",
+          "cspResourceId": "138993649",
+          "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
             "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
             "latitude": 37.4754,
@@ -5672,33 +4842,33 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:51:10",
+          "createdTime": "2026-05-18 08:10:58",
           "label": {
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "ncp-kr",
-            "sys.createdTime": "2026-05-12 09:51:10",
-            "sys.cspResourceId": "138234474",
-            "sys.cspResourceName": "tbd81fe7m6aji65qtg7sl0",
-            "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "sys.infraId": "my04-infra101",
+            "sys.createdTime": "2026-05-18 08:10:58",
+            "sys.cspResourceId": "138993649",
+            "sys.cspResourceName": "tbd85ch6epr9ha6omvqjog",
+            "sys.id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.infraId": "my08-infra101",
             "sys.labelType": "node",
             "sys.manager": "cb-tumblebug",
-            "sys.name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.namespace": "mig01",
-            "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
-            "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd81fe7m6aji65qtg7sl0",
-            "sys.vNetId": "my04-vnet-01"
+            "sys.nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.subnetId": "my08-subnet-01",
+            "sys.uid": "tbd85ch6epr9ha6omvqjog",
+            "sys.vNetId": "my08-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
           "region": {
             "region": "KR",
             "zone": "KR-1"
           },
-          "publicIP": "101.79.20.23",
+          "publicIP": "101.79.20.97",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.7",
+          "privateIP": "10.0.1.8",
           "privateDNS": "",
           "rootDiskType": "HDD",
           "rootDiskSize": 50,
@@ -5749,23 +4919,23 @@
             "osArchitecture": "x86_64",
             "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
           },
-          "vNetId": "my04-vnet-01",
-          "cspVNetId": "138792",
-          "subnetId": "my04-subnet-01",
-          "cspSubnetId": "300131",
+          "vNetId": "my08-vnet-01",
+          "cspVNetId": "139135",
+          "subnetId": "my08-subnet-01",
+          "cspSubnetId": "300855",
           "networkInterface": "eth0",
           "securityGroupIds": [
-            "my04-sg-03"
+            "my08-sg-03"
           ],
           "dataDiskIds": null,
-          "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+          "sshKeyId": "my08-sshkey-01",
+          "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
             "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
             "keyType": "ecdsa-sha2-nistp256",
             "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-            "firstUsedAt": "2026-05-12T09:51:28Z"
+            "firstUsedAt": "2026-05-18T08:11:04Z"
           },
           "commandStatus": [
             {
@@ -5773,22 +4943,22 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:51:27Z",
-              "completedTime": "2026-05-12T09:51:28Z",
-              "elapsedTime": 1,
+              "startedTime": "2026-05-18T08:11:03Z",
+              "completedTime": "2026-05-18T08:11:05Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81fe7m6aji65qtg7sl0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
           "addtionalDetails": [
             {
               "key": "ServerInstanceNo",
-              "value": "138234474"
+              "value": "138993649"
             },
             {
               "key": "ServerName",
-              "value": "tbd81fe7m6aji65qtg7sl0"
+              "value": "tbd85ch6epr9ha6omvqjog"
             },
             {
               "key": "CpuCount",
@@ -5804,7 +4974,7 @@
             },
             {
               "key": "LoginKeyName",
-              "value": "tbd81fd3e6aji65qtg7seg"
+              "value": "tbd85cg56pr9ha6omvqjj0"
             },
             {
               "key": "ServerInstanceStatus",
@@ -5820,11 +4990,11 @@
             },
             {
               "key": "CreateDate",
-              "value": "2026-05-12T18:47:18+0900"
+              "value": "2026-05-18T17:06:58+0900"
             },
             {
               "key": "Uptime",
-              "value": "2026-05-12T18:49:31+0900"
+              "value": "2026-05-18T17:09:11+0900"
             },
             {
               "key": "ServerImageProductCode",
@@ -5848,19 +5018,19 @@
             },
             {
               "key": "VpcNo",
-              "value": "138792"
+              "value": "139135"
             },
             {
               "key": "SubnetNo",
-              "value": "300131"
+              "value": "300855"
             },
             {
               "key": "NetworkInterfaceNoList",
-              "value": "5678078"
+              "value": "5694780"
             },
             {
               "key": "InitScriptNo",
-              "value": "170940"
+              "value": "171474"
             },
             {
               "key": "ServerInstanceType",
@@ -5890,12 +5060,12 @@
         },
         {
           "resourceType": "node",
-          "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd81fe7m6aji65qtg7sk0",
-          "cspResourceName": "tbd81fe7m6aji65qtg7sk0",
-          "cspResourceId": "138234467",
-          "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbd85ch6epr9ha6omvqjng",
+          "cspResourceName": "tbd85ch6epr9ha6omvqjng",
+          "cspResourceId": "138993635",
+          "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
             "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
             "latitude": 37.4754,
@@ -5907,30 +5077,30 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-12 09:50:58",
+          "createdTime": "2026-05-18 08:10:47",
           "label": {
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "ncp-kr",
-            "sys.createdTime": "2026-05-12 09:50:58",
-            "sys.cspResourceId": "138234467",
-            "sys.cspResourceName": "tbd81fe7m6aji65qtg7sk0",
-            "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "sys.infraId": "my04-infra101",
+            "sys.createdTime": "2026-05-18 08:10:47",
+            "sys.cspResourceId": "138993635",
+            "sys.cspResourceName": "tbd85ch6epr9ha6omvqjng",
+            "sys.id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.infraId": "my08-infra101",
             "sys.labelType": "node",
             "sys.manager": "cb-tumblebug",
-            "sys.name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.namespace": "mig01",
-            "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
-            "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd81fe7m6aji65qtg7sk0",
-            "sys.vNetId": "my04-vnet-01"
+            "sys.nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.subnetId": "my08-subnet-01",
+            "sys.uid": "tbd85ch6epr9ha6omvqjng",
+            "sys.vNetId": "my08-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
           "region": {
             "region": "KR",
             "zone": "KR-1"
           },
-          "publicIP": "101.79.19.56",
+          "publicIP": "101.79.16.239",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.6",
@@ -5984,23 +5154,23 @@
             "osArchitecture": "x86_64",
             "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
           },
-          "vNetId": "my04-vnet-01",
-          "cspVNetId": "138792",
-          "subnetId": "my04-subnet-01",
-          "cspSubnetId": "300131",
+          "vNetId": "my08-vnet-01",
+          "cspVNetId": "139135",
+          "subnetId": "my08-subnet-01",
+          "cspSubnetId": "300855",
           "networkInterface": "eth0",
           "securityGroupIds": [
-            "my04-sg-02"
+            "my08-sg-02"
           ],
           "dataDiskIds": null,
-          "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+          "sshKeyId": "my08-sshkey-01",
+          "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
             "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
             "keyType": "ecdsa-sha2-nistp256",
             "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-            "firstUsedAt": "2026-05-12T09:51:27Z"
+            "firstUsedAt": "2026-05-18T08:11:03Z"
           },
           "commandStatus": [
             {
@@ -6008,22 +5178,22 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-12T09:51:27Z",
-              "completedTime": "2026-05-12T09:51:28Z",
+              "startedTime": "2026-05-18T08:11:03Z",
+              "completedTime": "2026-05-18T08:11:04Z",
               "elapsedTime": 1,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd81fe7m6aji65qtg7sk0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
           "addtionalDetails": [
             {
               "key": "ServerInstanceNo",
-              "value": "138234467"
+              "value": "138993635"
             },
             {
               "key": "ServerName",
-              "value": "tbd81fe7m6aji65qtg7sk0"
+              "value": "tbd85ch6epr9ha6omvqjng"
             },
             {
               "key": "CpuCount",
@@ -6039,7 +5209,7 @@
             },
             {
               "key": "LoginKeyName",
-              "value": "tbd81fd3e6aji65qtg7seg"
+              "value": "tbd85cg56pr9ha6omvqjj0"
             },
             {
               "key": "ServerInstanceStatus",
@@ -6055,11 +5225,11 @@
             },
             {
               "key": "CreateDate",
-              "value": "2026-05-12T18:47:18+0900"
+              "value": "2026-05-18T17:06:54+0900"
             },
             {
               "key": "Uptime",
-              "value": "2026-05-12T18:49:23+0900"
+              "value": "2026-05-18T17:09:08+0900"
             },
             {
               "key": "ServerImageProductCode",
@@ -6083,19 +5253,19 @@
             },
             {
               "key": "VpcNo",
-              "value": "138792"
+              "value": "139135"
             },
             {
               "key": "SubnetNo",
-              "value": "300131"
+              "value": "300855"
             },
             {
               "key": "NetworkInterfaceNoList",
-              "value": "5678077"
+              "value": "5694778"
             },
             {
               "key": "InitScriptNo",
-              "value": "170939"
+              "value": "171472"
             },
             {
               "key": "ServerInstanceType",
@@ -6134,14 +5304,14 @@
       "postCommandResult": {
         "results": [
           {
-            "infraId": "my04-infra101",
-            "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "101.79.19.56",
+            "infraId": "my08-infra101",
+            "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "101.79.16.239",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81fe7m6aji65qtg7sk0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6149,14 +5319,14 @@
             "err": null
           },
           {
-            "infraId": "my04-infra101",
-            "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "101.79.20.23",
+            "infraId": "my08-infra101",
+            "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "101.79.20.97",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81fe7m6aji65qtg7sl0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6164,14 +5334,14 @@
             "err": null
           },
           {
-            "infraId": "my04-infra101",
-            "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "101.79.19.173",
+            "infraId": "my08-infra101",
+            "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "223.130.156.82",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd81fe7m6aji65qtg7sj0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6205,8 +5375,7 @@
 ```json
 {
   "idList": [
-    "my03-infra101",
-    "my04-infra101"
+    "my08-infra101"
   ]
 }
 ```
@@ -6234,9 +5403,9 @@
 ```json
 {
   "resourceType": "infra",
-  "id": "my04-infra101",
-  "uid": "tbd81fe7e6aji65qtg7si0",
-  "name": "my04-infra101",
+  "id": "my08-infra101",
+  "uid": "tbd85ch6epr9ha6omvqjlg",
+  "name": "my08-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
     "countTotal": 3,
@@ -6258,12 +5427,12 @@
   "configureCloudAdaptiveNetwork": "",
   "label": {
     "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
-    "sys.id": "my04-infra101",
+    "sys.id": "my08-infra101",
     "sys.labelType": "infra",
     "sys.manager": "cb-tumblebug",
-    "sys.name": "my04-infra101",
+    "sys.name": "my08-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd81fe7e6aji65qtg7si0"
+    "sys.uid": "tbd85ch6epr9ha6omvqjlg"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -6271,12 +5440,12 @@
   "node": [
     {
       "resourceType": "node",
-      "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd81fe7m6aji65qtg7sj0",
-      "cspResourceName": "tbd81fe7m6aji65qtg7sj0",
-      "cspResourceId": "138234481",
-      "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+      "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+      "uid": "tbd85ch6epr9ha6omvqjmg",
+      "cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+      "cspResourceId": "138993641",
+      "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+      "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -6288,33 +5457,33 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:51:22",
+      "createdTime": "2026-05-18 08:10:58",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-12 09:51:22",
-        "sys.cspResourceId": "138234481",
-        "sys.cspResourceName": "tbd81fe7m6aji65qtg7sj0",
-        "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "sys.infraId": "my04-infra101",
+        "sys.createdTime": "2026-05-18 08:10:58",
+        "sys.cspResourceId": "138993641",
+        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+        "sys.id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "sys.name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.namespace": "mig01",
-        "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
-        "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd81fe7m6aji65qtg7sj0",
-        "sys.vNetId": "my04-vnet-01"
+        "sys.nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
+        "sys.subnetId": "my08-subnet-01",
+        "sys.uid": "tbd85ch6epr9ha6omvqjmg",
+        "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=50.0% Image=75.0%",
       "region": {
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.19.173",
+      "publicIP": "223.130.156.82",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.8",
+      "privateIP": "10.0.1.7",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -6365,23 +5534,23 @@
         "osArchitecture": "x86_64",
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
-      "vNetId": "my04-vnet-01",
-      "cspVNetId": "138792",
-      "subnetId": "my04-subnet-01",
-      "cspSubnetId": "300131",
+      "vNetId": "my08-vnet-01",
+      "cspVNetId": "139135",
+      "subnetId": "my08-subnet-01",
+      "cspSubnetId": "300855",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "my04-sg-01"
+        "my08-sg-01"
       ],
       "dataDiskIds": null,
-      "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+      "sshKeyId": "my08-sshkey-01",
+      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-12T09:51:28Z"
+        "firstUsedAt": "2026-05-18T08:11:04Z"
       },
       "commandStatus": [
         {
@@ -6389,22 +5558,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:51:27Z",
-          "completedTime": "2026-05-12T09:51:28Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:11:03Z",
+          "completedTime": "2026-05-18T08:11:05Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fe7m6aji65qtg7sj0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138234481"
+          "value": "138993641"
         },
         {
           "key": "ServerName",
-          "value": "tbd81fe7m6aji65qtg7sj0"
+          "value": "tbd85ch6epr9ha6omvqjmg"
         },
         {
           "key": "CpuCount",
@@ -6420,7 +5589,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd81fd3e6aji65qtg7seg"
+          "value": "tbd85cg56pr9ha6omvqjj0"
         },
         {
           "key": "ServerInstanceStatus",
@@ -6436,11 +5605,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-12T18:47:18+0900"
+          "value": "2026-05-18T17:06:55+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-12T18:49:31+0900"
+          "value": "2026-05-18T17:09:13+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -6464,19 +5633,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "138792"
+          "value": "139135"
         },
         {
           "key": "SubnetNo",
-          "value": "300131"
+          "value": "300855"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5678079"
+          "value": "5694779"
         },
         {
           "key": "InitScriptNo",
-          "value": "170941"
+          "value": "171473"
         },
         {
           "key": "ServerInstanceType",
@@ -6506,12 +5675,12 @@
     },
     {
       "resourceType": "node",
-      "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd81fe7m6aji65qtg7sl0",
-      "cspResourceName": "tbd81fe7m6aji65qtg7sl0",
-      "cspResourceId": "138234474",
-      "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+      "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+      "uid": "tbd85ch6epr9ha6omvqjog",
+      "cspResourceName": "tbd85ch6epr9ha6omvqjog",
+      "cspResourceId": "138993649",
+      "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+      "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -6523,33 +5692,33 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:51:10",
+      "createdTime": "2026-05-18 08:10:58",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-12 09:51:10",
-        "sys.cspResourceId": "138234474",
-        "sys.cspResourceName": "tbd81fe7m6aji65qtg7sl0",
-        "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "sys.infraId": "my04-infra101",
+        "sys.createdTime": "2026-05-18 08:10:58",
+        "sys.cspResourceId": "138993649",
+        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjog",
+        "sys.id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "sys.name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.namespace": "mig01",
-        "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
-        "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd81fe7m6aji65qtg7sl0",
-        "sys.vNetId": "my04-vnet-01"
+        "sys.nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+        "sys.subnetId": "my08-subnet-01",
+        "sys.uid": "tbd85ch6epr9ha6omvqjog",
+        "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
       "region": {
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.20.23",
+      "publicIP": "101.79.20.97",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.7",
+      "privateIP": "10.0.1.8",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -6600,23 +5769,23 @@
         "osArchitecture": "x86_64",
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
-      "vNetId": "my04-vnet-01",
-      "cspVNetId": "138792",
-      "subnetId": "my04-subnet-01",
-      "cspSubnetId": "300131",
+      "vNetId": "my08-vnet-01",
+      "cspVNetId": "139135",
+      "subnetId": "my08-subnet-01",
+      "cspSubnetId": "300855",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "my04-sg-03"
+        "my08-sg-03"
       ],
       "dataDiskIds": null,
-      "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+      "sshKeyId": "my08-sshkey-01",
+      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-12T09:51:28Z"
+        "firstUsedAt": "2026-05-18T08:11:04Z"
       },
       "commandStatus": [
         {
@@ -6624,22 +5793,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:51:27Z",
-          "completedTime": "2026-05-12T09:51:28Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-05-18T08:11:03Z",
+          "completedTime": "2026-05-18T08:11:05Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fe7m6aji65qtg7sl0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138234474"
+          "value": "138993649"
         },
         {
           "key": "ServerName",
-          "value": "tbd81fe7m6aji65qtg7sl0"
+          "value": "tbd85ch6epr9ha6omvqjog"
         },
         {
           "key": "CpuCount",
@@ -6655,7 +5824,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd81fd3e6aji65qtg7seg"
+          "value": "tbd85cg56pr9ha6omvqjj0"
         },
         {
           "key": "ServerInstanceStatus",
@@ -6671,11 +5840,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-12T18:47:18+0900"
+          "value": "2026-05-18T17:06:58+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-12T18:49:31+0900"
+          "value": "2026-05-18T17:09:11+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -6699,19 +5868,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "138792"
+          "value": "139135"
         },
         {
           "key": "SubnetNo",
-          "value": "300131"
+          "value": "300855"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5678078"
+          "value": "5694780"
         },
         {
           "key": "InitScriptNo",
-          "value": "170940"
+          "value": "171474"
         },
         {
           "key": "ServerInstanceType",
@@ -6741,12 +5910,12 @@
     },
     {
       "resourceType": "node",
-      "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd81fe7m6aji65qtg7sk0",
-      "cspResourceName": "tbd81fe7m6aji65qtg7sk0",
-      "cspResourceId": "138234467",
-      "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+      "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+      "uid": "tbd85ch6epr9ha6omvqjng",
+      "cspResourceName": "tbd85ch6epr9ha6omvqjng",
+      "cspResourceId": "138993635",
+      "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+      "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
         "display": "Seoul(Gasan) / Pyeongchon (South Korea)",
         "latitude": 37.4754,
@@ -6758,30 +5927,30 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-12 09:50:58",
+      "createdTime": "2026-05-18 08:10:47",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-12 09:50:58",
-        "sys.cspResourceId": "138234467",
-        "sys.cspResourceName": "tbd81fe7m6aji65qtg7sk0",
-        "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "sys.infraId": "my04-infra101",
+        "sys.createdTime": "2026-05-18 08:10:47",
+        "sys.cspResourceId": "138993635",
+        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjng",
+        "sys.id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
         "sys.manager": "cb-tumblebug",
-        "sys.name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "sys.name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.namespace": "mig01",
-        "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
-        "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbd81fe7m6aji65qtg7sk0",
-        "sys.vNetId": "my04-vnet-01"
+        "sys.nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+        "sys.subnetId": "my08-subnet-01",
+        "sys.uid": "tbd85ch6epr9ha6omvqjng",
+        "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
       "region": {
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.19.56",
+      "publicIP": "101.79.16.239",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.6",
@@ -6835,23 +6004,23 @@
         "osArchitecture": "x86_64",
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
-      "vNetId": "my04-vnet-01",
-      "cspVNetId": "138792",
-      "subnetId": "my04-subnet-01",
-      "cspSubnetId": "300131",
+      "vNetId": "my08-vnet-01",
+      "cspVNetId": "139135",
+      "subnetId": "my08-subnet-01",
+      "cspSubnetId": "300855",
       "networkInterface": "eth0",
       "securityGroupIds": [
-        "my04-sg-02"
+        "my08-sg-02"
       ],
       "dataDiskIds": null,
-      "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbd81fd3e6aji65qtg7seg",
+      "sshKeyId": "my08-sshkey-01",
+      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-12T09:51:27Z"
+        "firstUsedAt": "2026-05-18T08:11:03Z"
       },
       "commandStatus": [
         {
@@ -6859,22 +6028,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-12T09:51:27Z",
-          "completedTime": "2026-05-12T09:51:28Z",
+          "startedTime": "2026-05-18T08:11:03Z",
+          "completedTime": "2026-05-18T08:11:04Z",
           "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd81fe7m6aji65qtg7sk0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138234467"
+          "value": "138993635"
         },
         {
           "key": "ServerName",
-          "value": "tbd81fe7m6aji65qtg7sk0"
+          "value": "tbd85ch6epr9ha6omvqjng"
         },
         {
           "key": "CpuCount",
@@ -6890,7 +6059,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd81fd3e6aji65qtg7seg"
+          "value": "tbd85cg56pr9ha6omvqjj0"
         },
         {
           "key": "ServerInstanceStatus",
@@ -6906,11 +6075,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-12T18:47:18+0900"
+          "value": "2026-05-18T17:06:54+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-12T18:49:23+0900"
+          "value": "2026-05-18T17:09:08+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -6934,19 +6103,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "138792"
+          "value": "139135"
         },
         {
           "key": "SubnetNo",
-          "value": "300131"
+          "value": "300855"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5678077"
+          "value": "5694778"
         },
         {
           "key": "InitScriptNo",
-          "value": "170939"
+          "value": "171472"
         },
         {
           "key": "ServerInstanceType",
@@ -6985,14 +6154,14 @@
   "postCommandResult": {
     "results": [
       {
-        "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "101.79.19.56",
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "101.79.16.239",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fe7m6aji65qtg7sk0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7000,14 +6169,14 @@
         "err": null
       },
       {
-        "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "101.79.20.23",
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "101.79.20.97",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fe7m6aji65qtg7sl0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7015,14 +6184,14 @@
         "err": null
       },
       {
-        "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "101.79.19.173",
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "223.130.156.82",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd81fe7m6aji65qtg7sj0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7078,10 +6247,10 @@
     {
       "attempts": 1,
       "command": "uname -a",
-      "nodeGroup": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
-      "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux tbd81fe7m6aji65qtg7sj0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "101.79.19.173",
+      "nodeGroup": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
+      "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+      "output": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "223.130.156.82",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -7090,10 +6259,10 @@
     {
       "attempts": 1,
       "command": "uname -a",
-      "nodeGroup": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
-      "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux tbd81fe7m6aji65qtg7sl0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "101.79.20.23",
+      "nodeGroup": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+      "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+      "output": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "101.79.20.97",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -7102,10 +6271,10 @@
     {
       "attempts": 1,
       "command": "uname -a",
-      "nodeGroup": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
-      "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux tbd81fe7m6aji65qtg7sk0 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "101.79.19.56",
+      "nodeGroup": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+      "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+      "output": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "101.79.16.239",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -7135,11 +6304,11 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-12 09:52:07
+**Generated At:** 2026-05-18 08:11:39
 
 **Namespace:** mig01
 
-**Infra Name:** my04-infra101
+**Infra Name:** my08-infra101
 
 ---
 
@@ -7147,7 +6316,7 @@
 
 | Property | Value |
 |----------|-------|
-| **Infra Name** | my04-infra101 |
+| **Infra Name** | my08-infra101 |
 | **Description** | Recommended VMs comprising multi-cloud infrastructure |
 | **Status** | Running:3 (R:3/3) |
 | **Target Cloud** | NCP |
@@ -7177,21 +6346,21 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 138234481 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 101.79.19.173<br>**Private IP:** 10.0.1.8<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 138234474 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 101.79.20.23<br>**Private IP:** 10.0.1.7<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 138234467 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 101.79.19.56<br>**Private IP:** 10.0.1.6<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
+| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 138993641 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 223.130.156.82<br>**Private IP:** 10.0.1.7<br>**SGs:** my08-sg-01<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 138993649 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.20.97<br>**Private IP:** 10.0.1.8<br>**SGs:** my08-sg-03<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 138993635 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.16.239<br>**Private IP:** 10.0.1.6<br>**SGs:** my08-sg-02<br>**SSH:** my08-sshkey-01 |
 
 
 ## Network Resources
 
 ### Virtual Networks (VPC/VNet)
 
-#### VNet: my04-vnet-01
+#### VNet: my08-vnet-01
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-vnet-01 |
-| **CSP VNet ID** | 138792 |
+| **Name** | my08-vnet-01 |
+| **CSP VNet ID** | 139135 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | ncp-kr |
 | **Subnet Count** | 1 |
@@ -7200,7 +6369,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my04-subnet-01 | 300131 | 10.0.1.0/24 | KR-1 |
+| my08-subnet-01 | 300855 | 10.0.1.0/24 | KR-1 |
 
 
 ## Security Resources
@@ -7209,17 +6378,17 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my04-sshkey-01 | tbd81fd3e6aji65qtg7seg | cb-user |  |
+| my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 | cb-user |  |
 
 ### Security Groups
 
-#### Security Group: my04-sg-01
+#### Security Group: my08-sg-01
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-sg-01 |
-| **CSP Security Group ID** | 352888 |
-| **VNet** | my04-vnet-01 |
+| **Name** | my08-sg-01 |
+| **CSP Security Group ID** | 353896 |
+| **VNet** | my08-vnet-01 |
 | **Rule Count** | 15 rules |
 
 **Security Group Rules:**
@@ -7242,13 +6411,13 @@
 | outbound | UDP | 1-65535 | 0.0.0.0/0 |
 | outbound | TCP | 1-65535 | 0.0.0.0/0 |
 
-#### Security Group: my04-sg-02
+#### Security Group: my08-sg-02
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-sg-02 |
-| **CSP Security Group ID** | 352889 |
-| **VNet** | my04-vnet-01 |
+| **Name** | my08-sg-02 |
+| **CSP Security Group ID** | 353897 |
+| **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
 **Security Group Rules:**
@@ -7276,13 +6445,13 @@
 | outbound | UDP | 1-65535 | 0.0.0.0/0 |
 | outbound | TCP | 1-65535 | 0.0.0.0/0 |
 
-#### Security Group: my04-sg-03
+#### Security Group: my08-sg-03
 
 | Property | Value |
 |----------|-------|
-| **Name** | my04-sg-03 |
-| **CSP Security Group ID** | 352890 |
-| **VNet** | my04-vnet-01 |
+| **Name** | my08-sg-03 |
+| **CSP Security Group ID** | 353898 |
+| **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
 **Security Group Rules:**
@@ -7331,9 +6500,9 @@
 
 | VM Name | Spec | Cost/Hour (USD) | Cost/Month (USD) |
 |---------|------|-----------------|------------------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | ci2-g3 | $0.0730 | $52.56 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3a | $0.0848 | $61.06 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | s4-g3a | $0.1747 | $125.78 |
+| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | ci2-g3 | $0.0730 | $52.56 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3a | $0.0848 | $61.06 |
+| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | s4-g3a | $0.1747 | $125.78 |
 
 
 
@@ -7357,7 +6526,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-12 09:52:13*
+*Report generated: 2026-05-18 08:11:44*
 
 ---
 
@@ -7367,7 +6536,7 @@ This report provides a comprehensive summary of the infrastructure migration fro
 
 **Target Region:** KR
 
-**Namespace:** mig01 | **Infra ID:** my04-infra101
+**Namespace:** mig01 | **Infra ID:** my08-infra101
 
 **Migration Status:** Completed
 
@@ -7386,10 +6555,10 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | s4-g3a, ci2-g3, s2-g3a |
+| 2 | **VM Spec** | 3 | ✅ Selected | ci2-g3, s2-g3a, s4-g3a |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
-| 4 | **VNet (VPC)** | 1 | ✅ Created | my04-vnet-01, CIDR: 10.0.0.0/21 |
-| 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my04-vnet-01) |
+| 4 | **VNet (VPC)** | 1 | ✅ Created | my08-vnet-01, CIDR: 10.0.0.0/21 |
+| 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my08-vnet-01) |
 | 6 | **Security Group** | 3 security groups | ✅ Created | Total 55 rules in 3 sgs |
 | 7 | **SSH Key** | 1 keys | ✅ Created | For VM access control |
 
@@ -7401,9 +6570,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 138234481<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 138234474<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 138234467<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 138993641<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 138993649<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 138993635<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7413,9 +6582,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM Spec | Source Server | Source Server Spec |
 |-----|-------------|---------|---------------|--------------------|
-| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** ci2-g3<br>**vCPUs:** 2<br>**Memory:** 4.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3a<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Spec ID:** s4-g3a<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 1 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** ci2-g3<br>**vCPUs:** 2<br>**Memory:** 4.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3a<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 3 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Spec ID:** s4-g3a<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
 
 ---
 
@@ -7425,9 +6594,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** 23214590<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu-22.04-base (Hypervisor:KVM) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -7435,13 +6604,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 **Summary:** 3 security group(s) with 55 security rule(s) have been created and configured for the migrated VMs.
 
-### Security Group: my04-sg-01
+### Security Group: my08-sg-01
 
-**CSP ID:** 352888 | **VNet:** my04-vnet-01 | **Rules:** 15
+**CSP ID:** 353896 | **VNet:** my08-vnet-01 | **Rules:** 15
 
 **Assigned VMs:**
 
-- **VM:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1
+- **VM:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1
   - **Source Server:** **Hostname:** N/A, **Machine ID:** vm-ec268ed7-821e-9d73-e79f
 
 **Security Rules:**
@@ -7464,13 +6633,13 @@ Summary of key infrastructure resources created or configured in the target clou
 | 14 | outbound | UDP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 | 15 | outbound | TCP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 
-### Security Group: my04-sg-02
+### Security Group: my08-sg-02
 
-**CSP ID:** 352889 | **VNet:** my04-vnet-01 | **Rules:** 20
+**CSP ID:** 353897 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
-- **VM:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1
+- **VM:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1
   - **Source Server:** **Hostname:** N/A, **Machine ID:** vm-ec2d32b5-98fb-5a96-7913
 
 **Security Rules:**
@@ -7498,13 +6667,13 @@ Summary of key infrastructure resources created or configured in the target clou
 | 19 | outbound | UDP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 | 20 | outbound | TCP | 1-65535 | 0.0.0.0/0 | - | Created by system |
 
-### Security Group: my04-sg-03
+### Security Group: my08-sg-03
 
-**CSP ID:** 352890 | **VNet:** my04-vnet-01 | **Rules:** 20
+**CSP ID:** 353898 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
-- **VM:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1
+- **VM:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1
   - **Source Server:** **Hostname:** N/A, **Machine ID:** vm-ec288dd0-c6fa-8a49-2f60
 
 **Security Rules:**
@@ -7542,13 +6711,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my04-vnet-01<br>**ID:** 138792 | 10.0.0.0/21 |
+| 1 | **Name:** my08-vnet-01<br>**ID:** 139135 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my04-subnet-01<br>**ID:** 300131 | 10.0.1.0/24 | my04-vnet-01 |
+| 1 | **Name:** my08-subnet-01<br>**ID:** 300855 | 10.0.1.0/24 | my08-vnet-01 |
 
 ### Source Network Information
 
@@ -7590,7 +6759,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my04-sshkey-01 | tbd81fd3e6aji65qtg7seg |  | Used by all 3 VMs |
+| 1 | my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 |  | Used by all 3 VMs |
 
 ---
 
@@ -7641,7 +6810,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ```json
 {
-  "message": "Successfully deleted the infrastructure and resources (nsId: mig01, infraId: my04-infra101)",
+  "message": "Successfully deleted the infrastructure and resources (nsId: mig01, infraId: my08-infra101)",
   "success": true
 }
 ```


### PR DESCRIPTION
- Update execution timestamps to May 18, 2026
- Update CM-Beetle version to c574040
- Refresh resource IDs from latest test run

(Note) In IBM's case, there is an accessibility check issue.