### PR TITLE
refactor(recommendation): remove client-side disk validation

### DIFF
--- a/pkg/core/recommendation/preflight.go
+++ b/pkg/core/recommendation/preflight.go
@@ -1,8 +1,6 @@
 package recommendation
 
 import (
-	"strings"
-
 	tbmodel "github.com/cloud-barista/cb-tumblebug/src/core/model"
 	tbclient "github.com/cloud-barista/cm-beetle/pkg/client/tumblebug"
 	"github.com/rs/zerolog/log"
@@ -22,68 +20,10 @@ type CspProvisioningPrecheck struct {
 	SuggestedSystemDisk string
 }
 
-// spiderKnownDiskTypes returns the root disk type names CB-Spider recognizes for a CSP.
-// Values are sourced from the rootdisktype field in:
-// https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/refs/heads/main/assets/spider/cloudos_meta.yaml
-// (CB-Tumblebug synchronizes this file from CB-Spider.)
-// Returns nil for unknown CSPs (no filtering applied).
-func spiderKnownDiskTypes(csp string) []string {
-	switch strings.ToLower(csp) {
-	case "aws":
-		return []string{"standard", "gp2", "gp3"}
-	case "azure":
-		return []string{"PremiumSSD", "StandardSSD", "StandardHDD"}
-	case "gcp":
-		return []string{"pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"}
-	case "alibaba":
-		// cloud_auto and cloud_essd_entry are valid on Alibaba but not yet listed in cloudos_meta.yaml.
-		return []string{"cloud_essd", "cloud_efficiency", "cloud", "cloud_ssd"}
-	case "tencent":
-		return []string{"CLOUD_PREMIUM", "CLOUD_SSD"}
-	case "ibm":
-		return []string{"general-purpose", "sdp"}
-	case "ncp", "ncpvpc":
-		return []string{"HDD"}
-	case "nhn":
-		return []string{"General_HDD", "General_SSD"}
-	case "kt", "ktvpc":
-		return []string{"HDD", "SSD"}
-	case "ktclassic":
-		return []string{"HDD", "SSD"}
-	default:
-		return nil // unknown CSP — pass through unchanged
-	}
-}
-
-// validateSuggestedDiskType returns diskType if CB-Spider recognizes it for the CSP,
-// or "" if not, falling back to the CSP's own default.
-func validateSuggestedDiskType(csp, diskType string) string {
-	if diskType == "" {
-		return ""
-	}
-	known := spiderKnownDiskTypes(csp)
-	if known == nil {
-		return diskType // unknown CSP — pass through unchanged
-	}
-	for _, t := range known {
-		if t == diskType {
-			return diskType
-		}
-	}
-	log.Warn().Msgf("SuggestedSystemDisk %q is not recognized by CB-Spider for %s; falling back to CSP default", diskType, csp)
-	return ""
-}
-
 // PreflightCheckCspProvisioning calls POST /specImagePairReview and returns image availability,
 // the resolved latest CSP image name, and the suggested system disk for the spec+zone.
 func PreflightCheckCspProvisioning(specId, imageId, currentCspImageName, rootDiskType string) (CspProvisioningPrecheck, error) {
 	empty := CspProvisioningPrecheck{ResolvedCspImageName: currentCspImageName}
-
-	// Extract CSP from specId (format: "csp+region+instanceType") for disk-type validation.
-	csp := ""
-	if parts := strings.SplitN(specId, "+", 2); len(parts) >= 1 {
-		csp = parts[0]
-	}
 
 	result, err := tbclient.NewSession().ReviewSpecImagePair(tbmodel.SpecImagePairReviewReq{
 		SpecId:       specId,
@@ -98,13 +38,11 @@ func PreflightCheckCspProvisioning(specId, imageId, currentCspImageName, rootDis
 		log.Warn().Msgf("spec-image review warning (specId: %s, imageId: %s): %s", specId, imageId, w)
 	}
 
-	suggestedDisk := validateSuggestedDiskType(csp, result.SuggestedSystemDisk)
-
 	if !result.ImageValidation.IsAvailable {
 		return CspProvisioningPrecheck{
 			ResolvedCspImageName: currentCspImageName,
 			IsAvailable:          false,
-			SuggestedSystemDisk:  suggestedDisk,
+			SuggestedSystemDisk:  result.SuggestedSystemDisk,
 		}, nil
 	}
 
@@ -118,6 +56,6 @@ func PreflightCheckCspProvisioning(specId, imageId, currentCspImageName, rootDis
 	return CspProvisioningPrecheck{
 		ResolvedCspImageName: resolvedName,
 		IsAvailable:          true,
-		SuggestedSystemDisk:  suggestedDisk,
+		SuggestedSystemDisk:  result.SuggestedSystemDisk,
 	}, nil
 }


### PR DESCRIPTION
- Trust CB-Tumblebug for system disk suggestions
- Remove duplicate CSP disk type mappings
- Simplify preflight check logic

Ref - https://github.com/cloud-barista/cm-beetle/issues/356#issuecomment-4478299305

Note - This will work correctly after Spider v0.12.22 is integrated.