### PR TITLE
docs(test-cli): refresh test results for Jun 2, 2026

### DIFF
--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-alibaba.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-alibaba.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:36:46 KST
-- Test Execution: 2026-05-08 20:36:46 KST
+- Test Date: June 2, 2026
+- Test Time: 21:31:32 KST
+- Test Execution: 2026-06-02 21:31:32 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 2.604s | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.103s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 753ms | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 11.855s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 2.23s | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.176s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 827ms | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 4.863s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 31.320060878s
+**Total Duration**: 24.10144815s
 
-*Test executed on May 8, 2026 at 20:36:46 KST (2026-05-08 20:36:46 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:31:32 KST (2026-06-02 21:31:32 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 10.103s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240215106630740` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 10.176s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403500871738337` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240215106630740",
+    "reqId": "1780403500871738337",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240215106630740"
+    "statusUrl": "/beetle/request/1780403500871738337"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 753ms
+- **Duration**: 827ms
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-aws.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-aws.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:34:29 KST
-- Test Execution: 2026-05-08 20:34:29 KST
+- Test Date: June 2, 2026
+- Test Time: 21:29:14 KST
+- Test Execution: 2026-06-02 21:29:14 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 1.625s | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.095s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 645ms | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 2.175s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 1.57s | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.149s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 730ms | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 5.374s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 20.546293923s
+**Total Duration**: 23.828301669s
 
-*Test executed on May 8, 2026 at 20:34:29 KST (2026-05-08 20:34:29 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:29:14 KST (2026-06-02 21:29:14 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 10.095s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240077505893612` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 10.149s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403361863924699` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240077505893612",
+    "reqId": "1780403361863924699",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240077505893612"
+    "statusUrl": "/beetle/request/1780403361863924699"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 645ms
+- **Duration**: 730ms
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-azure.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-azure.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:34:50 KST
-- Test Execution: 2026-05-08 20:34:50 KST
+- Test Date: June 2, 2026
+- Test Time: 21:29:38 KST
+- Test Execution: 2026-06-02 21:29:38 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 327ms | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.13s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 383ms | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 10.397s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 284ms | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.151s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 554ms | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 3.524s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 27.239895432s
+**Total Duration**: 20.519255344s
 
-*Test executed on May 8, 2026 at 20:34:50 KST (2026-05-08 20:34:50 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:29:38 KST (2026-06-02 21:29:38 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 10.13s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240096810768485` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 10.151s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403384432788620` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240096810768485",
+    "reqId": "1780403384432788620",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240096810768485"
+    "statusUrl": "/beetle/request/1780403384432788620"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 383ms
+- **Duration**: 554ms
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-gcp.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-gcp.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:35:17 KST
-- Test Execution: 2026-05-08 20:35:17 KST
+- Test Date: June 2, 2026
+- Test Time: 21:29:58 KST
+- Test Execution: 2026-06-02 21:29:58 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 6.592s | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 30.044s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 3.719s | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 42.428s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 6.937s | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 30.163s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 3.587s | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 47.188s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 1m28.786249623s
+**Total Duration**: 1m33.878995771s
 
-*Test executed on May 8, 2026 at 20:35:17 KST (2026-05-08 20:35:17 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:29:58 KST (2026-06-02 21:29:58 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 30.044s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240130233675469` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 30.163s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403411651049522` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240130233675469",
+    "reqId": "1780403411651049522",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240130233675469"
+    "statusUrl": "/beetle/request/1780403411651049522"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 3.719s
+- **Duration**: 3.587s
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-ibm.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-ibm.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:37:53 KST
-- Test Execution: 2026-05-08 20:37:53 KST
+- Test Date: June 2, 2026
+- Test Time: 21:32:35 KST
+- Test Execution: 2026-06-02 21:32:35 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 10.949s | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 50.11s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 3.245s | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 12.995s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 12.222s | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 50.081s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 2.804s | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 18.736s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 1m23.305484779s
+**Total Duration**: 1m29.848404934s
 
-*Test executed on May 8, 2026 at 20:37:53 KST (2026-05-08 20:37:53 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:32:35 KST (2026-06-02 21:32:35 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 50.11s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240290749983758` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 50.081s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403574059983030` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240290749983758",
+    "reqId": "1780403574059983030",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240290749983758"
+    "statusUrl": "/beetle/request/1780403574059983030"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 3.245s
+- **Duration**: 2.804s
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-kt.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-kt.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:40:43 KST
-- Test Execution: 2026-05-08 20:40:43 KST
+- Test Date: June 2, 2026
+- Test Time: 21:35:10 KST
+- Test Execution: 2026-06-02 21:35:10 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 294ms | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.118s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 449ms | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 10.837s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 849ms | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.038s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 455ms | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 3.865s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 27.70321335s
+**Total Duration**: 21.214119446s
 
-*Test executed on May 8, 2026 at 20:40:43 KST (2026-05-08 20:40:43 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:35:10 KST (2026-06-02 21:35:10 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 10.118s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240450117913605` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 10.038s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403717568788823` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240450117913605",
+    "reqId": "1780403717568788823",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240450117913605"
+    "statusUrl": "/beetle/request/1780403717568788823"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 449ms
+- **Duration**: 455ms
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-ncp.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-ncp.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:39:44 KST
-- Test Execution: 2026-05-08 20:39:44 KST
+- Test Date: June 2, 2026
+- Test Time: 21:34:26 KST
+- Test Execution: 2026-06-02 21:34:26 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 1.118s | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.34s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 688ms | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 11.523s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 846ms | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.309s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 627ms | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 4.309s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 29.674535703s
+**Total Duration**: 22.097693951s
 
-*Test executed on May 8, 2026 at 20:39:44 KST (2026-05-08 20:39:44 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:34:26 KST (2026-06-02 21:34:26 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 10.34s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240392251121859` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 10.309s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403673538906001` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240392251121859",
+    "reqId": "1780403673538906001",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240392251121859"
+    "statusUrl": "/beetle/request/1780403673538906001"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 688ms
+- **Duration**: 627ms
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-nhn.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-nhn.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:40:14 KST
-- Test Execution: 2026-05-08 20:40:14 KST
+- Test Date: June 2, 2026
+- Test Time: 21:34:48 KST
+- Test Execution: 2026-06-02 21:34:48 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 693ms | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.151s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 599ms | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 11.752s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 702ms | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.059s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 618ms | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 4.795s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 29.198468392s
+**Total Duration**: 22.177292662s
 
-*Test executed on May 8, 2026 at 20:40:14 KST (2026-05-08 20:40:14 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:34:48 KST (2026-06-02 21:34:48 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 10.151s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240421336226890` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 10.059s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403695251169147` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240421336226890",
+    "reqId": "1780403695251169147",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240421336226890"
+    "statusUrl": "/beetle/request/1780403695251169147"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 599ms
+- **Duration**: 618ms
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-openstack.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-openstack.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:39:17 KST
-- Test Execution: 2026-05-08 20:39:17 KST
+- Test Date: June 2, 2026
+- Test Time: 21:34:05 KST
+- Test Execution: 2026-06-02 21:34:05 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 496ms | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.042s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 435ms | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 10.8s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 469ms | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 10.061s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 417ms | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 3.782s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 27.776401748s
+**Total Duration**: 20.731731783s
 
-*Test executed on May 8, 2026 at 20:39:17 KST (2026-05-08 20:39:17 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:34:05 KST (2026-06-02 21:34:05 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 10.042s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240363553845734` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 10.061s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403652178377320` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240363553845734",
+    "reqId": "1780403652178377320",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240363553845734"
+    "statusUrl": "/beetle/request/1780403652178377320"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 435ms
+- **Duration**: 417ms
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/data/testresult/data-test-results-aws-to-tencent.md
+++ b/cmd/test-cli/data/testresult/data-test-results-aws-to-tencent.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-- CM-Beetle: transx/v0.1.2
+- CM-Beetle: imdl/v0.1.6
 - CB-Tumblebug: vunknown
 - Source CSP: AWS
 - Source Region: ap-northeast-2
@@ -19,9 +19,9 @@
 - Namespace: mig01
 - Name Seed: data01
 - Test CLI: CM-Beetle data migration automated test CLI
-- Test Date: May 8, 2026
-- Test Time: 20:37:17 KST
-- Test Execution: 2026-05-08 20:37:17 KST
+- Test Date: June 2, 2026
+- Test Time: 21:31:56 KST
+- Test Execution: 2026-06-02 21:31:56 KST
 
 ### Scenario
 
@@ -50,16 +50,16 @@
 
 | Step | Endpoint / Description | Status | Duration | Details |
 |------|------------------------|--------|----------|---------|
-| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 4.02s | Pass |
-| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 20.202s | Pass |
-| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 1.317s | Pass |
-| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 4.424s | Pass |
+| 1 | `POST /beetle/migration/middleware/ns/mig01/objectStorage` (target) | ✅ **PASS** | 3.776s | Pass |
+| 2 | `POST /beetle/migration/data` (migrate: source OS → target OS, encrypted, async) | ✅ **PASS** | 20.052s | Pass |
+| 3 | Verify migrated data (compare source and target object lists) | ✅ **PASS** | 1.292s | Pass |
+| 4 | `DELETE /beetle/migration/middleware/ns/mig01/objectStorage/{targetOsId}` (cleanup) | ✅ **PASS** | 8.075s | Pass |
 
 **Overall Result**: 4/4 steps passed ✅
 
-**Total Duration**: 35.965994768s
+**Total Duration**: 39.202555071s
 
-*Test executed on May 8, 2026 at 20:37:17 KST (2026-05-08 20:37:17 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 21:31:56 KST (2026-06-02 21:31:56 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -84,7 +84,6 @@
 
 ```json
 {
-  "nameSeed": "data01",
   "status": "recommended",
   "description": "Direct creation (no recommendation step)",
   "targetCloud": {
@@ -167,17 +166,17 @@
 #### 2.2 API Response Information
 
 - **Status**: ✅ **SUCCESS**
-- **Duration**: 20.202s
-- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1778240247941128304` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
+- **Duration**: 20.052s
+- **Note**: Initial response was `202 Accepted` (status: `Handling`). The test CLI polled `GET /beetle/request/1780403526407306789` every 10s (timeout: 600s) until migration completed with status `Success`. Step 3 was then executed.
 <details>
 <summary>Initial Response Body (202 Accepted)</summary>
 
 ```json
 {
   "data": {
-    "reqId": "1778240247941128304",
+    "reqId": "1780403526407306789",
     "status": "Handling",
-    "statusUrl": "/beetle/request/1778240247941128304"
+    "statusUrl": "/beetle/request/1780403526407306789"
   },
   "message": "Migration started. Use GET /request/{reqId} to check status.",
   "success": true
@@ -353,7 +352,7 @@
 - **Source objects**: 25
 - **Target objects**: 25
 - **Matched**: 25/25 ✅
-- **Duration**: 1.317s
+- **Duration**: 1.292s
 
 ### Step 4: Delete target object storage (cleanup)
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-alibaba.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-alibaba.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-19 13:45:42*
+*Report generated: 2026-06-02 11:59:06*
 
 ---
 
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj78l1w5alug26k1iue6<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj78kbqw7hi5a8zeaefq<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj78kbqw7hi5a8zeaefr<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj7e35tls2uwpys3780q<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj7e35tls2uwpys3780r<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj7caxyslyfjiirlhjj0<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260316.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260316.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260316.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260506.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260506.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260506.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-01
 
-**CSP ID:** sg-mj7ih4az5ak2r4h23yto | **VNet:** my04-vnet-01 | **Rules:** 14
+**CSP ID:** sg-mj71w6ok3fzhi53tij5j | **VNet:** my04-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-02
 
-**CSP ID:** sg-mj79ymqgqpvl4d76crer | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj7d6hrwmdy4yo1s8y96 | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-03
 
-**CSP ID:** sg-mj75u34nzaosi3yllnaa | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj780ni10nbsxrfvdoxa | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj7k204bw4tovqr3a2ktw | 10.0.0.0/21 |
+| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj77rilp5f4fn312w79hj | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj7xbgrjm2hxt61onvgnf | 10.0.1.0/24 | my04-vnet-01 |
+| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj713tfhuu6jxzc6pn93z | 10.0.1.0/24 | my04-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my04-sshkey-01 | tbctg260p3imgi0c2cla | 339dcb6b1dc361b0dbca2945c9f8c08b | Used by all 3 VMs |
+| 1 | my04-sshkey-01 | tbkc0tqjtqulqspk3vmj | 1984834c76edccca44bb64d2bea3009a | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-aws.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-aws.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:03:11*
+*Report generated: 2026-06-02 11:59:02*
 
 ---
 
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-05cc436e2832ffd93<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-055c3be58ba3b717a<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0fa2d84cd0c6e08bb<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-06534a82f97650b25<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-0b8bf7f9b3b9876c4<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0273cb7e68fdf8fac<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-08a1c21841a4c7a5f<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ami-08a1c21841a4c7a5f<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ami-08a1c21841a4c7a5f<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-0596f7562954deb8e<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ami-0596f7562954deb8e<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ami-0596f7562954deb8e<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-01
 
-**CSP ID:** sg-094d187b192dfdf77 | **VNet:** my01-vnet-01 | **Rules:** 14
+**CSP ID:** sg-073146fb5cc82a36a | **VNet:** my01-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-02
 
-**CSP ID:** sg-014a3bc57edc785c7 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0ce7c1c68b49dfdfd | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-03
 
-**CSP ID:** sg-0b2020b2fa704162e | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0199f16c43ae8cc63 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-07e218262146e7003 | 10.0.0.0/21 |
+| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-00b2b1e59e8d2653d | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0695096ac3c17916f | 10.0.1.0/24 | my01-vnet-01 |
+| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-005c104e63421b753 | 10.0.1.0/24 | my01-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my01-sshkey-01 | tbd85cetmpr9ha6omvqiog | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 | Used by all 3 VMs |
+| 1 | my01-sshkey-01 | tbgkl68qoqbt2irs6nn1 | 7c:ce:de:29:6e:56:dd:19:56:2c:0e:6a:3c:ff:d0:56:d1:64:f5:30 | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-azure.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-azure.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:04:07*
+*Report generated: 2026-06-02 11:59:44*
 
 ---
 
@@ -31,7 +31,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B2as_v2, Standard_B4as_v2, Standard_B2als_v2 |
+| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B2als_v2, Standard_B2as_v2, Standard_B4as_v2 |
 | 3 | **VM OS Image** | 2 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my02-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my02-vnet-01) |
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-01
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g | **VNet:** my02-vnet-01 | **Rules:** 14
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tba5q2q197u97gaalfpr | **VNet:** my02-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-02
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbfrrlj3eu12v1kqh8rp | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-03
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tb5vuraeoacia4ihdkd6 | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg | 10.0.0.0/21 |
+| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 | my02-vnet-01 |
+| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr | 10.0.1.0/24 | my02-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  | Used by all 3 VMs |
+| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-gcp.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-gcp.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:09:10*
+*Report generated: 2026-06-02 12:06:01*
 
 ---
 
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tbd85chgupr9ha6omvqjrg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tbd85chgupr9ha6omvqjtg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbd85chgupr9ha6omvqjsg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tb5aad3lmo0gt6dfk9uj<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tb25cler8rpicfonum0j<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbk09te5ihs839lat9rh<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-01
 
-**CSP ID:** tbd85cf7epr9ha6omvqjh0 | **VNet:** my03-vnet-01 | **Rules:** 14
+**CSP ID:** tbn194eshutbrfcgotga | **VNet:** my03-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-02
 
-**CSP ID:** tbd85cfrepr9ha6omvqjhg | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbd6ae36tqdum3bvi8od | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-03
 
-**CSP ID:** tbd85cgkmpr9ha6omvqjkg | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbol4toon26c949hihp0 | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my03-vnet-01<br>**ID:** tbd85cevepr9ha6omvqj20 | 10.0.0.0/21 |
+| 1 | **Name:** my03-vnet-01<br>**ID:** tbf2lc0iranl4gr0qrj1 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my03-subnet-01<br>**ID:** tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 | my03-vnet-01 |
+| 1 | **Name:** my03-subnet-01<br>**ID:** tbbbfhl31q35cvclvii0 | 10.0.1.0/24 | my03-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  | Used by all 3 VMs |
+| 1 | my03-sshkey-01 | tb6kf3c8jjcig0aqofjm |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-ibm.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-ibm.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-19 02:05:49*
+*Report generated: 2026-06-02 12:01:25*
 
 ---
 
@@ -31,7 +31,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | nxf-2x2, bxf-2x8, bxf-4x16 |
+| 2 | **VM Spec** | 3 | ✅ Selected | bxf-2x8, bxf-4x16, nxf-2x2 |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my06-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my06-vnet-01) |
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 02h7_f3d4a783-9b7a-457f-9787-84add44186f9<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** r026-3e2370e7-648b-4c31-9305-f09265b49632<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** r026-3e2370e7-648b-4c31-9305-f09265b49632<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** r026-3e2370e7-648b-4c31-9305-f09265b49632<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** r026-c8e249d4-f148-4416-a3c6-555b7a02f67d<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** r026-c8e249d4-f148-4416-a3c6-555b7a02f67d<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** r026-c8e249d4-f148-4416-a3c6-555b7a02f67d<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my06-sg-01
 
-**CSP ID:** r026-46eea056-e6af-4b54-89af-d772afbe34a4 | **VNet:** my06-vnet-01 | **Rules:** 14
+**CSP ID:** r026-cc7a1860-d3e6-4d83-a31f-753910673746 | **VNet:** my06-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -110,7 +110,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my06-sg-02
 
-**CSP ID:** r026-c9a5b2c1-7c4c-4667-9dc0-a9dfe3019693 | **VNet:** my06-vnet-01 | **Rules:** 19
+**CSP ID:** r026-09e47208-047d-4485-8bd2-19d7a50feb71 | **VNet:** my06-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -143,7 +143,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my06-sg-03
 
-**CSP ID:** r026-7090750f-4896-4245-a120-a41155025729 | **VNet:** my06-vnet-01 | **Rules:** 19
+**CSP ID:** r026-6e6f8825-c77d-4255-af1a-3eeeaad54cbc | **VNet:** my06-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -184,13 +184,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my06-vnet-01<br>**ID:** r026-a7ef8b86-1f9b-4b44-8720-86429cea400f | 10.0.0.0/21 |
+| 1 | **Name:** my06-vnet-01<br>**ID:** r026-5b6a8f03-385e-44ef-b1bc-825c662ed931 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my06-subnet-01<br>**ID:** 02h7-a0b66e6e-dbca-4527-980a-20e9e6237218 | 10.0.1.0/24 | my06-vnet-01 |
+| 1 | **Name:** my06-subnet-01<br>**ID:** 02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d | 10.0.1.0/24 | my06-vnet-01 |
 
 ### Source Network Information
 
@@ -232,7 +232,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my06-sshkey-01 | r026-8eebf157-a783-44b5-928d-0483871a4148 | SHA256:sYz80Z4IeGL3THfON6dTQifM2Lera2g8BaoVL37ccOo | Used by all 3 VMs |
+| 1 | my06-sshkey-01 | r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb | SHA256:TvBOM01LhEtmxXCF8izGk3MZUyQr9cHun/EEuzIgBLY | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-ncp.md
+++ b/cmd/test-cli/infra/testresult/beetle-report-mig-source-to-ncp.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:11:44*
+*Report generated: 2026-06-02 12:07:47*
 
 ---
 
@@ -31,7 +31,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | ci2-g3, s2-g3a, s4-g3a |
+| 2 | **VM Spec** | 3 | ✅ Selected | ci2-g3, s2-g3, s4-g3a |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my08-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my08-vnet-01) |
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 138993641<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 138993649<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 138993635<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 140607082<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 140607087<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 140607099<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -59,7 +59,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | No. | Migrated VM | VM Spec | Source Server | Source Server Spec |
 |-----|-------------|---------|---------------|--------------------|
 | 1 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** ci2-g3<br>**vCPUs:** 2<br>**Memory:** 4.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3a<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
 | 3 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Spec ID:** s4-g3a<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
 
 ---
@@ -82,7 +82,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my08-sg-01
 
-**CSP ID:** 353896 | **VNet:** my08-vnet-01 | **Rules:** 15
+**CSP ID:** 356310 | **VNet:** my08-vnet-01 | **Rules:** 15
 
 **Assigned VMs:**
 
@@ -111,7 +111,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my08-sg-02
 
-**CSP ID:** 353897 | **VNet:** my08-vnet-01 | **Rules:** 20
+**CSP ID:** 356311 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
@@ -145,7 +145,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my08-sg-03
 
-**CSP ID:** 353898 | **VNet:** my08-vnet-01 | **Rules:** 20
+**CSP ID:** 356314 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
@@ -187,13 +187,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my08-vnet-01<br>**ID:** 139135 | 10.0.0.0/21 |
+| 1 | **Name:** my08-vnet-01<br>**ID:** 139881 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my08-subnet-01<br>**ID:** 300855 | 10.0.1.0/24 | my08-vnet-01 |
+| 1 | **Name:** my08-subnet-01<br>**ID:** 302650 | 10.0.1.0/24 | my08-vnet-01 |
 
 ### Source Network Information
 
@@ -235,7 +235,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 |  | Used by all 3 VMs |
+| 1 | my08-sshkey-01 | tbbaetbunj5ueuro7mrm |  | Used by all 3 VMs |
 
 ---
 
@@ -256,7 +256,7 @@ Summary of key infrastructure resources created or configured in the target clou
 |-----------|------|--------------|------------|
 | ip-10-0-1-30 (migrated) | ci2-g3 | $52.56 | 22.0% |
 | ip-10-0-1-221 (migrated) | s4-g3a | $125.78 | 52.5% |
-| ip-10-0-1-138 (migrated) | s2-g3a | $61.06 | 25.5% |
+| ip-10-0-1-138 (migrated) | s2-g3 | $61.06 | 25.5% |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-source.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-source.md
@@ -1,6 +1,6 @@
 # Source Infrastructure Summary
 
-**Generated At:** 2026-05-19 13:43:43
+**Generated At:** 2026-06-02 11:57:02
 
 **Infrastructure Name:** infra-3-nodes
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-alibaba.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-alibaba.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-19 13:45:37
+**Generated At:** 2026-06-02 11:59:01
 
 **Namespace:** mig01
 
@@ -28,23 +28,23 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 | ecs.e-c1m1.large | 2 | 2.0 | - | x86_64 |  | $0.0178 | 1 |
 | ecs.e-c1m4.large | 2 | 8.0 | - | x86_64 |  | $0.0791 | 1 |
-| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| ubuntu_22_04_x64_20G_alibase_20260316.vhd | Ubuntu  22.04 64 bit | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 20 GB | 3 |
+| ubuntu_22_04_x64_20G_alibase_20260506.vhd | Ubuntu  22.04 64 bit | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 20 GB | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj78l1w5alug26k1iue6 | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.240.250<br>**Private IP:** 10.0.1.64<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj78kbqw7hi5a8zeaefq | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.57.53<br>**Private IP:** 10.0.1.65<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj78kbqw7hi5a8zeaefr | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.220.222.227<br>**Private IP:** 10.0.1.66<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj7e35tls2uwpys3780q | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.213.148.90<br>**Private IP:** 10.0.1.130<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj7e35tls2uwpys3780r | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.241.105<br>**Private IP:** 10.0.1.131<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj7caxyslyfjiirlhjj0 | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.241.200<br>**Private IP:** 10.0.1.129<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-vnet-01 |
-| **CSP VNet ID** | vpc-mj7k204bw4tovqr3a2ktw |
+| **CSP VNet ID** | vpc-mj77rilp5f4fn312w79hj |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | alibaba-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my04-subnet-01 | vsw-mj7xbgrjm2hxt61onvgnf | 10.0.1.0/24 | ap-northeast-2a |
+| my04-subnet-01 | vsw-mj713tfhuu6jxzc6pn93z | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my04-sshkey-01 | tbctg260p3imgi0c2cla |  | 339dcb6b1dc361b0dbca2945c9f8c08b |
+| my04-sshkey-01 | tbkc0tqjtqulqspk3vmj |  | 1984834c76edccca44bb64d2bea3009a |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-01 |
-| **CSP Security Group ID** | sg-mj7ih4az5ak2r4h23yto |
+| **CSP Security Group ID** | sg-mj71w6ok3fzhi53tij5j |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-02 |
-| **CSP Security Group ID** | sg-mj79ymqgqpvl4d76crer |
+| **CSP Security Group ID** | sg-mj7d6hrwmdy4yo1s8y96 |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-03 |
-| **CSP Security Group ID** | sg-mj75u34nzaosi3yllnaa |
+| **CSP Security Group ID** | sg-mj780ni10nbsxrfvdoxa |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-aws.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-aws.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:03:08
+**Generated At:** 2026-06-02 11:58:56
 
 **Namespace:** mig01
 
@@ -28,23 +28,23 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
-| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 | t3a.small | 2 | 2.0 | - | x86_64 |  | $0.0234 | 1 |
 | t3a.large | 2 | 8.0 | - | x86_64 |  | $0.0936 | 1 |
+| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| ami-08a1c21841a4c7a5f | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | Ubuntu 22.04 | Linux/UNIX | x86_64 | ebs | - | 3 |
+| ami-0596f7562954deb8e | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | Ubuntu 22.04 | Linux/UNIX | x86_64 | ebs | - | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-05cc436e2832ffd93 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.239.151<br>**Private IP:** 10.0.1.41<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-055c3be58ba3b717a | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 13.124.168.73<br>**Private IP:** 10.0.1.46<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0fa2d84cd0c6e08bb | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.166.174<br>**Private IP:** 10.0.1.204<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-06534a82f97650b25 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.244.82<br>**Private IP:** 10.0.1.140<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-0b8bf7f9b3b9876c4 | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.201.83.130<br>**Private IP:** 10.0.1.136<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0273cb7e68fdf8fac | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.4.197<br>**Private IP:** 10.0.1.239<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-vnet-01 |
-| **CSP VNet ID** | vpc-07e218262146e7003 |
+| **CSP VNet ID** | vpc-00b2b1e59e8d2653d |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my01-subnet-01 | subnet-0695096ac3c17916f | 10.0.1.0/24 | ap-northeast-2a |
+| my01-subnet-01 | subnet-005c104e63421b753 | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my01-sshkey-01 | tbd85cetmpr9ha6omvqiog |  | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 |
+| my01-sshkey-01 | tbgkl68qoqbt2irs6nn1 |  | 7c:ce:de:29:6e:56:dd:19:56:2c:0e:6a:3c:ff:d0:56:d1:64:f5:30 |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-01 |
-| **CSP Security Group ID** | sg-094d187b192dfdf77 |
+| **CSP Security Group ID** | sg-073146fb5cc82a36a |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-02 |
-| **CSP Security Group ID** | sg-014a3bc57edc785c7 |
+| **CSP Security Group ID** | sg-0ce7c1c68b49dfdfd |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-03 |
-| **CSP Security Group ID** | sg-0b2020b2fa704162e |
+| **CSP Security Group ID** | sg-0199f16c43ae8cc63 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-azure.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-azure.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:04:01
+**Generated At:** 2026-06-02 11:59:38
 
 **Namespace:** mig01
 
@@ -28,24 +28,24 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| Standard_B2as_v2 | 2 | 7.8 | - | x86_64 |  | $0.0865 | 1 |
 | Standard_B4as_v2 | 4 | 15.6 | - | x86_64 |  | $0.1730 | 1 |
 | Standard_B2als_v2 | 2 | 3.9 | - | x86_64 |  | $0.0432 | 1 |
-| Standard_B2as_v2 | 2 | 7.8 | - | x86_64 |  | $0.0865 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 2 |
-| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
+| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 2 |
+| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.25.229<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.26.6<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.195.68<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 40.89.209.210<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2 | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.195.8<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.40.12<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
 
 
 ## Network Resources
@@ -57,7 +57,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-vnet-01 |
-| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg |
+| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | azure-koreasouth |
 | **Subnet Count** | 1 |
@@ -66,7 +66,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 |  |
+| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -75,7 +75,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  |  |
+| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks |  |  |
 
 ### Security Groups
 
@@ -84,7 +84,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-01 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tba5q2q197u97gaalfpr |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -112,7 +112,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-02 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbfrrlj3eu12v1kqh8rp |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -145,7 +145,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-03 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tb5vuraeoacia4ihdkd6 |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-gcp.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-gcp.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:09:08
+**Generated At:** 2026-06-02 12:05:56
 
 **Namespace:** mig01
 
@@ -28,23 +28,23 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
-| e2-standard-2 | 2 | 7.8 | - | x86_64 |  | $0.0860 | 1 |
 | e2-standard-4 | 4 | 15.6 | - | x86_64 |  | $0.1719 | 1 |
 | e2-highcpu-2 | 2 | 2.0 | - | x86_64 |  | $0.0635 | 1 |
+| e2-standard-2 | 2 | 7.8 | - | x86_64 |  | $0.0860 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421 | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 10 GB | 3 |
+| https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520 | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 10 GB | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tbd85chgupr9ha6omvqjrg | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.47.88.87<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tbd85chgupr9ha6omvqjtg | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.234.91<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbd85chgupr9ha6omvqjsg | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.135.175<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tb5aad3lmo0gt6dfk9uj | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.158.221.135<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tb25cler8rpicfonum0j | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.204.98<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbk09te5ihs839lat9rh | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 8.230.18.51<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-vnet-01 |
-| **CSP VNet ID** | tbd85cevepr9ha6omvqj20 |
+| **CSP VNet ID** | tbf2lc0iranl4gr0qrj1 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | gcp-asia-northeast3 |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my03-subnet-01 | tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 |  |
+| my03-subnet-01 | tbbbfhl31q35cvclvii0 | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  |  |
+| my03-sshkey-01 | tb6kf3c8jjcig0aqofjm |  |  |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-01 |
-| **CSP Security Group ID** | tbd85cf7epr9ha6omvqjh0 |
+| **CSP Security Group ID** | tbn194eshutbrfcgotga |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-02 |
-| **CSP Security Group ID** | tbd85cfrepr9ha6omvqjhg |
+| **CSP Security Group ID** | tbd6ae36tqdum3bvi8od |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-03 |
-| **CSP Security Group ID** | tbd85cgkmpr9ha6omvqjkg |
+| **CSP Security Group ID** | tbol4toon26c949hihp0 |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-ibm.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-ibm.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-19 02:05:43
+**Generated At:** 2026-06-02 12:01:20
 
 **Namespace:** mig01
 
@@ -36,15 +36,15 @@
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| r026-3e2370e7-648b-4c31-9305-f09265b49632 | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | - | 3 |
+| r026-c8e249d4-f148-4416-a3c6-555b7a02f67d | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | - | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f | Running | 2 vCPU, 2.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.91.41<br>**Private IP:** 10.0.1.5<br>**SGs:** my06-sg-01<br>**SSH:** my06-sshkey-01 |
-| my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a | Running | 2 vCPU, 8.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.91.42<br>**Private IP:** 10.0.1.4<br>**SGs:** my06-sg-03<br>**SSH:** my06-sshkey-01 |
-| my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 02h7_f3d4a783-9b7a-457f-9787-84add44186f9 | Running | 4 vCPU, 16.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.98.92<br>**Private IP:** 10.0.1.6<br>**SGs:** my06-sg-02<br>**SSH:** my06-sshkey-01 |
+| my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457 | Running | 2 vCPU, 2.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.102.221<br>**Private IP:** 10.0.1.5<br>**SGs:** my06-sg-01<br>**SSH:** my06-sshkey-01 |
+| my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4 | Running | 2 vCPU, 8.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.98.218<br>**Private IP:** 10.0.1.6<br>**SGs:** my06-sg-03<br>**SSH:** my06-sshkey-01 |
+| my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6 | Running | 4 vCPU, 16.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.94.110<br>**Private IP:** 10.0.1.4<br>**SGs:** my06-sg-02<br>**SSH:** my06-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-vnet-01 |
-| **CSP VNet ID** | r026-a7ef8b86-1f9b-4b44-8720-86429cea400f |
+| **CSP VNet ID** | r026-5b6a8f03-385e-44ef-b1bc-825c662ed931 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | ibm-au-syd |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my06-subnet-01 | 02h7-a0b66e6e-dbca-4527-980a-20e9e6237218 | 10.0.1.0/24 | au-syd-1 |
+| my06-subnet-01 | 02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d | 10.0.1.0/24 | au-syd-1 |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my06-sshkey-01 | r026-8eebf157-a783-44b5-928d-0483871a4148 |  | SHA256:sYz80Z4IeGL3THfON6dTQifM2Lera2g8BaoVL37ccOo |
+| my06-sshkey-01 | r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb |  | SHA256:TvBOM01LhEtmxXCF8izGk3MZUyQr9cHun/EEuzIgBLY |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-sg-01 |
-| **CSP Security Group ID** | r026-46eea056-e6af-4b54-89af-d772afbe34a4 |
+| **CSP Security Group ID** | r026-cc7a1860-d3e6-4d83-a31f-753910673746 |
 | **VNet** | my06-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -111,7 +111,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-sg-02 |
-| **CSP Security Group ID** | r026-c9a5b2c1-7c4c-4667-9dc0-a9dfe3019693 |
+| **CSP Security Group ID** | r026-09e47208-047d-4485-8bd2-19d7a50feb71 |
 | **VNet** | my06-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -144,7 +144,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-sg-03 |
-| **CSP Security Group ID** | r026-7090750f-4896-4245-a120-a41155025729 |
+| **CSP Security Group ID** | r026-6e6f8825-c77d-4255-af1a-3eeeaad54cbc |
 | **VNet** | my06-vnet-01 |
 | **Rule Count** | 19 rules |
 

--- a/cmd/test-cli/infra/testresult/beetle-summary-target-ncp.md
+++ b/cmd/test-cli/infra/testresult/beetle-summary-target-ncp.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:11:39
+**Generated At:** 2026-06-02 12:07:41
 
 **Namespace:** mig01
 
@@ -29,7 +29,7 @@
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
 | ci2-g3 | 2 | 4.0 | - | x86_64 | default | $0.0730 | 1 |
-| s2-g3a | 2 | 8.0 | - | x86_64 | default | $0.0848 | 1 |
+| s2-g3 | 2 | 8.0 | - | x86_64 | default | $0.0848 | 1 |
 | s4-g3a | 4 | 16.0 | - | x86_64 | default | $0.1747 | 1 |
 
 ### VM Images
@@ -42,9 +42,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 138993641 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 223.130.156.82<br>**Private IP:** 10.0.1.7<br>**SGs:** my08-sg-01<br>**SSH:** my08-sshkey-01 |
-| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 138993649 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.20.97<br>**Private IP:** 10.0.1.8<br>**SGs:** my08-sg-03<br>**SSH:** my08-sshkey-01 |
-| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 138993635 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.16.239<br>**Private IP:** 10.0.1.6<br>**SGs:** my08-sg-02<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 140607082 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.10.57<br>**Private IP:** 10.0.1.6<br>**SGs:** my08-sg-01<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 140607087 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 223.130.162.232<br>**Private IP:** 10.0.1.7<br>**SGs:** my08-sg-03<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 140607099 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.20.104<br>**Private IP:** 10.0.1.8<br>**SGs:** my08-sg-02<br>**SSH:** my08-sshkey-01 |
 
 
 ## Network Resources
@@ -56,7 +56,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-vnet-01 |
-| **CSP VNet ID** | 139135 |
+| **CSP VNet ID** | 139881 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | ncp-kr |
 | **Subnet Count** | 1 |
@@ -65,7 +65,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my08-subnet-01 | 300855 | 10.0.1.0/24 | KR-1 |
+| my08-subnet-01 | 302650 | 10.0.1.0/24 | KR-1 |
 
 
 ## Security Resources
@@ -74,7 +74,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 | cb-user |  |
+| my08-sshkey-01 | tbbaetbunj5ueuro7mrm | cb-user |  |
 
 ### Security Groups
 
@@ -83,7 +83,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-sg-01 |
-| **CSP Security Group ID** | 353896 |
+| **CSP Security Group ID** | 356310 |
 | **VNet** | my08-vnet-01 |
 | **Rule Count** | 15 rules |
 
@@ -112,7 +112,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-sg-02 |
-| **CSP Security Group ID** | 353897 |
+| **CSP Security Group ID** | 356311 |
 | **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
@@ -146,7 +146,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-sg-03 |
-| **CSP Security Group ID** | 353898 |
+| **CSP Security Group ID** | 356314 |
 | **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
@@ -197,7 +197,7 @@
 | VM Name | Spec | Cost/Hour (USD) | Cost/Month (USD) |
 |---------|------|-----------------|------------------|
 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | ci2-g3 | $0.0730 | $52.56 |
-| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3a | $0.0848 | $61.06 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3 | $0.0848 | $61.06 |
 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | s4-g3a | $0.1747 | $125.78 |
 
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-alibaba.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-alibaba.md
@@ -7,19 +7,19 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (fa1a108)
-- imdl: v0.1.5+ (fa1a108)
-- CB-Tumblebug: v0.12.10
-- CB-Spider: v0.12.24
-- CB-MapUI: v0.12.31
+- CM-Beetle: imdl/v0.1.5+ (4987539)
+- imdl: v0.1.5+ (4987539)
+- CB-Tumblebug: v0.12.13
+- CB-Spider: v0.12.26
+- CB-MapUI: v0.12.34
 - Target CSP: ALIBABA
 - Target Region: ap-northeast-2
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 19, 2026
-- Test Time: 22:43:43 KST
-- Test Execution: 2026-05-19 22:43:43 KST
+- Test Date: June 2, 2026
+- Test Time: 20:57:07 KST
+- Test Execution: 2026-06-02 20:57:07 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 9.845s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m7.409s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 31ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 6ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 18ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 7.581s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m9.011s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 42ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 9ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 20ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.341s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.351s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 27.031s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.617s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.392s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 27.428s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 2m56.664865787s
+**Total Duration**: 2m56.723688087s
 
-*Test executed on May 19, 2026 at 22:43:43 KST (2026-05-19 22:43:43 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 20:57:07 KST (2026-06-02 20:57:07 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1967,8 +1967,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "alibaba-ap-northeast-2",
             "specId": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
-            "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -1988,8 +1987,7 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "alibaba-ap-northeast-2",
             "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
-            "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2009,15 +2007,14 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "alibaba-ap-northeast-2",
             "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
-            "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
               "sg-03"
             ],
             "sshKeyId": "sshkey-01",
-            "rootDiskType": "cloud_auto",
+            "rootDiskType": "cloud_essd_entry",
             "rootDiskSize": 40,
             "dataDiskIds": null
           }
@@ -2055,7 +2052,7 @@
       "targetSpecList": [
         {
           "id": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
-          "uid": "d7k8jalq1uu3ogmrrt1g",
+          "uid": "tb22bvs9dmjl7rovrih3",
           "cspSpecName": "ecs.e-c1m1.large",
           "name": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
           "namespace": "system",
@@ -2092,7 +2089,7 @@
         },
         {
           "id": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
-          "uid": "d7k8jalq1uu3ogmrrt4g",
+          "uid": "tbsicck91u4j0a9tcksp",
           "cspSpecName": "ecs.e-c1m4.xlarge",
           "name": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
           "namespace": "system",
@@ -2129,7 +2126,7 @@
         },
         {
           "id": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
-          "uid": "d7k8jalq1uu3ogmrrt40",
+          "uid": "tb9a4h1b61gvn02av5sa",
           "cspSpecName": "ecs.e-c1m4.large",
           "name": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
           "namespace": "system",
@@ -2170,39 +2167,46 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "alibaba",
-          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "regionList": [
             "ap-northeast-1",
             "ap-northeast-2",
+            "ap-southeast-1",
             "ap-southeast-3",
             "ap-southeast-5",
             "ap-southeast-6",
             "ap-southeast-7",
             "cn-beijing",
+            "cn-chengdu",
             "cn-fuzhou",
             "cn-guangzhou",
+            "cn-hangzhou",
             "cn-heyuan",
+            "cn-hongkong",
             "cn-huhehaote",
             "cn-nanjing",
+            "cn-qingdao",
             "cn-shanghai",
             "cn-shenzhen",
             "cn-wuhan-lr",
+            "cn-wulanchabu",
             "cn-zhangjiakou",
             "eu-central-1",
             "eu-west-1",
             "me-central-1",
             "me-east-1",
             "na-south-1",
+            "us-east-1",
             "us-west-1"
           ],
-          "id": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-          "uid": "d7k8jmtq1uu3ogmt0glg",
-          "name": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "id": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "uid": "tb6oo0277t33o19iufdl",
+          "name": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "alibaba-ap-northeast-2",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:03 Wed",
+          "fetchedTime": "2026.05.27 06:32:44 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -2221,7 +2225,7 @@
             },
             {
               "key": "ImageId",
-              "value": "ubuntu_22_04_x64_20G_alibase_20260316.vhd"
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
             },
             {
               "key": "ImageOwnerAlias",
@@ -2253,7 +2257,7 @@
             },
             {
               "key": "Description",
-              "value": "Kernel version is 5.15.0-173-generic, 2026.3.20"
+              "value": "Kernel version is 5.15.0-177-generic, 2026.5.7"
             },
             {
               "key": "Usage",
@@ -2269,7 +2273,7 @@
             },
             {
               "key": "ImageVersion",
-              "value": "v2026.3.20"
+              "value": "v2026.5.7"
             },
             {
               "key": "OSType",
@@ -2285,7 +2289,7 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-03-20T01:44:09Z"
+              "value": "2026-05-07T09:38:17Z"
             },
             {
               "key": "Progress",
@@ -2297,7 +2301,7 @@
             },
             {
               "key": "ImageName",
-              "value": "ubuntu_22_04_x64_20G_alibase_20260316.vhd"
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
             },
             {
               "key": "Status",
@@ -2329,7 +2333,7 @@
             }
           ],
           "systemLabel": "",
-          "description": "Kernel version is 5.15.0-173-generic, 2026.3.20",
+          "description": "Kernel version is 5.15.0-177-generic, 2026.5.7",
           "commandHistory": null
         }
       ],
@@ -2680,8 +2684,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "alibaba-ap-northeast-2",
             "specId": "alibaba+ap-northeast-2+ecs.t6-c1m1.large",
-            "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2700,9 +2703,8 @@
             },
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "alibaba-ap-northeast-2",
-            "specId": "alibaba+ap-northeast-2+ecs.g6.xlarge",
-            "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "specId": "alibaba+ap-northeast-2+ecs.t6-c1m4.xlarge",
+            "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2721,9 +2723,8 @@
             },
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "alibaba-ap-northeast-2",
-            "specId": "alibaba+ap-northeast-2+ecs.g6.large",
-            "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "specId": "alibaba+ap-northeast-2+ecs.t6-c1m4.large",
+            "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2768,7 +2769,7 @@
       "targetSpecList": [
         {
           "id": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
-          "uid": "d7k8jalq1uu3ogmrrt1g",
+          "uid": "tb22bvs9dmjl7rovrih3",
           "cspSpecName": "ecs.e-c1m1.large",
           "name": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
           "namespace": "system",
@@ -2805,7 +2806,7 @@
         },
         {
           "id": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
-          "uid": "d7k8jalq1uu3ogmrrt4g",
+          "uid": "tbsicck91u4j0a9tcksp",
           "cspSpecName": "ecs.e-c1m4.xlarge",
           "name": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
           "namespace": "system",
@@ -2842,7 +2843,7 @@
         },
         {
           "id": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
-          "uid": "d7k8jalq1uu3ogmrrt40",
+          "uid": "tb9a4h1b61gvn02av5sa",
           "cspSpecName": "ecs.e-c1m4.large",
           "name": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
           "namespace": "system",
@@ -2879,7 +2880,7 @@
         },
         {
           "id": "alibaba+ap-northeast-2+ecs.t6-c1m1.large",
-          "uid": "d7k8jalq1uu3ogmrruqg",
+          "uid": "tb616f1atpg0p9me2cvs",
           "cspSpecName": "ecs.t6-c1m1.large",
           "name": "alibaba+ap-northeast-2+ecs.t6-c1m1.large",
           "namespace": "system",
@@ -2915,10 +2916,10 @@
           ]
         },
         {
-          "id": "alibaba+ap-northeast-2+ecs.g6.xlarge",
-          "uid": "d7k8jalq1uu3ogmrrt80",
-          "cspSpecName": "ecs.g6.xlarge",
-          "name": "alibaba+ap-northeast-2+ecs.g6.xlarge",
+          "id": "alibaba+ap-northeast-2+ecs.t6-c1m4.xlarge",
+          "uid": "tbb0efvo1jl1j7tdo9ke",
+          "cspSpecName": "ecs.t6-c1m4.xlarge",
+          "name": "alibaba+ap-northeast-2+ecs.t6-c1m4.xlarge",
           "namespace": "system",
           "connectionName": "alibaba-ap-northeast-2",
           "providerName": "alibaba",
@@ -2930,7 +2931,7 @@
           "vCPU": 4,
           "memoryGiB": 16,
           "diskSizeGB": -1,
-          "costPerHour": 0.160848,
+          "costPerHour": 0.16926,
           "evaluationScore01": -1,
           "evaluationScore02": -1,
           "evaluationScore03": -1,
@@ -2952,10 +2953,10 @@
           ]
         },
         {
-          "id": "alibaba+ap-northeast-2+ecs.g6.large",
-          "uid": "d7k8jalq1uu3ogmrrt7g",
-          "cspSpecName": "ecs.g6.large",
-          "name": "alibaba+ap-northeast-2+ecs.g6.large",
+          "id": "alibaba+ap-northeast-2+ecs.t6-c1m4.large",
+          "uid": "tbeqle1g3f7uedh3q57s",
+          "cspSpecName": "ecs.t6-c1m4.large",
+          "name": "alibaba+ap-northeast-2+ecs.t6-c1m4.large",
           "namespace": "system",
           "connectionName": "alibaba-ap-northeast-2",
           "providerName": "alibaba",
@@ -2967,7 +2968,7 @@
           "vCPU": 2,
           "memoryGiB": 8,
           "diskSizeGB": -1,
-          "costPerHour": 0.080424,
+          "costPerHour": 0.08463,
           "evaluationScore01": -1,
           "evaluationScore02": -1,
           "evaluationScore03": -1,
@@ -2994,39 +2995,46 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "alibaba",
-          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "regionList": [
             "ap-northeast-1",
             "ap-northeast-2",
+            "ap-southeast-1",
             "ap-southeast-3",
             "ap-southeast-5",
             "ap-southeast-6",
             "ap-southeast-7",
             "cn-beijing",
+            "cn-chengdu",
             "cn-fuzhou",
             "cn-guangzhou",
+            "cn-hangzhou",
             "cn-heyuan",
+            "cn-hongkong",
             "cn-huhehaote",
             "cn-nanjing",
+            "cn-qingdao",
             "cn-shanghai",
             "cn-shenzhen",
             "cn-wuhan-lr",
+            "cn-wulanchabu",
             "cn-zhangjiakou",
             "eu-central-1",
             "eu-west-1",
             "me-central-1",
             "me-east-1",
             "na-south-1",
+            "us-east-1",
             "us-west-1"
           ],
-          "id": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
-          "uid": "d7k8jmtq1uu3ogmt0glg",
-          "name": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "id": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+          "uid": "tb6oo0277t33o19iufdl",
+          "name": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "alibaba-ap-northeast-2",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:03 Wed",
+          "fetchedTime": "2026.05.27 06:32:44 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -3045,7 +3053,7 @@
             },
             {
               "key": "ImageId",
-              "value": "ubuntu_22_04_x64_20G_alibase_20260316.vhd"
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
             },
             {
               "key": "ImageOwnerAlias",
@@ -3077,7 +3085,7 @@
             },
             {
               "key": "Description",
-              "value": "Kernel version is 5.15.0-173-generic, 2026.3.20"
+              "value": "Kernel version is 5.15.0-177-generic, 2026.5.7"
             },
             {
               "key": "Usage",
@@ -3093,7 +3101,7 @@
             },
             {
               "key": "ImageVersion",
-              "value": "v2026.3.20"
+              "value": "v2026.5.7"
             },
             {
               "key": "OSType",
@@ -3109,7 +3117,7 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-03-20T01:44:09Z"
+              "value": "2026-05-07T09:38:17Z"
             },
             {
               "key": "Progress",
@@ -3121,7 +3129,7 @@
             },
             {
               "key": "ImageName",
-              "value": "ubuntu_22_04_x64_20G_alibase_20260316.vhd"
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
             },
             {
               "key": "Status",
@@ -3153,7 +3161,7 @@
             }
           ],
           "systemLabel": "",
-          "description": "Kernel version is 5.15.0-173-generic, 2026.3.20",
+          "description": "Kernel version is 5.15.0-177-generic, 2026.5.7",
           "commandHistory": null
         }
       ],
@@ -3510,7 +3518,7 @@
 {
   "resourceType": "infra",
   "id": "my04-infra101",
-  "uid": "tba3l2ii7vs6m2l9lrr2",
+  "uid": "tbsb9sq51v4fnsipkeap",
   "name": "my04-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -3538,7 +3546,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my04-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tba3l2ii7vs6m2l9lrr2"
+    "sys.uid": "tbsb9sq51v4fnsipkeap"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -3547,9 +3555,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbjrfv60d47b3qklq12a",
-      "cspResourceName": "tbjrfv60d47b3qklq12a",
-      "cspResourceId": "i-mj78l1w5alug26k1iue6",
+      "uid": "tbhs2tl9c3te0mksjp02",
+      "cspResourceName": "tbhs2tl9c3te0mksjp02",
+      "cspResourceId": "i-mj7e35tls2uwpys3780q",
       "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -3563,13 +3571,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 13:44:56",
+      "createdTime": "2026-06-02 11:58:17",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-19 13:44:56",
-        "sys.cspResourceId": "i-mj78l1w5alug26k1iue6",
-        "sys.cspResourceName": "tbjrfv60d47b3qklq12a",
+        "sys.createdTime": "2026-06-02 11:58:17",
+        "sys.cspResourceId": "i-mj7e35tls2uwpys3780q",
+        "sys.cspResourceName": "tbhs2tl9c3te0mksjp02",
         "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -3578,7 +3586,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbjrfv60d47b3qklq12a",
+        "sys.uid": "tbhs2tl9c3te0mksjp02",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -3586,10 +3594,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.240.250",
+      "publicIP": "8.213.148.90",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.64",
+      "privateIP": "10.0.1.130",
       "privateDNS": "",
       "rootDiskType": "cloud_auto",
       "rootDiskSize": 40,
@@ -3631,33 +3639,33 @@
         "memoryGiB": 2,
         "costPerHour": 0.0178
       },
-      "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+      "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-      "networkInterface": "eni-mj78l1w5alug26jxuxyh",
+      "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+      "networkInterface": "eni-mj7e35tls2uwpys2lvv7",
       "securityGroupIds": [
         "my04-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbctg260p3imgi0c2cla",
+      "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "5tfb36r$l51!lA",
+      "nodeUserPassword": "$cpn1fbmnt!Abl",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHgE29E4ah5i7cDe2cScHHR34gc3kjFUc5cgptp2RSX5d6/WcveegCAyPBBiwJmMxrJewQ9wuWm4yZNNSf1m5aE=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNhMNxzCV4xDgqQZg5+XGyt06ozb7LlWixrfbFJWox/iiHeJdkvx+xu/LmaVx6kjg/KPkOVil3M8LlcpqqmEpdk=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:gg7oVGuteCzPhCLtONEd8svh1u8XYtcLS8Ow5nX2Q3Q",
-        "firstUsedAt": "2026-05-19T13:45:09Z"
+        "fingerprint": "SHA256:wyhhKV/Me4xRzt4oodcl1P0bOWE1botx6CeeFuzBOW0",
+        "firstUsedAt": "2026-06-02T11:58:31Z"
       },
       "commandStatus": [
         {
@@ -3665,11 +3673,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-19T13:45:08Z",
-          "completedTime": "2026-05-19T13:45:10Z",
+          "startedTime": "2026-06-02T11:58:31Z",
+          "completedTime": "2026-06-02T11:58:33Z",
           "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj78l1w5alug26k1iue6Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -3704,7 +3712,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbjrfv60d47b3qklq12a"
+          "value": "tbhs2tl9c3te0mksjp02"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -3724,7 +3732,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "ZoneId",
@@ -3740,7 +3748,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj78l1w5alug26k1iue6Z"
+          "value": "iZmj7e35tls2uwpys3780qZ"
         },
         {
           "key": "Status",
@@ -3772,7 +3780,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "7c6e1078-2175-4a2a-9daa-f583bda9e534"
+          "value": "aaf96940-aed7-409b-939f-aea783b600b6"
         },
         {
           "key": "RegionId",
@@ -3792,7 +3800,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj78l1w5alug26k1iue6"
+          "value": "i-mj7e35tls2uwpys3780q"
         },
         {
           "key": "Recyclable",
@@ -3812,11 +3820,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbctg260p3imgi0c2cla"
+          "value": "tbkc0tqjtqulqspk3vmj"
         },
         {
           "key": "LocalStorageCapacity",
@@ -3840,7 +3848,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7ih4az5ak2r4h23yto]}"
+          "value": "{SecurityGroupId:[sg-mj71w6ok3fzhi53tij5j]}"
         },
         {
           "key": "InnerIpAddress",
@@ -3848,7 +3856,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.240.250]}"
+          "value": "{IpAddress:[8.213.148.90]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -3896,7 +3904,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.64]}}"
+          "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.130]}}"
         },
         {
           "key": "Tags",
@@ -3904,7 +3912,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1b,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78l1w5alug26jxuxyh,PrimaryIpAddress:10.0.1.64,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.64,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a8,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvv7,PrimaryIpAddress:10.0.1.130,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.130,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -3915,9 +3923,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tb6qlrf2igoq7p2tfnfh",
-      "cspResourceName": "tb6qlrf2igoq7p2tfnfh",
-      "cspResourceId": "i-mj78kbqw7hi5a8zeaefq",
+      "uid": "tbcpprl9juav33e9q3c2",
+      "cspResourceName": "tbcpprl9juav33e9q3c2",
+      "cspResourceId": "i-mj7e35tls2uwpys3780r",
       "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -3931,13 +3939,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 13:44:54",
+      "createdTime": "2026-06-02 11:58:24",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-19 13:44:54",
-        "sys.cspResourceId": "i-mj78kbqw7hi5a8zeaefq",
-        "sys.cspResourceName": "tb6qlrf2igoq7p2tfnfh",
+        "sys.createdTime": "2026-06-02 11:58:24",
+        "sys.cspResourceId": "i-mj7e35tls2uwpys3780r",
+        "sys.cspResourceName": "tbcpprl9juav33e9q3c2",
         "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -3946,7 +3954,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tb6qlrf2igoq7p2tfnfh",
+        "sys.uid": "tbcpprl9juav33e9q3c2",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -3954,12 +3962,12 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.57.53",
+      "publicIP": "47.80.241.105",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.65",
+      "privateIP": "10.0.1.131",
       "privateDNS": "",
-      "rootDiskType": "cloud_auto",
+      "rootDiskType": "cloud_essd_entry",
       "rootDiskSize": 40,
       "RootDeviceName": "/dev/xvda",
       "connectionName": "alibaba-ap-northeast-2",
@@ -3999,33 +4007,33 @@
         "memoryGiB": 8,
         "costPerHour": 0.0791
       },
-      "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+      "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-      "networkInterface": "eni-mj78kbqw7hi5a8z7623q",
+      "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+      "networkInterface": "eni-mj7e35tls2uwpys2lvva",
       "securityGroupIds": [
         "my04-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbctg260p3imgi0c2cla",
+      "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "f631tkftA$dgb!",
+      "nodeUserPassword": "og1p!0lt8bfAm$",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNrJVIL28QRMVz7t0oyjZ+9sWWrs4oHZJNAne0rkMGcYwTM96MoiyC0tNAtgL0D+k4dL2ywFyrTJ7vqOTdmfE3g=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD1gzSk9e926lbr/5G5aVaQiCrn/ll3UEMwqHa/mQNWN3remyRmCxaVjOBpRTG6Oq8982X2IJ403G4BSAEzHBmg=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:qPI/irEUcipor00FlW69EaHhHLNrqOOQAHYXaEWaDGw",
-        "firstUsedAt": "2026-05-19T13:45:08Z"
+        "fingerprint": "SHA256:riHiQusw8+6WASDQXHPWeQ9s9W79YdIKy6bv+E597Kc",
+        "firstUsedAt": "2026-06-02T11:58:32Z"
       },
       "commandStatus": [
         {
@@ -4033,11 +4041,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-19T13:45:08Z",
-          "completedTime": "2026-05-19T13:45:09Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-06-02T11:58:31Z",
+          "completedTime": "2026-06-02T11:58:33Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj78kbqw7hi5a8zeaefqZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4072,7 +4080,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tb6qlrf2igoq7p2tfnfh"
+          "value": "tbcpprl9juav33e9q3c2"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -4092,7 +4100,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "ZoneId",
@@ -4108,7 +4116,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj78kbqw7hi5a8zeaefqZ"
+          "value": "iZmj7e35tls2uwpys3780rZ"
         },
         {
           "key": "Status",
@@ -4140,7 +4148,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "9d15b1bd-ccda-43d1-9032-53d5daa94734"
+          "value": "769359a1-ff5c-47f6-aa50-705ede2c8b58"
         },
         {
           "key": "RegionId",
@@ -4160,7 +4168,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj78kbqw7hi5a8zeaefq"
+          "value": "i-mj7e35tls2uwpys3780r"
         },
         {
           "key": "Recyclable",
@@ -4180,11 +4188,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbctg260p3imgi0c2cla"
+          "value": "tbkc0tqjtqulqspk3vmj"
         },
         {
           "key": "LocalStorageCapacity",
@@ -4208,7 +4216,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj75u34nzaosi3yllnaa]}"
+          "value": "{SecurityGroupId:[sg-mj780ni10nbsxrfvdoxa]}"
         },
         {
           "key": "InnerIpAddress",
@@ -4216,7 +4224,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.57.53]}"
+          "value": "{IpAddress:[47.80.241.105]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -4264,7 +4272,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.65]}}"
+          "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.131]}}"
         },
         {
           "key": "Tags",
@@ -4272,7 +4280,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1c,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78kbqw7hi5a8z7623q,PrimaryIpAddress:10.0.1.65,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.65,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a9,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvva,PrimaryIpAddress:10.0.1.131,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.131,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -4283,9 +4291,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbm5ho6vihi1d1lj90d7",
-      "cspResourceName": "tbm5ho6vihi1d1lj90d7",
-      "cspResourceId": "i-mj78kbqw7hi5a8zeaefr",
+      "uid": "tb0gc9fc2ec0v7te0en2",
+      "cspResourceName": "tb0gc9fc2ec0v7te0en2",
+      "cspResourceId": "i-mj7caxyslyfjiirlhjj0",
       "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4299,13 +4307,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 13:45:00",
+      "createdTime": "2026-06-02 11:58:19",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-19 13:45:00",
-        "sys.cspResourceId": "i-mj78kbqw7hi5a8zeaefr",
-        "sys.cspResourceName": "tbm5ho6vihi1d1lj90d7",
+        "sys.createdTime": "2026-06-02 11:58:19",
+        "sys.cspResourceId": "i-mj7caxyslyfjiirlhjj0",
+        "sys.cspResourceName": "tb0gc9fc2ec0v7te0en2",
         "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -4314,7 +4322,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbm5ho6vihi1d1lj90d7",
+        "sys.uid": "tb0gc9fc2ec0v7te0en2",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -4322,10 +4330,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "8.220.222.227",
+      "publicIP": "47.80.241.200",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.66",
+      "privateIP": "10.0.1.129",
       "privateDNS": "",
       "rootDiskType": "cloud_essd_entry",
       "rootDiskSize": 40,
@@ -4367,33 +4375,33 @@
         "memoryGiB": 16,
         "costPerHour": 0.1582
       },
-      "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+      "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-      "networkInterface": "eni-mj78kbqw7hi5a8z7623t",
+      "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+      "networkInterface": "eni-mj7caxyslyfjiirmuk6r",
       "securityGroupIds": [
         "my04-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbctg260p3imgi0c2cla",
+      "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "pnbet$o!9ufA1g",
+      "nodeUserPassword": "07qr$1j!1Ab9ot",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJQa+O67Uk0W7Uxe5w7jIPARZm2x4adleQZ9epQUwmOoTac/Chw+kbRLU9zbzAnp5ah00319gpc7GFpwmPLEXok=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA36aUcHKHQ+RZ14yQy69ODrhFbF5gSjK7aKhCsDtxNKCAhSEkZ/x4ee4OO+z34nzoF7nlslcVVpwf2C1pOA02k=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:ktjlrRzjIDbyzhxKFkR4Taz2M+TmMczGq34guelf9XE",
-        "firstUsedAt": "2026-05-19T13:45:09Z"
+        "fingerprint": "SHA256:Il27QVw0TAS24BNoLHeyuwBFqvo13kGaDO+NVrf6Roo",
+        "firstUsedAt": "2026-06-02T11:58:32Z"
       },
       "commandStatus": [
         {
@@ -4401,11 +4409,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-19T13:45:08Z",
-          "completedTime": "2026-05-19T13:45:10Z",
+          "startedTime": "2026-06-02T11:58:31Z",
+          "completedTime": "2026-06-02T11:58:33Z",
           "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj78kbqw7hi5a8zeaefrZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4440,7 +4448,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbm5ho6vihi1d1lj90d7"
+          "value": "tb0gc9fc2ec0v7te0en2"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -4460,7 +4468,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "ZoneId",
@@ -4476,7 +4484,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj78kbqw7hi5a8zeaefrZ"
+          "value": "iZmj7caxyslyfjiirlhjj0Z"
         },
         {
           "key": "Status",
@@ -4508,7 +4516,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "d98c35c8-8b3f-451b-a333-a66ec3bb4639"
+          "value": "6ea8094f-30c3-4bf8-b920-8f69ab5460e0"
         },
         {
           "key": "RegionId",
@@ -4528,7 +4536,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj78kbqw7hi5a8zeaefr"
+          "value": "i-mj7caxyslyfjiirlhjj0"
         },
         {
           "key": "Recyclable",
@@ -4548,11 +4556,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbctg260p3imgi0c2cla"
+          "value": "tbkc0tqjtqulqspk3vmj"
         },
         {
           "key": "LocalStorageCapacity",
@@ -4576,7 +4584,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj79ymqgqpvl4d76crer]}"
+          "value": "{SecurityGroupId:[sg-mj7d6hrwmdy4yo1s8y96]}"
         },
         {
           "key": "InnerIpAddress",
@@ -4584,7 +4592,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[8.220.222.227]}"
+          "value": "{IpAddress:[47.80.241.200]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -4632,7 +4640,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.66]}}"
+          "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.129]}}"
         },
         {
           "key": "Tags",
@@ -4640,7 +4648,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1d,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78kbqw7hi5a8z7623t,PrimaryIpAddress:10.0.1.66,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.66,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a7,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7caxyslyfjiirmuk6r,PrimaryIpAddress:10.0.1.129,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.129,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -4660,28 +4668,13 @@
     "results": [
       {
         "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "47.80.57.53",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux iZmj78kbqw7hi5a8zeaefqZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "47.80.240.250",
+        "nodeIp": "8.213.148.90",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj78l1w5alug26k1iue6Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4691,12 +4684,27 @@
       {
         "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "8.220.222.227",
+        "nodeIp": "47.80.241.200",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj78kbqw7hi5a8zeaefrZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my04-infra101",
+        "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "47.80.241.105",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4731,8 +4739,1171 @@
   "infra": [
     {
       "resourceType": "infra",
+      "id": "my01-infra101",
+      "uid": "tb2drt09mfdcqasro93p",
+      "name": "my01-infra101",
+      "status": "Running:3 (R:3/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 0,
+        "countRunning": 3,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "None",
+      "targetAction": "None",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my01-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my01-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tb2drt09mfdcqasro93p"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tb9lrr7qljeqacqgv2u5",
+          "cspResourceName": "tb9lrr7qljeqacqgv2u5",
+          "cspResourceId": "i-06534a82f97650b25",
+          "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-06-02 11:57:58",
+          "label": {
+            "Name": "tb9lrr7qljeqacqgv2u5",
+            "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.connectionName": "aws-ap-northeast-2",
+            "sys.createdTime": "2026-06-02 11:57:58",
+            "sys.cspResourceId": "i-06534a82f97650b25",
+            "sys.cspResourceName": "tb9lrr7qljeqacqgv2u5",
+            "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.infraId": "my01-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.subnetId": "my01-subnet-01",
+            "sys.uid": "tb9lrr7qljeqacqgv2u5",
+            "sys.vNetId": "my01-vnet-01"
+          },
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "52.78.244.82",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.140",
+          "privateDNS": "ip-10-0-1-140.ap-northeast-2.compute.internal",
+          "rootDiskType": "gp2",
+          "rootDiskSize": 10,
+          "RootDeviceName": "/dev/sda1",
+          "connectionName": "aws-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "aws-ap-northeast-2",
+            "providerName": "aws",
+            "driverName": "aws-driver-v1.0.so",
+            "credentialName": "aws",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "aws-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "Asia Pacific (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b",
+                "ap-northeast-2c",
+                "ap-northeast-2d"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "aws+ap-northeast-2+t3a.small",
+          "cspSpecName": "t3a.small",
+          "spec": {
+            "cspSpecName": "t3a.small",
+            "vCPU": 2,
+            "memoryGiB": 2,
+            "costPerHour": 0.0234
+          },
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ami-0596f7562954deb8e",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
+          },
+          "vNetId": "my01-vnet-01",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
+          "subnetId": "my01-subnet-01",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-05d9a8c5dc9658780",
+          "securityGroupIds": [
+            "my01-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my01-sshkey-01",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJTQ3SSJJ7tSaj0WZyFGnlovTpmAJ3neLicuOZcZ8+5894+2Fg7gxHO3jPuVAXf7mjQZiXmXhr3ebTh7z3C5fNk=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:3SwXDiiyzPRZcm7FKBhxVlokHTSSsW+3aNJln+hby+Y",
+            "firstUsedAt": "2026-06-02T11:58:07Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:08Z",
+              "elapsedTime": 2,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "AmiLaunchIndex",
+              "value": "0"
+            },
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:39Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0e1622ebc7e0ae0be}}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CapacityReservationSpecification",
+              "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+            },
+            {
+              "key": "ClientToken",
+              "value": "2A6DB7BA-D37C-45E3-8AFE-B062DEC1496A"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{CoreCount:1,ThreadsPerCore:2}"
+            },
+            {
+              "key": "EbsOptimized",
+              "value": "false"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "EnclaveOptions",
+              "value": "{Enabled:false}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-0596f7562954deb8e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-06534a82f97650b25"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.small"
+            },
+            {
+              "key": "KeyName",
+              "value": "tbgkl68qoqbt2irs6nn1"
+            },
+            {
+              "key": "LaunchTime",
+              "value": "2026-06-02T11:57:38Z"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+            },
+            {
+              "key": "Monitoring",
+              "value": "{State:disabled}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Attachment:{AttachTime:2026-06-02T11:57:38Z,AttachmentId:eni-attach-05d9a8c5dc9658780,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:55:94:dc:34:3b,NetworkInterfaceId:eni-04ea4fac87e5ad333,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.140,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.140}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
+            },
+            {
+              "key": "Placement",
+              "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+            },
+            {
+              "key": "PrivateDnsName",
+              "value": "ip-10-0-1-140.ap-northeast-2.compute.internal"
+            },
+            {
+              "key": "PrivateIpAddress",
+              "value": "10.0.1.140"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "52.78.244.82"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SecurityGroups",
+              "value": "{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}"
+            },
+            {
+              "key": "SourceDestCheck",
+              "value": "true"
+            },
+            {
+              "key": "State",
+              "value": "{Code:16,Name:running}"
+            },
+            {
+              "key": "SubnetId",
+              "value": "subnet-005c104e63421b753"
+            },
+            {
+              "key": "Tags",
+              "value": "{Key:Name,Value:tb9lrr7qljeqacqgv2u5}"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            },
+            {
+              "key": "VpcId",
+              "value": "vpc-00b2b1e59e8d2653d"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbd9vt5h7b3mi7hlnsrl",
+          "cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
+          "cspResourceId": "i-0b8bf7f9b3b9876c4",
+          "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-06-02 11:58:01",
+          "label": {
+            "Name": "tbd9vt5h7b3mi7hlnsrl",
+            "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.connectionName": "aws-ap-northeast-2",
+            "sys.createdTime": "2026-06-02 11:58:01",
+            "sys.cspResourceId": "i-0b8bf7f9b3b9876c4",
+            "sys.cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
+            "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.infraId": "my01-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.subnetId": "my01-subnet-01",
+            "sys.uid": "tbd9vt5h7b3mi7hlnsrl",
+            "sys.vNetId": "my01-vnet-01"
+          },
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "43.201.83.130",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.136",
+          "privateDNS": "ip-10-0-1-136.ap-northeast-2.compute.internal",
+          "rootDiskType": "gp2",
+          "rootDiskSize": 10,
+          "RootDeviceName": "/dev/sda1",
+          "connectionName": "aws-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "aws-ap-northeast-2",
+            "providerName": "aws",
+            "driverName": "aws-driver-v1.0.so",
+            "credentialName": "aws",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "aws-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "Asia Pacific (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b",
+                "ap-northeast-2c",
+                "ap-northeast-2d"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "aws+ap-northeast-2+t3a.large",
+          "cspSpecName": "t3a.large",
+          "spec": {
+            "cspSpecName": "t3a.large",
+            "vCPU": 2,
+            "memoryGiB": 8,
+            "costPerHour": 0.0936
+          },
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ami-0596f7562954deb8e",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
+          },
+          "vNetId": "my01-vnet-01",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
+          "subnetId": "my01-subnet-01",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-00d6d6972528706c2",
+          "securityGroupIds": [
+            "my01-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my01-sshkey-01",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtx2r8Ou4fXFF0/0OPQ0Rk+x8nxvnqwJeTL+9tBaIzgNXkZJMZ89BpJskE2U2XGlPGjmzheQYG3idrFrwV6U98=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:kledbHEJr8DxkYCKFS+YqOfbAGwfb7bYstah9IAFp4U",
+            "firstUsedAt": "2026-06-02T11:58:08Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Failed",
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:26Z",
+              "elapsedTime": 20,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "AmiLaunchIndex",
+              "value": "0"
+            },
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd90939abf365ee0}}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CapacityReservationSpecification",
+              "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+            },
+            {
+              "key": "ClientToken",
+              "value": "8A15C17A-F15C-460F-A71C-A57EF5F8E78E"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{CoreCount:1,ThreadsPerCore:2}"
+            },
+            {
+              "key": "EbsOptimized",
+              "value": "false"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "EnclaveOptions",
+              "value": "{Enabled:false}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-0596f7562954deb8e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-0b8bf7f9b3b9876c4"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.large"
+            },
+            {
+              "key": "KeyName",
+              "value": "tbgkl68qoqbt2irs6nn1"
+            },
+            {
+              "key": "LaunchTime",
+              "value": "2026-06-02T11:57:40Z"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+            },
+            {
+              "key": "Monitoring",
+              "value": "{State:disabled}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-00d6d6972528706c2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:67:60:31:ee:45,NetworkInterfaceId:eni-010ee71d81f863c52,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.136,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.136}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
+            },
+            {
+              "key": "Placement",
+              "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+            },
+            {
+              "key": "PrivateDnsName",
+              "value": "ip-10-0-1-136.ap-northeast-2.compute.internal"
+            },
+            {
+              "key": "PrivateIpAddress",
+              "value": "10.0.1.136"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "43.201.83.130"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SecurityGroups",
+              "value": "{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}"
+            },
+            {
+              "key": "SourceDestCheck",
+              "value": "true"
+            },
+            {
+              "key": "State",
+              "value": "{Code:16,Name:running}"
+            },
+            {
+              "key": "SubnetId",
+              "value": "subnet-005c104e63421b753"
+            },
+            {
+              "key": "Tags",
+              "value": "{Key:Name,Value:tbd9vt5h7b3mi7hlnsrl}"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            },
+            {
+              "key": "VpcId",
+              "value": "vpc-00b2b1e59e8d2653d"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbrh382k22c02gj6or2q",
+          "cspResourceName": "tbrh382k22c02gj6or2q",
+          "cspResourceId": "i-0273cb7e68fdf8fac",
+          "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.36,
+            "longitude": 126.78
+          },
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-06-02 11:58:00",
+          "label": {
+            "Name": "tbrh382k22c02gj6or2q",
+            "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.connectionName": "aws-ap-northeast-2",
+            "sys.createdTime": "2026-06-02 11:58:00",
+            "sys.cspResourceId": "i-0273cb7e68fdf8fac",
+            "sys.cspResourceName": "tbrh382k22c02gj6or2q",
+            "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.infraId": "my01-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.subnetId": "my01-subnet-01",
+            "sys.uid": "tbrh382k22c02gj6or2q",
+            "sys.vNetId": "my01-vnet-01"
+          },
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
+          },
+          "publicIP": "52.78.4.197",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.239",
+          "privateDNS": "ip-10-0-1-239.ap-northeast-2.compute.internal",
+          "rootDiskType": "gp2",
+          "rootDiskSize": 10,
+          "RootDeviceName": "/dev/sda1",
+          "connectionName": "aws-ap-northeast-2",
+          "connectionConfig": {
+            "configName": "aws-ap-northeast-2",
+            "providerName": "aws",
+            "driverName": "aws-driver-v1.0.so",
+            "credentialName": "aws",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "aws-ap-northeast-2",
+            "regionZoneInfo": {
+              "assignedRegion": "ap-northeast-2",
+              "assignedZone": "ap-northeast-2a"
+            },
+            "regionDetail": {
+              "regionId": "ap-northeast-2",
+              "regionName": "ap-northeast-2",
+              "description": "Asia Pacific (Seoul)",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.36,
+                "longitude": 126.78
+              },
+              "zones": [
+                "ap-northeast-2a",
+                "ap-northeast-2b",
+                "ap-northeast-2c",
+                "ap-northeast-2d"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "aws+ap-northeast-2+t3a.xlarge",
+          "cspSpecName": "t3a.xlarge",
+          "spec": {
+            "cspSpecName": "t3a.xlarge",
+            "vCPU": 4,
+            "memoryGiB": 16,
+            "costPerHour": 0.1872
+          },
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "ami-0596f7562954deb8e",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
+          },
+          "vNetId": "my01-vnet-01",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
+          "subnetId": "my01-subnet-01",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-0638cbee4cdabd7bd",
+          "securityGroupIds": [
+            "my01-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my01-sshkey-01",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBH97D952EztvAI/plpOdoCRtd21dx035GA7gRqjte2Nms1wIDFCgt9jQFauHyJRz8HXg/43acRo6d4xSZzc2ACw=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:Fk9INcBJUzgOLcr6k2etg2P8ucfdRb5QkjAk/dNW5Bo",
+            "firstUsedAt": "2026-06-02T11:58:08Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Failed",
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:26Z",
+              "elapsedTime": 20,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "AmiLaunchIndex",
+              "value": "0"
+            },
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0387f952743f64ec0}}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CapacityReservationSpecification",
+              "value": "{CapacityReservationPreference:open,CapacityReservationTarget:null}"
+            },
+            {
+              "key": "ClientToken",
+              "value": "9F574316-EB84-4652-B3FF-92E90421877B"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{CoreCount:2,ThreadsPerCore:2}"
+            },
+            {
+              "key": "EbsOptimized",
+              "value": "false"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "EnclaveOptions",
+              "value": "{Enabled:false}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-0596f7562954deb8e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-0273cb7e68fdf8fac"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.xlarge"
+            },
+            {
+              "key": "KeyName",
+              "value": "tbgkl68qoqbt2irs6nn1"
+            },
+            {
+              "key": "LaunchTime",
+              "value": "2026-06-02T11:57:40Z"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:enabled,HttpPutResponseHopLimit:1,HttpTokens:optional,State:applied}"
+            },
+            {
+              "key": "Monitoring",
+              "value": "{State:disabled}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-0638cbee4cdabd7bd,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c1:be:34:65:23,NetworkInterfaceId:eni-0dff89b4de2d2ff27,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.239,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.239}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
+            },
+            {
+              "key": "Placement",
+              "value": "{Affinity:null,AvailabilityZone:ap-northeast-2a,GroupName:,HostId:null,HostResourceGroupArn:null,PartitionNumber:null,SpreadDomain:null,Tenancy:default}"
+            },
+            {
+              "key": "PrivateDnsName",
+              "value": "ip-10-0-1-239.ap-northeast-2.compute.internal"
+            },
+            {
+              "key": "PrivateIpAddress",
+              "value": "10.0.1.239"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "52.78.4.197"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SecurityGroups",
+              "value": "{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}"
+            },
+            {
+              "key": "SourceDestCheck",
+              "value": "true"
+            },
+            {
+              "key": "State",
+              "value": "{Code:16,Name:running}"
+            },
+            {
+              "key": "SubnetId",
+              "value": "subnet-005c104e63421b753"
+            },
+            {
+              "key": "Tags",
+              "value": "{Key:Name,Value:tbrh382k22c02gj6or2q}"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            },
+            {
+              "key": "VpcId",
+              "value": "vpc-00b2b1e59e8d2653d"
+            }
+          ]
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": [
+          {
+            "infraId": "my01-infra101",
+            "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "52.78.244.82",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my01-infra101",
+            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "52.78.4.197",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {},
+            "stderr": {},
+            "err": null
+          },
+          {
+            "infraId": "my01-infra101",
+            "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "43.201.83.130",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {},
+            "stderr": {},
+            "err": null
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": "infra",
+      "id": "my02-infra101",
+      "uid": "tbv4r5dg0r6ctsgj7tfe",
+      "name": "my02-infra101",
+      "status": "Creating:3 (R:0/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 3,
+        "countRunning": 0,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "Running",
+      "targetAction": "Create",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my02-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my02-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbv4r5dg0r6ctsgj7tfe"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tb81h514blbmih6th0ra",
+          "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2als_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbj3l6ut11ch7mvkq2p2",
+          "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2as_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tblumcks3qbld4l0rqdu",
+          "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 30,
+          "RootDeviceName": "",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b4as_v2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my02-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": ""
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": null
+      }
+    },
+    {
+      "resourceType": "infra",
       "id": "my04-infra101",
-      "uid": "tba3l2ii7vs6m2l9lrr2",
+      "uid": "tbsb9sq51v4fnsipkeap",
       "name": "my04-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -4760,7 +5931,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my04-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tba3l2ii7vs6m2l9lrr2"
+        "sys.uid": "tbsb9sq51v4fnsipkeap"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -4769,9 +5940,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbjrfv60d47b3qklq12a",
-          "cspResourceName": "tbjrfv60d47b3qklq12a",
-          "cspResourceId": "i-mj78l1w5alug26k1iue6",
+          "uid": "tbhs2tl9c3te0mksjp02",
+          "cspResourceName": "tbhs2tl9c3te0mksjp02",
+          "cspResourceId": "i-mj7e35tls2uwpys3780q",
           "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -4785,13 +5956,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-19 13:44:56",
+          "createdTime": "2026-06-02 11:58:17",
           "label": {
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-19 13:44:56",
-            "sys.cspResourceId": "i-mj78l1w5alug26k1iue6",
-            "sys.cspResourceName": "tbjrfv60d47b3qklq12a",
+            "sys.createdTime": "2026-06-02 11:58:17",
+            "sys.cspResourceId": "i-mj7e35tls2uwpys3780q",
+            "sys.cspResourceName": "tbhs2tl9c3te0mksjp02",
             "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -4800,7 +5971,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbjrfv60d47b3qklq12a",
+            "sys.uid": "tbhs2tl9c3te0mksjp02",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -4808,10 +5979,10 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "47.80.240.250",
+          "publicIP": "8.213.148.90",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.64",
+          "privateIP": "10.0.1.130",
           "privateDNS": "",
           "rootDiskType": "cloud_auto",
           "rootDiskSize": 40,
@@ -4853,33 +6024,33 @@
             "memoryGiB": 2,
             "costPerHour": 0.0178
           },
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-          "networkInterface": "eni-mj78l1w5alug26jxuxyh",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7e35tls2uwpys2lvv7",
           "securityGroupIds": [
             "my04-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbctg260p3imgi0c2cla",
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "5tfb36r$l51!lA",
+          "nodeUserPassword": "$cpn1fbmnt!Abl",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHgE29E4ah5i7cDe2cScHHR34gc3kjFUc5cgptp2RSX5d6/WcveegCAyPBBiwJmMxrJewQ9wuWm4yZNNSf1m5aE=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNhMNxzCV4xDgqQZg5+XGyt06ozb7LlWixrfbFJWox/iiHeJdkvx+xu/LmaVx6kjg/KPkOVil3M8LlcpqqmEpdk=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:gg7oVGuteCzPhCLtONEd8svh1u8XYtcLS8Ow5nX2Q3Q",
-            "firstUsedAt": "2026-05-19T13:45:09Z"
+            "fingerprint": "SHA256:wyhhKV/Me4xRzt4oodcl1P0bOWE1botx6CeeFuzBOW0",
+            "firstUsedAt": "2026-06-02T11:58:31Z"
           },
           "commandStatus": [
             {
@@ -4887,11 +6058,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-19T13:45:08Z",
-              "completedTime": "2026-05-19T13:45:10Z",
+              "startedTime": "2026-06-02T11:58:31Z",
+              "completedTime": "2026-06-02T11:58:33Z",
               "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj78l1w5alug26k1iue6Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -4926,7 +6097,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbjrfv60d47b3qklq12a"
+              "value": "tbhs2tl9c3te0mksjp02"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -4946,7 +6117,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-19T13:44Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "ZoneId",
@@ -4962,7 +6133,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj78l1w5alug26k1iue6Z"
+              "value": "iZmj7e35tls2uwpys3780qZ"
             },
             {
               "key": "Status",
@@ -4994,7 +6165,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "7c6e1078-2175-4a2a-9daa-f583bda9e534"
+              "value": "aaf96940-aed7-409b-939f-aea783b600b6"
             },
             {
               "key": "RegionId",
@@ -5014,7 +6185,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj78l1w5alug26k1iue6"
+              "value": "i-mj7e35tls2uwpys3780q"
             },
             {
               "key": "Recyclable",
@@ -5034,11 +6205,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-19T13:44Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbctg260p3imgi0c2cla"
+              "value": "tbkc0tqjtqulqspk3vmj"
             },
             {
               "key": "LocalStorageCapacity",
@@ -5062,7 +6233,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj7ih4az5ak2r4h23yto]}"
+              "value": "{SecurityGroupId:[sg-mj71w6ok3fzhi53tij5j]}"
             },
             {
               "key": "InnerIpAddress",
@@ -5070,7 +6241,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[47.80.240.250]}"
+              "value": "{IpAddress:[8.213.148.90]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -5118,7 +6289,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.64]}}"
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.130]}}"
             },
             {
               "key": "Tags",
@@ -5126,7 +6297,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1b,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78l1w5alug26jxuxyh,PrimaryIpAddress:10.0.1.64,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.64,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a8,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvv7,PrimaryIpAddress:10.0.1.130,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.130,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -5137,9 +6308,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tb6qlrf2igoq7p2tfnfh",
-          "cspResourceName": "tb6qlrf2igoq7p2tfnfh",
-          "cspResourceId": "i-mj78kbqw7hi5a8zeaefq",
+          "uid": "tbcpprl9juav33e9q3c2",
+          "cspResourceName": "tbcpprl9juav33e9q3c2",
+          "cspResourceId": "i-mj7e35tls2uwpys3780r",
           "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5153,13 +6324,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-19 13:44:54",
+          "createdTime": "2026-06-02 11:58:24",
           "label": {
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-19 13:44:54",
-            "sys.cspResourceId": "i-mj78kbqw7hi5a8zeaefq",
-            "sys.cspResourceName": "tb6qlrf2igoq7p2tfnfh",
+            "sys.createdTime": "2026-06-02 11:58:24",
+            "sys.cspResourceId": "i-mj7e35tls2uwpys3780r",
+            "sys.cspResourceName": "tbcpprl9juav33e9q3c2",
             "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -5168,7 +6339,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tb6qlrf2igoq7p2tfnfh",
+            "sys.uid": "tbcpprl9juav33e9q3c2",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -5176,12 +6347,12 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "47.80.57.53",
+          "publicIP": "47.80.241.105",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.65",
+          "privateIP": "10.0.1.131",
           "privateDNS": "",
-          "rootDiskType": "cloud_auto",
+          "rootDiskType": "cloud_essd_entry",
           "rootDiskSize": 40,
           "RootDeviceName": "/dev/xvda",
           "connectionName": "alibaba-ap-northeast-2",
@@ -5221,33 +6392,33 @@
             "memoryGiB": 8,
             "costPerHour": 0.0791
           },
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-          "networkInterface": "eni-mj78kbqw7hi5a8z7623q",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7e35tls2uwpys2lvva",
           "securityGroupIds": [
             "my04-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbctg260p3imgi0c2cla",
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "f631tkftA$dgb!",
+          "nodeUserPassword": "og1p!0lt8bfAm$",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNrJVIL28QRMVz7t0oyjZ+9sWWrs4oHZJNAne0rkMGcYwTM96MoiyC0tNAtgL0D+k4dL2ywFyrTJ7vqOTdmfE3g=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD1gzSk9e926lbr/5G5aVaQiCrn/ll3UEMwqHa/mQNWN3remyRmCxaVjOBpRTG6Oq8982X2IJ403G4BSAEzHBmg=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:qPI/irEUcipor00FlW69EaHhHLNrqOOQAHYXaEWaDGw",
-            "firstUsedAt": "2026-05-19T13:45:08Z"
+            "fingerprint": "SHA256:riHiQusw8+6WASDQXHPWeQ9s9W79YdIKy6bv+E597Kc",
+            "firstUsedAt": "2026-06-02T11:58:32Z"
           },
           "commandStatus": [
             {
@@ -5255,11 +6426,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-19T13:45:08Z",
-              "completedTime": "2026-05-19T13:45:09Z",
-              "elapsedTime": 1,
+              "startedTime": "2026-06-02T11:58:31Z",
+              "completedTime": "2026-06-02T11:58:33Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj78kbqw7hi5a8zeaefqZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5294,7 +6465,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tb6qlrf2igoq7p2tfnfh"
+              "value": "tbcpprl9juav33e9q3c2"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -5314,7 +6485,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-19T13:44Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "ZoneId",
@@ -5330,7 +6501,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj78kbqw7hi5a8zeaefqZ"
+              "value": "iZmj7e35tls2uwpys3780rZ"
             },
             {
               "key": "Status",
@@ -5362,7 +6533,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "9d15b1bd-ccda-43d1-9032-53d5daa94734"
+              "value": "769359a1-ff5c-47f6-aa50-705ede2c8b58"
             },
             {
               "key": "RegionId",
@@ -5382,7 +6553,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj78kbqw7hi5a8zeaefq"
+              "value": "i-mj7e35tls2uwpys3780r"
             },
             {
               "key": "Recyclable",
@@ -5402,11 +6573,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-19T13:44Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbctg260p3imgi0c2cla"
+              "value": "tbkc0tqjtqulqspk3vmj"
             },
             {
               "key": "LocalStorageCapacity",
@@ -5430,7 +6601,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj75u34nzaosi3yllnaa]}"
+              "value": "{SecurityGroupId:[sg-mj780ni10nbsxrfvdoxa]}"
             },
             {
               "key": "InnerIpAddress",
@@ -5438,7 +6609,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[47.80.57.53]}"
+              "value": "{IpAddress:[47.80.241.105]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -5486,7 +6657,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.65]}}"
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.131]}}"
             },
             {
               "key": "Tags",
@@ -5494,7 +6665,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1c,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78kbqw7hi5a8z7623q,PrimaryIpAddress:10.0.1.65,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.65,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a9,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvva,PrimaryIpAddress:10.0.1.131,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.131,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -5505,9 +6676,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbm5ho6vihi1d1lj90d7",
-          "cspResourceName": "tbm5ho6vihi1d1lj90d7",
-          "cspResourceId": "i-mj78kbqw7hi5a8zeaefr",
+          "uid": "tb0gc9fc2ec0v7te0en2",
+          "cspResourceName": "tb0gc9fc2ec0v7te0en2",
+          "cspResourceId": "i-mj7caxyslyfjiirlhjj0",
           "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5521,13 +6692,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-19 13:45:00",
+          "createdTime": "2026-06-02 11:58:19",
           "label": {
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-19 13:45:00",
-            "sys.cspResourceId": "i-mj78kbqw7hi5a8zeaefr",
-            "sys.cspResourceName": "tbm5ho6vihi1d1lj90d7",
+            "sys.createdTime": "2026-06-02 11:58:19",
+            "sys.cspResourceId": "i-mj7caxyslyfjiirlhjj0",
+            "sys.cspResourceName": "tb0gc9fc2ec0v7te0en2",
             "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -5536,7 +6707,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbm5ho6vihi1d1lj90d7",
+            "sys.uid": "tb0gc9fc2ec0v7te0en2",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -5544,10 +6715,10 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "8.220.222.227",
+          "publicIP": "47.80.241.200",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.66",
+          "privateIP": "10.0.1.129",
           "privateDNS": "",
           "rootDiskType": "cloud_essd_entry",
           "rootDiskSize": 40,
@@ -5589,33 +6760,33 @@
             "memoryGiB": 16,
             "costPerHour": 0.1582
           },
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-          "networkInterface": "eni-mj78kbqw7hi5a8z7623t",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7caxyslyfjiirmuk6r",
           "securityGroupIds": [
             "my04-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbctg260p3imgi0c2cla",
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "pnbet$o!9ufA1g",
+          "nodeUserPassword": "07qr$1j!1Ab9ot",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJQa+O67Uk0W7Uxe5w7jIPARZm2x4adleQZ9epQUwmOoTac/Chw+kbRLU9zbzAnp5ah00319gpc7GFpwmPLEXok=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA36aUcHKHQ+RZ14yQy69ODrhFbF5gSjK7aKhCsDtxNKCAhSEkZ/x4ee4OO+z34nzoF7nlslcVVpwf2C1pOA02k=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:ktjlrRzjIDbyzhxKFkR4Taz2M+TmMczGq34guelf9XE",
-            "firstUsedAt": "2026-05-19T13:45:09Z"
+            "fingerprint": "SHA256:Il27QVw0TAS24BNoLHeyuwBFqvo13kGaDO+NVrf6Roo",
+            "firstUsedAt": "2026-06-02T11:58:32Z"
           },
           "commandStatus": [
             {
@@ -5623,11 +6794,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-19T13:45:08Z",
-              "completedTime": "2026-05-19T13:45:10Z",
+              "startedTime": "2026-06-02T11:58:31Z",
+              "completedTime": "2026-06-02T11:58:33Z",
               "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj78kbqw7hi5a8zeaefrZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5662,7 +6833,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbm5ho6vihi1d1lj90d7"
+              "value": "tb0gc9fc2ec0v7te0en2"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -5682,7 +6853,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-19T13:44Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "ZoneId",
@@ -5698,7 +6869,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj78kbqw7hi5a8zeaefrZ"
+              "value": "iZmj7caxyslyfjiirlhjj0Z"
             },
             {
               "key": "Status",
@@ -5730,7 +6901,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "d98c35c8-8b3f-451b-a333-a66ec3bb4639"
+              "value": "6ea8094f-30c3-4bf8-b920-8f69ab5460e0"
             },
             {
               "key": "RegionId",
@@ -5750,7 +6921,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj78kbqw7hi5a8zeaefr"
+              "value": "i-mj7caxyslyfjiirlhjj0"
             },
             {
               "key": "Recyclable",
@@ -5770,11 +6941,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-19T13:44Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbctg260p3imgi0c2cla"
+              "value": "tbkc0tqjtqulqspk3vmj"
             },
             {
               "key": "LocalStorageCapacity",
@@ -5798,7 +6969,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj79ymqgqpvl4d76crer]}"
+              "value": "{SecurityGroupId:[sg-mj7d6hrwmdy4yo1s8y96]}"
             },
             {
               "key": "InnerIpAddress",
@@ -5806,7 +6977,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[8.220.222.227]}"
+              "value": "{IpAddress:[47.80.241.200]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -5854,7 +7025,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.66]}}"
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.129]}}"
             },
             {
               "key": "Tags",
@@ -5862,7 +7033,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1d,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78kbqw7hi5a8z7623t,PrimaryIpAddress:10.0.1.66,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.66,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a7,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7caxyslyfjiirmuk6r,PrimaryIpAddress:10.0.1.129,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.129,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -5882,28 +7053,13 @@
         "results": [
           {
             "infraId": "my04-infra101",
-            "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "47.80.57.53",
-            "command": {
-              "0": "uname -a"
-            },
-            "stdout": {
-              "0": "Linux iZmj78kbqw7hi5a8zeaefqZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
-            "err": null
-          },
-          {
-            "infraId": "my04-infra101",
             "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "47.80.240.250",
+            "nodeIp": "8.213.148.90",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj78l1w5alug26k1iue6Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5913,12 +7069,27 @@
           {
             "infraId": "my04-infra101",
             "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "8.220.222.227",
+            "nodeIp": "47.80.241.200",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj78kbqw7hi5a8zeaefrZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my04-infra101",
+            "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "47.80.241.105",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5952,6 +7123,8 @@
 ```json
 {
   "idList": [
+    "my01-infra101",
+    "my02-infra101",
     "my04-infra101"
   ]
 }
@@ -5981,7 +7154,7 @@
 {
   "resourceType": "infra",
   "id": "my04-infra101",
-  "uid": "tba3l2ii7vs6m2l9lrr2",
+  "uid": "tbsb9sq51v4fnsipkeap",
   "name": "my04-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -6009,7 +7182,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my04-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tba3l2ii7vs6m2l9lrr2"
+    "sys.uid": "tbsb9sq51v4fnsipkeap"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -6018,9 +7191,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbjrfv60d47b3qklq12a",
-      "cspResourceName": "tbjrfv60d47b3qklq12a",
-      "cspResourceId": "i-mj78l1w5alug26k1iue6",
+      "uid": "tbhs2tl9c3te0mksjp02",
+      "cspResourceName": "tbhs2tl9c3te0mksjp02",
+      "cspResourceId": "i-mj7e35tls2uwpys3780q",
       "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -6034,13 +7207,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 13:44:56",
+      "createdTime": "2026-06-02 11:58:17",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-19 13:44:56",
-        "sys.cspResourceId": "i-mj78l1w5alug26k1iue6",
-        "sys.cspResourceName": "tbjrfv60d47b3qklq12a",
+        "sys.createdTime": "2026-06-02 11:58:17",
+        "sys.cspResourceId": "i-mj7e35tls2uwpys3780q",
+        "sys.cspResourceName": "tbhs2tl9c3te0mksjp02",
         "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -6049,7 +7222,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbjrfv60d47b3qklq12a",
+        "sys.uid": "tbhs2tl9c3te0mksjp02",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -6057,10 +7230,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.240.250",
+      "publicIP": "8.213.148.90",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.64",
+      "privateIP": "10.0.1.130",
       "privateDNS": "",
       "rootDiskType": "cloud_auto",
       "rootDiskSize": 40,
@@ -6102,33 +7275,33 @@
         "memoryGiB": 2,
         "costPerHour": 0.0178
       },
-      "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+      "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-      "networkInterface": "eni-mj78l1w5alug26jxuxyh",
+      "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+      "networkInterface": "eni-mj7e35tls2uwpys2lvv7",
       "securityGroupIds": [
         "my04-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbctg260p3imgi0c2cla",
+      "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "5tfb36r$l51!lA",
+      "nodeUserPassword": "$cpn1fbmnt!Abl",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHgE29E4ah5i7cDe2cScHHR34gc3kjFUc5cgptp2RSX5d6/WcveegCAyPBBiwJmMxrJewQ9wuWm4yZNNSf1m5aE=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNhMNxzCV4xDgqQZg5+XGyt06ozb7LlWixrfbFJWox/iiHeJdkvx+xu/LmaVx6kjg/KPkOVil3M8LlcpqqmEpdk=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:gg7oVGuteCzPhCLtONEd8svh1u8XYtcLS8Ow5nX2Q3Q",
-        "firstUsedAt": "2026-05-19T13:45:09Z"
+        "fingerprint": "SHA256:wyhhKV/Me4xRzt4oodcl1P0bOWE1botx6CeeFuzBOW0",
+        "firstUsedAt": "2026-06-02T11:58:31Z"
       },
       "commandStatus": [
         {
@@ -6136,11 +7309,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-19T13:45:08Z",
-          "completedTime": "2026-05-19T13:45:10Z",
+          "startedTime": "2026-06-02T11:58:31Z",
+          "completedTime": "2026-06-02T11:58:33Z",
           "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj78l1w5alug26k1iue6Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6175,7 +7348,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbjrfv60d47b3qklq12a"
+          "value": "tbhs2tl9c3te0mksjp02"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -6195,7 +7368,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "ZoneId",
@@ -6211,7 +7384,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj78l1w5alug26k1iue6Z"
+          "value": "iZmj7e35tls2uwpys3780qZ"
         },
         {
           "key": "Status",
@@ -6243,7 +7416,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "7c6e1078-2175-4a2a-9daa-f583bda9e534"
+          "value": "aaf96940-aed7-409b-939f-aea783b600b6"
         },
         {
           "key": "RegionId",
@@ -6263,7 +7436,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj78l1w5alug26k1iue6"
+          "value": "i-mj7e35tls2uwpys3780q"
         },
         {
           "key": "Recyclable",
@@ -6283,11 +7456,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbctg260p3imgi0c2cla"
+          "value": "tbkc0tqjtqulqspk3vmj"
         },
         {
           "key": "LocalStorageCapacity",
@@ -6311,7 +7484,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj7ih4az5ak2r4h23yto]}"
+          "value": "{SecurityGroupId:[sg-mj71w6ok3fzhi53tij5j]}"
         },
         {
           "key": "InnerIpAddress",
@@ -6319,7 +7492,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.240.250]}"
+          "value": "{IpAddress:[8.213.148.90]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -6367,7 +7540,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.64]}}"
+          "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.130]}}"
         },
         {
           "key": "Tags",
@@ -6375,7 +7548,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1b,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78l1w5alug26jxuxyh,PrimaryIpAddress:10.0.1.64,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.64,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a8,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvv7,PrimaryIpAddress:10.0.1.130,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.130,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -6386,9 +7559,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tb6qlrf2igoq7p2tfnfh",
-      "cspResourceName": "tb6qlrf2igoq7p2tfnfh",
-      "cspResourceId": "i-mj78kbqw7hi5a8zeaefq",
+      "uid": "tbcpprl9juav33e9q3c2",
+      "cspResourceName": "tbcpprl9juav33e9q3c2",
+      "cspResourceId": "i-mj7e35tls2uwpys3780r",
       "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6402,13 +7575,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 13:44:54",
+      "createdTime": "2026-06-02 11:58:24",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-19 13:44:54",
-        "sys.cspResourceId": "i-mj78kbqw7hi5a8zeaefq",
-        "sys.cspResourceName": "tb6qlrf2igoq7p2tfnfh",
+        "sys.createdTime": "2026-06-02 11:58:24",
+        "sys.cspResourceId": "i-mj7e35tls2uwpys3780r",
+        "sys.cspResourceName": "tbcpprl9juav33e9q3c2",
         "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -6417,7 +7590,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tb6qlrf2igoq7p2tfnfh",
+        "sys.uid": "tbcpprl9juav33e9q3c2",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -6425,12 +7598,12 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "47.80.57.53",
+      "publicIP": "47.80.241.105",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.65",
+      "privateIP": "10.0.1.131",
       "privateDNS": "",
-      "rootDiskType": "cloud_auto",
+      "rootDiskType": "cloud_essd_entry",
       "rootDiskSize": 40,
       "RootDeviceName": "/dev/xvda",
       "connectionName": "alibaba-ap-northeast-2",
@@ -6470,33 +7643,33 @@
         "memoryGiB": 8,
         "costPerHour": 0.0791
       },
-      "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+      "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-      "networkInterface": "eni-mj78kbqw7hi5a8z7623q",
+      "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+      "networkInterface": "eni-mj7e35tls2uwpys2lvva",
       "securityGroupIds": [
         "my04-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbctg260p3imgi0c2cla",
+      "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "f631tkftA$dgb!",
+      "nodeUserPassword": "og1p!0lt8bfAm$",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNrJVIL28QRMVz7t0oyjZ+9sWWrs4oHZJNAne0rkMGcYwTM96MoiyC0tNAtgL0D+k4dL2ywFyrTJ7vqOTdmfE3g=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD1gzSk9e926lbr/5G5aVaQiCrn/ll3UEMwqHa/mQNWN3remyRmCxaVjOBpRTG6Oq8982X2IJ403G4BSAEzHBmg=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:qPI/irEUcipor00FlW69EaHhHLNrqOOQAHYXaEWaDGw",
-        "firstUsedAt": "2026-05-19T13:45:08Z"
+        "fingerprint": "SHA256:riHiQusw8+6WASDQXHPWeQ9s9W79YdIKy6bv+E597Kc",
+        "firstUsedAt": "2026-06-02T11:58:32Z"
       },
       "commandStatus": [
         {
@@ -6504,11 +7677,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-19T13:45:08Z",
-          "completedTime": "2026-05-19T13:45:09Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-06-02T11:58:31Z",
+          "completedTime": "2026-06-02T11:58:33Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj78kbqw7hi5a8zeaefqZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6543,7 +7716,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tb6qlrf2igoq7p2tfnfh"
+          "value": "tbcpprl9juav33e9q3c2"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -6563,7 +7736,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "ZoneId",
@@ -6579,7 +7752,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj78kbqw7hi5a8zeaefqZ"
+          "value": "iZmj7e35tls2uwpys3780rZ"
         },
         {
           "key": "Status",
@@ -6611,7 +7784,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "9d15b1bd-ccda-43d1-9032-53d5daa94734"
+          "value": "769359a1-ff5c-47f6-aa50-705ede2c8b58"
         },
         {
           "key": "RegionId",
@@ -6631,7 +7804,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj78kbqw7hi5a8zeaefq"
+          "value": "i-mj7e35tls2uwpys3780r"
         },
         {
           "key": "Recyclable",
@@ -6651,11 +7824,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbctg260p3imgi0c2cla"
+          "value": "tbkc0tqjtqulqspk3vmj"
         },
         {
           "key": "LocalStorageCapacity",
@@ -6679,7 +7852,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj75u34nzaosi3yllnaa]}"
+          "value": "{SecurityGroupId:[sg-mj780ni10nbsxrfvdoxa]}"
         },
         {
           "key": "InnerIpAddress",
@@ -6687,7 +7860,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[47.80.57.53]}"
+          "value": "{IpAddress:[47.80.241.105]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -6735,7 +7908,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.65]}}"
+          "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.131]}}"
         },
         {
           "key": "Tags",
@@ -6743,7 +7916,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1c,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78kbqw7hi5a8z7623q,PrimaryIpAddress:10.0.1.65,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.65,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a9,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvva,PrimaryIpAddress:10.0.1.131,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.131,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -6754,9 +7927,9 @@
     {
       "resourceType": "node",
       "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbm5ho6vihi1d1lj90d7",
-      "cspResourceName": "tbm5ho6vihi1d1lj90d7",
-      "cspResourceId": "i-mj78kbqw7hi5a8zeaefr",
+      "uid": "tb0gc9fc2ec0v7te0en2",
+      "cspResourceName": "tb0gc9fc2ec0v7te0en2",
+      "cspResourceId": "i-mj7caxyslyfjiirlhjj0",
       "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -6770,13 +7943,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 13:45:00",
+      "createdTime": "2026-06-02 11:58:19",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "alibaba-ap-northeast-2",
-        "sys.createdTime": "2026-05-19 13:45:00",
-        "sys.cspResourceId": "i-mj78kbqw7hi5a8zeaefr",
-        "sys.cspResourceName": "tbm5ho6vihi1d1lj90d7",
+        "sys.createdTime": "2026-06-02 11:58:19",
+        "sys.cspResourceId": "i-mj7caxyslyfjiirlhjj0",
+        "sys.cspResourceName": "tb0gc9fc2ec0v7te0en2",
         "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my04-infra101",
         "sys.labelType": "node",
@@ -6785,7 +7958,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my04-subnet-01",
-        "sys.uid": "tbm5ho6vihi1d1lj90d7",
+        "sys.uid": "tb0gc9fc2ec0v7te0en2",
         "sys.vNetId": "my04-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -6793,10 +7966,10 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "8.220.222.227",
+      "publicIP": "47.80.241.200",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.66",
+      "privateIP": "10.0.1.129",
       "privateDNS": "",
       "rootDiskType": "cloud_essd_entry",
       "rootDiskSize": 40,
@@ -6838,33 +8011,33 @@
         "memoryGiB": 16,
         "costPerHour": 0.1582
       },
-      "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+      "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+        "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu  22.04 64 bit"
       },
       "vNetId": "my04-vnet-01",
-      "cspVNetId": "vpc-mj7k204bw4tovqr3a2ktw",
+      "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
       "subnetId": "my04-subnet-01",
-      "cspSubnetId": "vsw-mj7xbgrjm2hxt61onvgnf",
-      "networkInterface": "eni-mj78kbqw7hi5a8z7623t",
+      "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+      "networkInterface": "eni-mj7caxyslyfjiirmuk6r",
       "securityGroupIds": [
         "my04-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my04-sshkey-01",
-      "cspSshKeyId": "tbctg260p3imgi0c2cla",
+      "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
       "nodeUserName": "cb-user",
-      "nodeUserPassword": "pnbet$o!9ufA1g",
+      "nodeUserPassword": "07qr$1j!1Ab9ot",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJQa+O67Uk0W7Uxe5w7jIPARZm2x4adleQZ9epQUwmOoTac/Chw+kbRLU9zbzAnp5ah00319gpc7GFpwmPLEXok=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA36aUcHKHQ+RZ14yQy69ODrhFbF5gSjK7aKhCsDtxNKCAhSEkZ/x4ee4OO+z34nzoF7nlslcVVpwf2C1pOA02k=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:ktjlrRzjIDbyzhxKFkR4Taz2M+TmMczGq34guelf9XE",
-        "firstUsedAt": "2026-05-19T13:45:09Z"
+        "fingerprint": "SHA256:Il27QVw0TAS24BNoLHeyuwBFqvo13kGaDO+NVrf6Roo",
+        "firstUsedAt": "2026-06-02T11:58:32Z"
       },
       "commandStatus": [
         {
@@ -6872,11 +8045,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-19T13:45:08Z",
-          "completedTime": "2026-05-19T13:45:10Z",
+          "startedTime": "2026-06-02T11:58:31Z",
+          "completedTime": "2026-06-02T11:58:33Z",
           "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux iZmj78kbqw7hi5a8zeaefrZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6911,7 +8084,7 @@
         },
         {
           "key": "InstanceName",
-          "value": "tbm5ho6vihi1d1lj90d7"
+          "value": "tb0gc9fc2ec0v7te0en2"
         },
         {
           "key": "DeploymentSetGroupNo",
@@ -6931,7 +8104,7 @@
         },
         {
           "key": "StartTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "ZoneId",
@@ -6947,7 +8120,7 @@
         },
         {
           "key": "HostName",
-          "value": "iZmj78kbqw7hi5a8zeaefrZ"
+          "value": "iZmj7caxyslyfjiirlhjj0Z"
         },
         {
           "key": "Status",
@@ -6979,7 +8152,7 @@
         },
         {
           "key": "SerialNumber",
-          "value": "d98c35c8-8b3f-451b-a333-a66ec3bb4639"
+          "value": "6ea8094f-30c3-4bf8-b920-8f69ab5460e0"
         },
         {
           "key": "RegionId",
@@ -6999,7 +8172,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-mj78kbqw7hi5a8zeaefr"
+          "value": "i-mj7caxyslyfjiirlhjj0"
         },
         {
           "key": "Recyclable",
@@ -7019,11 +8192,11 @@
         },
         {
           "key": "CreationTime",
-          "value": "2026-05-19T13:44Z"
+          "value": "2026-06-02T11:57Z"
         },
         {
           "key": "KeyPairName",
-          "value": "tbctg260p3imgi0c2cla"
+          "value": "tbkc0tqjtqulqspk3vmj"
         },
         {
           "key": "LocalStorageCapacity",
@@ -7047,7 +8220,7 @@
         },
         {
           "key": "SecurityGroupIds",
-          "value": "{SecurityGroupId:[sg-mj79ymqgqpvl4d76crer]}"
+          "value": "{SecurityGroupId:[sg-mj7d6hrwmdy4yo1s8y96]}"
         },
         {
           "key": "InnerIpAddress",
@@ -7055,7 +8228,7 @@
         },
         {
           "key": "PublicIpAddress",
-          "value": "{IpAddress:[8.220.222.227]}"
+          "value": "{IpAddress:[47.80.241.200]}"
         },
         {
           "key": "RdmaIpAddress",
@@ -7103,7 +8276,7 @@
         },
         {
           "key": "VpcAttributes",
-          "value": "{VSwitchId:vsw-mj7xbgrjm2hxt61onvgnf,VpcId:vpc-mj7k204bw4tovqr3a2ktw,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.66]}}"
+          "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.129]}}"
         },
         {
           "key": "Tags",
@@ -7111,7 +8284,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:ba:1d,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj78kbqw7hi5a8z7623t,PrimaryIpAddress:10.0.1.66,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.66,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+          "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a7,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7caxyslyfjiirmuk6r,PrimaryIpAddress:10.0.1.129,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.129,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
         },
         {
           "key": "OperationLocks",
@@ -7131,28 +8304,13 @@
     "results": [
       {
         "infraId": "my04-infra101",
-        "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "47.80.57.53",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux iZmj78kbqw7hi5a8zeaefqZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "47.80.240.250",
+        "nodeIp": "8.213.148.90",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj78l1w5alug26k1iue6Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7162,12 +8320,27 @@
       {
         "infraId": "my04-infra101",
         "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "8.220.222.227",
+        "nodeIp": "47.80.241.200",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux iZmj78kbqw7hi5a8zeaefrZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my04-infra101",
+        "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "47.80.241.105",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7225,8 +8398,8 @@
       "command": "uname -a",
       "nodeGroup": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux iZmj78l1w5alug26k1iue6Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "47.80.240.250",
+      "output": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "8.213.148.90",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -7237,8 +8410,8 @@
       "command": "uname -a",
       "nodeGroup": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux iZmj78kbqw7hi5a8zeaefqZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "47.80.57.53",
+      "output": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "47.80.241.105",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -7249,8 +8422,8 @@
       "command": "uname -a",
       "nodeGroup": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux iZmj78kbqw7hi5a8zeaefrZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "8.220.222.227",
+      "output": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "47.80.241.200",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -7280,7 +8453,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-19 13:45:37
+**Generated At:** 2026-06-02 11:59:01
 
 **Namespace:** mig01
 
@@ -7308,23 +8481,23 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 | ecs.e-c1m1.large | 2 | 2.0 | - | x86_64 |  | $0.0178 | 1 |
 | ecs.e-c1m4.large | 2 | 8.0 | - | x86_64 |  | $0.0791 | 1 |
-| ecs.e-c1m4.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1582 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| ubuntu_22_04_x64_20G_alibase_20260316.vhd | Ubuntu  22.04 64 bit | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 20 GB | 3 |
+| ubuntu_22_04_x64_20G_alibase_20260506.vhd | Ubuntu  22.04 64 bit | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 20 GB | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj78l1w5alug26k1iue6 | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.240.250<br>**Private IP:** 10.0.1.64<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj78kbqw7hi5a8zeaefq | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.57.53<br>**Private IP:** 10.0.1.65<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
-| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj78kbqw7hi5a8zeaefr | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.220.222.227<br>**Private IP:** 10.0.1.66<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-mj7e35tls2uwpys3780q | Running | 2 vCPU, 2.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 8.213.148.90<br>**Private IP:** 10.0.1.130<br>**SGs:** my04-sg-01<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-mj7e35tls2uwpys3780r | Running | 2 vCPU, 8.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.241.105<br>**Private IP:** 10.0.1.131<br>**SGs:** my04-sg-03<br>**SSH:** my04-sshkey-01 |
+| my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-mj7caxyslyfjiirlhjj0 | Running | 4 vCPU, 16.0 GiB | Ubuntu  22.04 64 bit (Ubuntu  22.04 64 bit) | **VNet:** my04-vnet-01<br>**Subnet:** my04-subnet-01<br>**Public IP:** 47.80.241.200<br>**Private IP:** 10.0.1.129<br>**SGs:** my04-sg-02<br>**SSH:** my04-sshkey-01 |
 
 
 ## Network Resources
@@ -7336,7 +8509,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-vnet-01 |
-| **CSP VNet ID** | vpc-mj7k204bw4tovqr3a2ktw |
+| **CSP VNet ID** | vpc-mj77rilp5f4fn312w79hj |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | alibaba-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -7345,7 +8518,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my04-subnet-01 | vsw-mj7xbgrjm2hxt61onvgnf | 10.0.1.0/24 | ap-northeast-2a |
+| my04-subnet-01 | vsw-mj713tfhuu6jxzc6pn93z | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -7354,7 +8527,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my04-sshkey-01 | tbctg260p3imgi0c2cla |  | 339dcb6b1dc361b0dbca2945c9f8c08b |
+| my04-sshkey-01 | tbkc0tqjtqulqspk3vmj |  | 1984834c76edccca44bb64d2bea3009a |
 
 ### Security Groups
 
@@ -7363,7 +8536,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-01 |
-| **CSP Security Group ID** | sg-mj7ih4az5ak2r4h23yto |
+| **CSP Security Group ID** | sg-mj71w6ok3fzhi53tij5j |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -7391,7 +8564,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-02 |
-| **CSP Security Group ID** | sg-mj79ymqgqpvl4d76crer |
+| **CSP Security Group ID** | sg-mj7d6hrwmdy4yo1s8y96 |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7424,7 +8597,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my04-sg-03 |
-| **CSP Security Group ID** | sg-mj75u34nzaosi3yllnaa |
+| **CSP Security Group ID** | sg-mj780ni10nbsxrfvdoxa |
 | **VNet** | my04-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7499,7 +8672,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-19 13:45:42*
+*Report generated: 2026-06-02 11:59:06*
 
 ---
 
@@ -7543,9 +8716,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj78l1w5alug26k1iue6<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj78kbqw7hi5a8zeaefq<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj78kbqw7hi5a8zeaefr<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-mj7e35tls2uwpys3780q<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-mj7e35tls2uwpys3780r<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-mj7caxyslyfjiirlhjj0<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7567,9 +8740,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260316.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260316.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260316.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260506.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260506.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ubuntu_22_04_x64_20G_alibase_20260506.vhd<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu  22.04 64 bit | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -7579,7 +8752,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-01
 
-**CSP ID:** sg-mj7ih4az5ak2r4h23yto | **VNet:** my04-vnet-01 | **Rules:** 14
+**CSP ID:** sg-mj71w6ok3fzhi53tij5j | **VNet:** my04-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7607,7 +8780,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-02
 
-**CSP ID:** sg-mj79ymqgqpvl4d76crer | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj7d6hrwmdy4yo1s8y96 | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7640,7 +8813,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my04-sg-03
 
-**CSP ID:** sg-mj75u34nzaosi3yllnaa | **VNet:** my04-vnet-01 | **Rules:** 19
+**CSP ID:** sg-mj780ni10nbsxrfvdoxa | **VNet:** my04-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7681,13 +8854,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj7k204bw4tovqr3a2ktw | 10.0.0.0/21 |
+| 1 | **Name:** my04-vnet-01<br>**ID:** vpc-mj77rilp5f4fn312w79hj | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj7xbgrjm2hxt61onvgnf | 10.0.1.0/24 | my04-vnet-01 |
+| 1 | **Name:** my04-subnet-01<br>**ID:** vsw-mj713tfhuu6jxzc6pn93z | 10.0.1.0/24 | my04-vnet-01 |
 
 ### Source Network Information
 
@@ -7729,7 +8902,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my04-sshkey-01 | tbctg260p3imgi0c2cla | 339dcb6b1dc361b0dbca2945c9f8c08b | Used by all 3 VMs |
+| 1 | my04-sshkey-01 | tbkc0tqjtqulqspk3vmj | 1984834c76edccca44bb64d2bea3009a | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-aws.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-aws.md
@@ -7,19 +7,19 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (c574040)
-- cm-model: unknown
-- CB-Tumblebug: vunknown
-- CB-Spider: vunknown
-- CB-MapUI: vunknown
+- CM-Beetle: imdl/v0.1.5+ (4987539)
+- imdl: v0.1.5+ (4987539)
+- CB-Tumblebug: v0.12.13
+- CB-Spider: v0.12.26
+- CB-MapUI: v0.12.34
 - Target CSP: AWS
 - Target Region: ap-northeast-2
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 18, 2026
-- Test Time: 17:01:38 KST
-- Test Execution: 2026-05-18 17:01:38 KST
+- Test Date: June 2, 2026
+- Test Time: 20:57:02 KST
+- Test Execution: 2026-06-02 20:57:02 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 8.161s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 51.47s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 67ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 7ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 14ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 11.915s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m2.785s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 43ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 5ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 24ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.26s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.261s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 48.582s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.411s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.503s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 47.728s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 3m1.278720403s
+**Total Duration**: 3m17.5792455s
 
-*Test executed on May 18, 2026 at 17:01:38 KST (2026-05-18 17:01:38 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 20:57:02 KST (2026-06-02 20:57:02 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1967,7 +1967,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "aws-ap-northeast-2",
             "specId": "aws+ap-northeast-2+t3a.small",
-            "imageId": "ami-08a1c21841a4c7a5f",
+            "imageId": "ami-0596f7562954deb8e",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -1986,7 +1986,7 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "aws-ap-northeast-2",
             "specId": "aws+ap-northeast-2+t3a.xlarge",
-            "imageId": "ami-08a1c21841a4c7a5f",
+            "imageId": "ami-0596f7562954deb8e",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2005,7 +2005,7 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "aws-ap-northeast-2",
             "specId": "aws+ap-northeast-2+t3a.large",
-            "imageId": "ami-08a1c21841a4c7a5f",
+            "imageId": "ami-0596f7562954deb8e",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2049,7 +2049,7 @@
       "targetSpecList": [
         {
           "id": "aws+ap-northeast-2+t3a.small",
-          "uid": "d7k8jatq1uu3ogmrn28g",
+          "uid": "tbnsjonojsjqdqkd1270",
           "cspSpecName": "t3a.small",
           "name": "aws+ap-northeast-2+t3a.small",
           "namespace": "system",
@@ -2162,7 +2162,7 @@
         },
         {
           "id": "aws+ap-northeast-2+t3a.xlarge",
-          "uid": "d7k8jatq1uu3ogmrna20",
+          "uid": "tbi9aroitrku4r3m44pa",
           "cspSpecName": "t3a.xlarge",
           "name": "aws+ap-northeast-2+t3a.xlarge",
           "namespace": "system",
@@ -2275,7 +2275,7 @@
         },
         {
           "id": "aws+ap-northeast-2+t3a.large",
-          "uid": "d7k8jatq1uu3ogmrn6jg",
+          "uid": "tbafees5r4eb0o6oonhe",
           "cspSpecName": "t3a.large",
           "name": "aws+ap-northeast-2+t3a.large",
           "namespace": "system",
@@ -2392,26 +2392,26 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "aws",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "cspImageName": "ami-0596f7562954deb8e",
           "regionList": [
             "ap-northeast-2"
           ],
-          "id": "ami-08a1c21841a4c7a5f",
-          "uid": "d7k8jrtq1uu3ogmu5a80",
-          "name": "ami-08a1c21841a4c7a5f",
+          "id": "ami-0596f7562954deb8e",
+          "uid": "tb3ohim056hpf65all8h",
+          "name": "ami-0596f7562954deb8e",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "aws-ap-northeast-2",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:23 Wed",
-          "creationDate": "2026-04-10T07:02:45.000Z",
+          "fetchedTime": "2026.05.27 06:33:07 Wed",
+          "creationDate": "2026-05-21T07:01:17.000Z",
           "isGPUImage": false,
           "isKubernetesImage": false,
           "isBasicImage": true,
           "osType": "Ubuntu 22.04",
           "osArchitecture": "x86_64",
           "osPlatform": "Linux/UNIX",
-          "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410",
+          "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521",
           "osDiskType": "ebs",
           "osDiskSizeGB": -1,
           "imageStatus": "Available",
@@ -2422,7 +2422,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{DeleteOnTermination:true,Encrypted:false,Iops:null,KmsKeyId:null,OutpostArn:null,SnapshotId:snap-0ac37bfc8e74555b8,Throughput:null,VolumeSize:8,VolumeType:gp2},NoDevice:null,VirtualName:null}; {DeviceName:/dev/sdb,Ebs:null,NoDevice:null,VirtualName:ephemeral0}; {DeviceName:/dev/sdc,Ebs:null,NoDevice:null,VirtualName:ephemeral1}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{DeleteOnTermination:true,Encrypted:false,Iops:null,KmsKeyId:null,OutpostArn:null,SnapshotId:snap-05a6d6e4a7c5c5972,Throughput:null,VolumeSize:8,VolumeType:gp2},NoDevice:null,VirtualName:null}; {DeviceName:/dev/sdb,Ebs:null,NoDevice:null,VirtualName:ephemeral0}; {DeviceName:/dev/sdc,Ebs:null,NoDevice:null,VirtualName:ephemeral1}"
             },
             {
               "key": "BootMode",
@@ -2430,11 +2430,11 @@
             },
             {
               "key": "CreationDate",
-              "value": "2026-04-10T07:02:45.000Z"
+              "value": "2026-05-21T07:01:17.000Z"
             },
             {
               "key": "DeprecationTime",
-              "value": "2028-04-10T07:02:45.000Z"
+              "value": "2028-05-21T07:01:17.000Z"
             },
             {
               "key": "Description",
@@ -2450,11 +2450,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "ImageLocation",
-              "value": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+              "value": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
             },
             {
               "key": "ImageOwnerAlias",
@@ -2466,7 +2466,7 @@
             },
             {
               "key": "Name",
-              "value": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+              "value": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
             },
             {
               "key": "OwnerId",
@@ -2857,7 +2857,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "aws-ap-northeast-2",
             "specId": "aws+ap-northeast-2+t3.small",
-            "imageId": "ami-08a1c21841a4c7a5f",
+            "imageId": "ami-0596f7562954deb8e",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2876,7 +2876,7 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "aws-ap-northeast-2",
             "specId": "aws+ap-northeast-2+t3.xlarge",
-            "imageId": "ami-08a1c21841a4c7a5f",
+            "imageId": "ami-0596f7562954deb8e",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2895,7 +2895,7 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "aws-ap-northeast-2",
             "specId": "aws+ap-northeast-2+t3.large",
-            "imageId": "ami-08a1c21841a4c7a5f",
+            "imageId": "ami-0596f7562954deb8e",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2939,7 +2939,7 @@
       "targetSpecList": [
         {
           "id": "aws+ap-northeast-2+t3a.small",
-          "uid": "d7k8jatq1uu3ogmrn28g",
+          "uid": "tbnsjonojsjqdqkd1270",
           "cspSpecName": "t3a.small",
           "name": "aws+ap-northeast-2+t3a.small",
           "namespace": "system",
@@ -3052,7 +3052,7 @@
         },
         {
           "id": "aws+ap-northeast-2+t3a.xlarge",
-          "uid": "d7k8jatq1uu3ogmrna20",
+          "uid": "tbi9aroitrku4r3m44pa",
           "cspSpecName": "t3a.xlarge",
           "name": "aws+ap-northeast-2+t3a.xlarge",
           "namespace": "system",
@@ -3165,7 +3165,7 @@
         },
         {
           "id": "aws+ap-northeast-2+t3a.large",
-          "uid": "d7k8jatq1uu3ogmrn6jg",
+          "uid": "tbafees5r4eb0o6oonhe",
           "cspSpecName": "t3a.large",
           "name": "aws+ap-northeast-2+t3a.large",
           "namespace": "system",
@@ -3278,7 +3278,7 @@
         },
         {
           "id": "aws+ap-northeast-2+t3.small",
-          "uid": "d7k8jatq1uu3ogmrn93g",
+          "uid": "tblj285a69esu34esbk8",
           "cspSpecName": "t3.small",
           "name": "aws+ap-northeast-2+t3.small",
           "namespace": "system",
@@ -3391,7 +3391,7 @@
         },
         {
           "id": "aws+ap-northeast-2+t3.xlarge",
-          "uid": "d7k8jatq1uu3ogmrn2jg",
+          "uid": "tblk3qibfmcdjt5v3h64",
           "cspSpecName": "t3.xlarge",
           "name": "aws+ap-northeast-2+t3.xlarge",
           "namespace": "system",
@@ -3504,7 +3504,7 @@
         },
         {
           "id": "aws+ap-northeast-2+t3.large",
-          "uid": "d7k8jatq1uu3ogmrn2eg",
+          "uid": "tbb79ho0u3d33vdk40oq",
           "cspSpecName": "t3.large",
           "name": "aws+ap-northeast-2+t3.large",
           "namespace": "system",
@@ -3621,26 +3621,26 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "aws",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "cspImageName": "ami-0596f7562954deb8e",
           "regionList": [
             "ap-northeast-2"
           ],
-          "id": "ami-08a1c21841a4c7a5f",
-          "uid": "d7k8jrtq1uu3ogmu5a80",
-          "name": "ami-08a1c21841a4c7a5f",
+          "id": "ami-0596f7562954deb8e",
+          "uid": "tb3ohim056hpf65all8h",
+          "name": "ami-0596f7562954deb8e",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "aws-ap-northeast-2",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:23 Wed",
-          "creationDate": "2026-04-10T07:02:45.000Z",
+          "fetchedTime": "2026.05.27 06:33:07 Wed",
+          "creationDate": "2026-05-21T07:01:17.000Z",
           "isGPUImage": false,
           "isKubernetesImage": false,
           "isBasicImage": true,
           "osType": "Ubuntu 22.04",
           "osArchitecture": "x86_64",
           "osPlatform": "Linux/UNIX",
-          "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410",
+          "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521",
           "osDiskType": "ebs",
           "osDiskSizeGB": -1,
           "imageStatus": "Available",
@@ -3651,7 +3651,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{DeleteOnTermination:true,Encrypted:false,Iops:null,KmsKeyId:null,OutpostArn:null,SnapshotId:snap-0ac37bfc8e74555b8,Throughput:null,VolumeSize:8,VolumeType:gp2},NoDevice:null,VirtualName:null}; {DeviceName:/dev/sdb,Ebs:null,NoDevice:null,VirtualName:ephemeral0}; {DeviceName:/dev/sdc,Ebs:null,NoDevice:null,VirtualName:ephemeral1}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{DeleteOnTermination:true,Encrypted:false,Iops:null,KmsKeyId:null,OutpostArn:null,SnapshotId:snap-05a6d6e4a7c5c5972,Throughput:null,VolumeSize:8,VolumeType:gp2},NoDevice:null,VirtualName:null}; {DeviceName:/dev/sdb,Ebs:null,NoDevice:null,VirtualName:ephemeral0}; {DeviceName:/dev/sdc,Ebs:null,NoDevice:null,VirtualName:ephemeral1}"
             },
             {
               "key": "BootMode",
@@ -3659,11 +3659,11 @@
             },
             {
               "key": "CreationDate",
-              "value": "2026-04-10T07:02:45.000Z"
+              "value": "2026-05-21T07:01:17.000Z"
             },
             {
               "key": "DeprecationTime",
-              "value": "2028-04-10T07:02:45.000Z"
+              "value": "2028-05-21T07:01:17.000Z"
             },
             {
               "key": "Description",
@@ -3679,11 +3679,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "ImageLocation",
-              "value": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+              "value": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
             },
             {
               "key": "ImageOwnerAlias",
@@ -3695,7 +3695,7 @@
             },
             {
               "key": "Name",
-              "value": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+              "value": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
             },
             {
               "key": "OwnerId",
@@ -4092,7 +4092,7 @@
 {
   "resourceType": "infra",
   "id": "my01-infra101",
-  "uid": "tbd85cevepr9ha6omvqit0",
+  "uid": "tb2drt09mfdcqasro93p",
   "name": "my01-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -4120,7 +4120,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my01-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85cevepr9ha6omvqit0"
+    "sys.uid": "tb2drt09mfdcqasro93p"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -4129,9 +4129,9 @@
     {
       "resourceType": "node",
       "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85cevepr9ha6omvqiu0",
-      "cspResourceName": "tbd85cevepr9ha6omvqiu0",
-      "cspResourceId": "i-05cc436e2832ffd93",
+      "uid": "tb9lrr7qljeqacqgv2u5",
+      "cspResourceName": "tb9lrr7qljeqacqgv2u5",
+      "cspResourceId": "i-06534a82f97650b25",
       "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -4145,14 +4145,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:02:29",
+      "createdTime": "2026-06-02 11:57:58",
       "label": {
-        "Name": "tbd85cevepr9ha6omvqiu0",
+        "Name": "tb9lrr7qljeqacqgv2u5",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 08:02:29",
-        "sys.cspResourceId": "i-05cc436e2832ffd93",
-        "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
+        "sys.createdTime": "2026-06-02 11:57:58",
+        "sys.cspResourceId": "i-06534a82f97650b25",
+        "sys.cspResourceName": "tb9lrr7qljeqacqgv2u5",
         "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4161,7 +4161,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd85cevepr9ha6omvqiu0",
+        "sys.uid": "tb9lrr7qljeqacqgv2u5",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4169,11 +4169,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.203.239.151",
+      "publicIP": "52.78.244.82",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.41",
-      "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.140",
+      "privateDNS": "ip-10-0-1-140.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -4216,32 +4216,32 @@
         "memoryGiB": 2,
         "costPerHour": 0.0234
       },
-      "imageId": "ami-08a1c21841a4c7a5f",
-      "cspImageName": "ami-08a1c21841a4c7a5f",
+      "imageId": "ami-0596f7562954deb8e",
+      "cspImageName": "ami-0596f7562954deb8e",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ami-08a1c21841a4c7a5f",
+        "cspImageName": "ami-0596f7562954deb8e",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-07e218262146e7003",
+      "cspVNetId": "vpc-00b2b1e59e8d2653d",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0695096ac3c17916f",
-      "networkInterface": "eni-attach-04753091ce5855ac2",
+      "cspSubnetId": "subnet-005c104e63421b753",
+      "networkInterface": "eni-attach-05d9a8c5dc9658780",
       "securityGroupIds": [
         "my01-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+      "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJTQ3SSJJ7tSaj0WZyFGnlovTpmAJ3neLicuOZcZ8+5894+2Fg7gxHO3jPuVAXf7mjQZiXmXhr3ebTh7z3C5fNk=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
-        "firstUsedAt": "2026-05-18T08:02:39Z"
+        "fingerprint": "SHA256:3SwXDiiyzPRZcm7FKBhxVlokHTSSsW+3aNJln+hby+Y",
+        "firstUsedAt": "2026-06-02T11:58:07Z"
       },
       "commandStatus": [
         {
@@ -4249,11 +4249,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:02:37Z",
-          "completedTime": "2026-05-18T08:02:40Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-06-02T11:58:06Z",
+          "completedTime": "2026-06-02T11:58:08Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4268,7 +4268,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:39Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0e1622ebc7e0ae0be}}"
         },
         {
           "key": "BootMode",
@@ -4280,7 +4280,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
+          "value": "2A6DB7BA-D37C-45E3-8AFE-B062DEC1496A"
         },
         {
           "key": "CpuOptions",
@@ -4308,11 +4308,11 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-08a1c21841a4c7a5f"
+          "value": "ami-0596f7562954deb8e"
         },
         {
           "key": "InstanceId",
-          "value": "i-05cc436e2832ffd93"
+          "value": "i-06534a82f97650b25"
         },
         {
           "key": "InstanceType",
@@ -4320,11 +4320,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd85cetmpr9ha6omvqiog"
+          "value": "tbgkl68qoqbt2irs6nn1"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-18T08:02:08Z"
+          "value": "2026-06-02T11:57:38Z"
         },
         {
           "key": "MetadataOptions",
@@ -4336,7 +4336,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Attachment:{AttachTime:2026-06-02T11:57:38Z,AttachmentId:eni-attach-05d9a8c5dc9658780,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:55:94:dc:34:3b,NetworkInterfaceId:eni-04ea4fac87e5ad333,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.140,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.140}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
         },
         {
           "key": "Placement",
@@ -4344,15 +4344,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-140.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.41"
+          "value": "10.0.1.140"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.203.239.151"
+          "value": "52.78.244.82"
         },
         {
           "key": "RootDeviceName",
@@ -4364,7 +4364,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
+          "value": "{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}"
         },
         {
           "key": "SourceDestCheck",
@@ -4376,11 +4376,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0695096ac3c17916f"
+          "value": "subnet-005c104e63421b753"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
+          "value": "{Key:Name,Value:tb9lrr7qljeqacqgv2u5}"
         },
         {
           "key": "VirtualizationType",
@@ -4388,16 +4388,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-07e218262146e7003"
+          "value": "vpc-00b2b1e59e8d2653d"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85cevepr9ha6omvqj00",
-      "cspResourceName": "tbd85cevepr9ha6omvqj00",
-      "cspResourceId": "i-055c3be58ba3b717a",
+      "uid": "tbd9vt5h7b3mi7hlnsrl",
+      "cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
+      "cspResourceId": "i-0b8bf7f9b3b9876c4",
       "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -4411,14 +4411,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:02:31",
+      "createdTime": "2026-06-02 11:58:01",
       "label": {
-        "Name": "tbd85cevepr9ha6omvqj00",
+        "Name": "tbd9vt5h7b3mi7hlnsrl",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 08:02:31",
-        "sys.cspResourceId": "i-055c3be58ba3b717a",
-        "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
+        "sys.createdTime": "2026-06-02 11:58:01",
+        "sys.cspResourceId": "i-0b8bf7f9b3b9876c4",
+        "sys.cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
         "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4427,7 +4427,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd85cevepr9ha6omvqj00",
+        "sys.uid": "tbd9vt5h7b3mi7hlnsrl",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4435,11 +4435,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "13.124.168.73",
+      "publicIP": "43.201.83.130",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.46",
-      "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.136",
+      "privateDNS": "ip-10-0-1-136.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -4482,45 +4482,44 @@
         "memoryGiB": 8,
         "costPerHour": 0.0936
       },
-      "imageId": "ami-08a1c21841a4c7a5f",
-      "cspImageName": "ami-08a1c21841a4c7a5f",
+      "imageId": "ami-0596f7562954deb8e",
+      "cspImageName": "ami-0596f7562954deb8e",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ami-08a1c21841a4c7a5f",
+        "cspImageName": "ami-0596f7562954deb8e",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-07e218262146e7003",
+      "cspVNetId": "vpc-00b2b1e59e8d2653d",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0695096ac3c17916f",
-      "networkInterface": "eni-attach-0512107afc0efe575",
+      "cspSubnetId": "subnet-005c104e63421b753",
+      "networkInterface": "eni-attach-00d6d6972528706c2",
       "securityGroupIds": [
         "my01-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+      "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtx2r8Ou4fXFF0/0OPQ0Rk+x8nxvnqwJeTL+9tBaIzgNXkZJMZ89BpJskE2U2XGlPGjmzheQYG3idrFrwV6U98=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
-        "firstUsedAt": "2026-05-18T08:02:39Z"
+        "fingerprint": "SHA256:kledbHEJr8DxkYCKFS+YqOfbAGwfb7bYstah9IAFp4U",
+        "firstUsedAt": "2026-06-02T11:58:08Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-05-18T08:02:37Z",
-          "completedTime": "2026-05-18T08:02:40Z",
-          "elapsedTime": 3,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-06-02T11:58:06Z",
+          "completedTime": "2026-06-02T11:58:26Z",
+          "elapsedTime": 20,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -4534,7 +4533,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd90939abf365ee0}}"
         },
         {
           "key": "BootMode",
@@ -4546,7 +4545,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
+          "value": "8A15C17A-F15C-460F-A71C-A57EF5F8E78E"
         },
         {
           "key": "CpuOptions",
@@ -4574,11 +4573,11 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-08a1c21841a4c7a5f"
+          "value": "ami-0596f7562954deb8e"
         },
         {
           "key": "InstanceId",
-          "value": "i-055c3be58ba3b717a"
+          "value": "i-0b8bf7f9b3b9876c4"
         },
         {
           "key": "InstanceType",
@@ -4586,11 +4585,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd85cetmpr9ha6omvqiog"
+          "value": "tbgkl68qoqbt2irs6nn1"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-18T08:02:08Z"
+          "value": "2026-06-02T11:57:40Z"
         },
         {
           "key": "MetadataOptions",
@@ -4602,7 +4601,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-00d6d6972528706c2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:67:60:31:ee:45,NetworkInterfaceId:eni-010ee71d81f863c52,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.136,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.136}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
         },
         {
           "key": "Placement",
@@ -4610,15 +4609,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-136.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.46"
+          "value": "10.0.1.136"
         },
         {
           "key": "PublicIpAddress",
-          "value": "13.124.168.73"
+          "value": "43.201.83.130"
         },
         {
           "key": "RootDeviceName",
@@ -4630,7 +4629,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
+          "value": "{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}"
         },
         {
           "key": "SourceDestCheck",
@@ -4642,11 +4641,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0695096ac3c17916f"
+          "value": "subnet-005c104e63421b753"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
+          "value": "{Key:Name,Value:tbd9vt5h7b3mi7hlnsrl}"
         },
         {
           "key": "VirtualizationType",
@@ -4654,16 +4653,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-07e218262146e7003"
+          "value": "vpc-00b2b1e59e8d2653d"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85cevepr9ha6omvqiv0",
-      "cspResourceName": "tbd85cevepr9ha6omvqiv0",
-      "cspResourceId": "i-0fa2d84cd0c6e08bb",
+      "uid": "tbrh382k22c02gj6or2q",
+      "cspResourceName": "tbrh382k22c02gj6or2q",
+      "cspResourceId": "i-0273cb7e68fdf8fac",
       "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4677,14 +4676,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:02:28",
+      "createdTime": "2026-06-02 11:58:00",
       "label": {
-        "Name": "tbd85cevepr9ha6omvqiv0",
+        "Name": "tbrh382k22c02gj6or2q",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 08:02:28",
-        "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
-        "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
+        "sys.createdTime": "2026-06-02 11:58:00",
+        "sys.cspResourceId": "i-0273cb7e68fdf8fac",
+        "sys.cspResourceName": "tbrh382k22c02gj6or2q",
         "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -4693,7 +4692,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd85cevepr9ha6omvqiv0",
+        "sys.uid": "tbrh382k22c02gj6or2q",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4701,11 +4700,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "52.78.166.174",
+      "publicIP": "52.78.4.197",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.204",
-      "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.239",
+      "privateDNS": "ip-10-0-1-239.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -4748,45 +4747,44 @@
         "memoryGiB": 16,
         "costPerHour": 0.1872
       },
-      "imageId": "ami-08a1c21841a4c7a5f",
-      "cspImageName": "ami-08a1c21841a4c7a5f",
+      "imageId": "ami-0596f7562954deb8e",
+      "cspImageName": "ami-0596f7562954deb8e",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ami-08a1c21841a4c7a5f",
+        "cspImageName": "ami-0596f7562954deb8e",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-07e218262146e7003",
+      "cspVNetId": "vpc-00b2b1e59e8d2653d",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0695096ac3c17916f",
-      "networkInterface": "eni-attach-0dacfd07e29c82162",
+      "cspSubnetId": "subnet-005c104e63421b753",
+      "networkInterface": "eni-attach-0638cbee4cdabd7bd",
       "securityGroupIds": [
         "my01-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+      "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBH97D952EztvAI/plpOdoCRtd21dx035GA7gRqjte2Nms1wIDFCgt9jQFauHyJRz8HXg/43acRo6d4xSZzc2ACw=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
-        "firstUsedAt": "2026-05-18T08:02:37Z"
+        "fingerprint": "SHA256:Fk9INcBJUzgOLcr6k2etg2P8ucfdRb5QkjAk/dNW5Bo",
+        "firstUsedAt": "2026-06-02T11:58:08Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-05-18T08:02:37Z",
-          "completedTime": "2026-05-18T08:02:40Z",
-          "elapsedTime": 3,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-06-02T11:58:06Z",
+          "completedTime": "2026-06-02T11:58:26Z",
+          "elapsedTime": 20,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -4800,7 +4798,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0387f952743f64ec0}}"
         },
         {
           "key": "BootMode",
@@ -4812,7 +4810,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
+          "value": "9F574316-EB84-4652-B3FF-92E90421877B"
         },
         {
           "key": "CpuOptions",
@@ -4840,11 +4838,11 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-08a1c21841a4c7a5f"
+          "value": "ami-0596f7562954deb8e"
         },
         {
           "key": "InstanceId",
-          "value": "i-0fa2d84cd0c6e08bb"
+          "value": "i-0273cb7e68fdf8fac"
         },
         {
           "key": "InstanceType",
@@ -4852,11 +4850,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd85cetmpr9ha6omvqiog"
+          "value": "tbgkl68qoqbt2irs6nn1"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-18T08:02:07Z"
+          "value": "2026-06-02T11:57:40Z"
         },
         {
           "key": "MetadataOptions",
@@ -4868,7 +4866,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-0638cbee4cdabd7bd,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c1:be:34:65:23,NetworkInterfaceId:eni-0dff89b4de2d2ff27,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.239,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.239}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
         },
         {
           "key": "Placement",
@@ -4876,15 +4874,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-239.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.204"
+          "value": "10.0.1.239"
         },
         {
           "key": "PublicIpAddress",
-          "value": "52.78.166.174"
+          "value": "52.78.4.197"
         },
         {
           "key": "RootDeviceName",
@@ -4896,7 +4894,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
+          "value": "{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}"
         },
         {
           "key": "SourceDestCheck",
@@ -4908,11 +4906,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0695096ac3c17916f"
+          "value": "subnet-005c104e63421b753"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
+          "value": "{Key:Name,Value:tbrh382k22c02gj6or2q}"
         },
         {
           "key": "VirtualizationType",
@@ -4920,7 +4918,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-07e218262146e7003"
+          "value": "vpc-00b2b1e59e8d2653d"
         }
       ]
     }
@@ -4936,13 +4934,13 @@
     "results": [
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "52.78.166.174",
+        "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "52.78.244.82",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4951,32 +4949,24 @@
       },
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "43.203.239.151",
+        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "52.78.4.197",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       },
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "13.124.168.73",
+        "nodeIp": "43.201.83.130",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       }
     ]
@@ -5008,7 +4998,7 @@
     {
       "resourceType": "infra",
       "id": "my01-infra101",
-      "uid": "tbd85cevepr9ha6omvqit0",
+      "uid": "tb2drt09mfdcqasro93p",
       "name": "my01-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -5036,7 +5026,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my01-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85cevepr9ha6omvqit0"
+        "sys.uid": "tb2drt09mfdcqasro93p"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5045,9 +5035,9 @@
         {
           "resourceType": "node",
           "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85cevepr9ha6omvqiu0",
-          "cspResourceName": "tbd85cevepr9ha6omvqiu0",
-          "cspResourceId": "i-05cc436e2832ffd93",
+          "uid": "tb9lrr7qljeqacqgv2u5",
+          "cspResourceName": "tb9lrr7qljeqacqgv2u5",
+          "cspResourceId": "i-06534a82f97650b25",
           "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -5061,14 +5051,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:29",
+          "createdTime": "2026-06-02 11:57:58",
           "label": {
-            "Name": "tbd85cevepr9ha6omvqiu0",
+            "Name": "tb9lrr7qljeqacqgv2u5",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:29",
-            "sys.cspResourceId": "i-05cc436e2832ffd93",
-            "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
+            "sys.createdTime": "2026-06-02 11:57:58",
+            "sys.cspResourceId": "i-06534a82f97650b25",
+            "sys.cspResourceName": "tb9lrr7qljeqacqgv2u5",
             "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5077,7 +5067,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd85cevepr9ha6omvqiu0",
+            "sys.uid": "tb9lrr7qljeqacqgv2u5",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5085,11 +5075,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "43.203.239.151",
+          "publicIP": "52.78.244.82",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.41",
-          "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.140",
+          "privateDNS": "ip-10-0-1-140.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
@@ -5132,32 +5122,32 @@
             "memoryGiB": 2,
             "costPerHour": 0.0234
           },
-          "imageId": "ami-08a1c21841a4c7a5f",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "cspImageName": "ami-0596f7562954deb8e",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-07e218262146e7003",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0695096ac3c17916f",
-          "networkInterface": "eni-attach-04753091ce5855ac2",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-05d9a8c5dc9658780",
           "securityGroupIds": [
             "my01-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJTQ3SSJJ7tSaj0WZyFGnlovTpmAJ3neLicuOZcZ8+5894+2Fg7gxHO3jPuVAXf7mjQZiXmXhr3ebTh7z3C5fNk=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
-            "firstUsedAt": "2026-05-18T08:02:39Z"
+            "fingerprint": "SHA256:3SwXDiiyzPRZcm7FKBhxVlokHTSSsW+3aNJln+hby+Y",
+            "firstUsedAt": "2026-06-02T11:58:07Z"
           },
           "commandStatus": [
             {
@@ -5165,11 +5155,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:02:37Z",
-              "completedTime": "2026-05-18T08:02:40Z",
-              "elapsedTime": 3,
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:08Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5184,7 +5174,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:39Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0e1622ebc7e0ae0be}}"
             },
             {
               "key": "BootMode",
@@ -5196,7 +5186,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
+              "value": "2A6DB7BA-D37C-45E3-8AFE-B062DEC1496A"
             },
             {
               "key": "CpuOptions",
@@ -5224,11 +5214,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "InstanceId",
-              "value": "i-05cc436e2832ffd93"
+              "value": "i-06534a82f97650b25"
             },
             {
               "key": "InstanceType",
@@ -5236,11 +5226,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd85cetmpr9ha6omvqiog"
+              "value": "tbgkl68qoqbt2irs6nn1"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-18T08:02:08Z"
+              "value": "2026-06-02T11:57:38Z"
             },
             {
               "key": "MetadataOptions",
@@ -5252,7 +5242,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Attachment:{AttachTime:2026-06-02T11:57:38Z,AttachmentId:eni-attach-05d9a8c5dc9658780,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:55:94:dc:34:3b,NetworkInterfaceId:eni-04ea4fac87e5ad333,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.140,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.140}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
             },
             {
               "key": "Placement",
@@ -5260,15 +5250,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-140.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.41"
+              "value": "10.0.1.140"
             },
             {
               "key": "PublicIpAddress",
-              "value": "43.203.239.151"
+              "value": "52.78.244.82"
             },
             {
               "key": "RootDeviceName",
@@ -5280,7 +5270,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
+              "value": "{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}"
             },
             {
               "key": "SourceDestCheck",
@@ -5292,11 +5282,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0695096ac3c17916f"
+              "value": "subnet-005c104e63421b753"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
+              "value": "{Key:Name,Value:tb9lrr7qljeqacqgv2u5}"
             },
             {
               "key": "VirtualizationType",
@@ -5304,16 +5294,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-07e218262146e7003"
+              "value": "vpc-00b2b1e59e8d2653d"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85cevepr9ha6omvqj00",
-          "cspResourceName": "tbd85cevepr9ha6omvqj00",
-          "cspResourceId": "i-055c3be58ba3b717a",
+          "uid": "tbd9vt5h7b3mi7hlnsrl",
+          "cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
+          "cspResourceId": "i-0b8bf7f9b3b9876c4",
           "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5327,14 +5317,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:31",
+          "createdTime": "2026-06-02 11:58:01",
           "label": {
-            "Name": "tbd85cevepr9ha6omvqj00",
+            "Name": "tbd9vt5h7b3mi7hlnsrl",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:31",
-            "sys.cspResourceId": "i-055c3be58ba3b717a",
-            "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
+            "sys.createdTime": "2026-06-02 11:58:01",
+            "sys.cspResourceId": "i-0b8bf7f9b3b9876c4",
+            "sys.cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
             "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5343,7 +5333,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd85cevepr9ha6omvqj00",
+            "sys.uid": "tbd9vt5h7b3mi7hlnsrl",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5351,11 +5341,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "13.124.168.73",
+          "publicIP": "43.201.83.130",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.46",
-          "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.136",
+          "privateDNS": "ip-10-0-1-136.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
@@ -5398,45 +5388,44 @@
             "memoryGiB": 8,
             "costPerHour": 0.0936
           },
-          "imageId": "ami-08a1c21841a4c7a5f",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "cspImageName": "ami-0596f7562954deb8e",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-07e218262146e7003",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0695096ac3c17916f",
-          "networkInterface": "eni-attach-0512107afc0efe575",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-00d6d6972528706c2",
           "securityGroupIds": [
             "my01-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtx2r8Ou4fXFF0/0OPQ0Rk+x8nxvnqwJeTL+9tBaIzgNXkZJMZ89BpJskE2U2XGlPGjmzheQYG3idrFrwV6U98=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
-            "firstUsedAt": "2026-05-18T08:02:39Z"
+            "fingerprint": "SHA256:kledbHEJr8DxkYCKFS+YqOfbAGwfb7bYstah9IAFp4U",
+            "firstUsedAt": "2026-06-02T11:58:08Z"
           },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-05-18T08:02:37Z",
-              "completedTime": "2026-05-18T08:02:40Z",
-              "elapsedTime": 3,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
+              "status": "Failed",
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:26Z",
+              "elapsedTime": 20,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -5450,7 +5439,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd90939abf365ee0}}"
             },
             {
               "key": "BootMode",
@@ -5462,7 +5451,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
+              "value": "8A15C17A-F15C-460F-A71C-A57EF5F8E78E"
             },
             {
               "key": "CpuOptions",
@@ -5490,11 +5479,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "InstanceId",
-              "value": "i-055c3be58ba3b717a"
+              "value": "i-0b8bf7f9b3b9876c4"
             },
             {
               "key": "InstanceType",
@@ -5502,11 +5491,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd85cetmpr9ha6omvqiog"
+              "value": "tbgkl68qoqbt2irs6nn1"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-18T08:02:08Z"
+              "value": "2026-06-02T11:57:40Z"
             },
             {
               "key": "MetadataOptions",
@@ -5518,7 +5507,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-00d6d6972528706c2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:67:60:31:ee:45,NetworkInterfaceId:eni-010ee71d81f863c52,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.136,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.136}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
             },
             {
               "key": "Placement",
@@ -5526,15 +5515,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-136.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.46"
+              "value": "10.0.1.136"
             },
             {
               "key": "PublicIpAddress",
-              "value": "13.124.168.73"
+              "value": "43.201.83.130"
             },
             {
               "key": "RootDeviceName",
@@ -5546,7 +5535,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
+              "value": "{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}"
             },
             {
               "key": "SourceDestCheck",
@@ -5558,11 +5547,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0695096ac3c17916f"
+              "value": "subnet-005c104e63421b753"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
+              "value": "{Key:Name,Value:tbd9vt5h7b3mi7hlnsrl}"
             },
             {
               "key": "VirtualizationType",
@@ -5570,16 +5559,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-07e218262146e7003"
+              "value": "vpc-00b2b1e59e8d2653d"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85cevepr9ha6omvqiv0",
-          "cspResourceName": "tbd85cevepr9ha6omvqiv0",
-          "cspResourceId": "i-0fa2d84cd0c6e08bb",
+          "uid": "tbrh382k22c02gj6or2q",
+          "cspResourceName": "tbrh382k22c02gj6or2q",
+          "cspResourceId": "i-0273cb7e68fdf8fac",
           "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5593,14 +5582,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:28",
+          "createdTime": "2026-06-02 11:58:00",
           "label": {
-            "Name": "tbd85cevepr9ha6omvqiv0",
+            "Name": "tbrh382k22c02gj6or2q",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:28",
-            "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
-            "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
+            "sys.createdTime": "2026-06-02 11:58:00",
+            "sys.cspResourceId": "i-0273cb7e68fdf8fac",
+            "sys.cspResourceName": "tbrh382k22c02gj6or2q",
             "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5609,7 +5598,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd85cevepr9ha6omvqiv0",
+            "sys.uid": "tbrh382k22c02gj6or2q",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5617,11 +5606,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "52.78.166.174",
+          "publicIP": "52.78.4.197",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.204",
-          "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.239",
+          "privateDNS": "ip-10-0-1-239.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
@@ -5664,45 +5653,44 @@
             "memoryGiB": 16,
             "costPerHour": 0.1872
           },
-          "imageId": "ami-08a1c21841a4c7a5f",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "cspImageName": "ami-0596f7562954deb8e",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-07e218262146e7003",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0695096ac3c17916f",
-          "networkInterface": "eni-attach-0dacfd07e29c82162",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-0638cbee4cdabd7bd",
           "securityGroupIds": [
             "my01-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBH97D952EztvAI/plpOdoCRtd21dx035GA7gRqjte2Nms1wIDFCgt9jQFauHyJRz8HXg/43acRo6d4xSZzc2ACw=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
-            "firstUsedAt": "2026-05-18T08:02:37Z"
+            "fingerprint": "SHA256:Fk9INcBJUzgOLcr6k2etg2P8ucfdRb5QkjAk/dNW5Bo",
+            "firstUsedAt": "2026-06-02T11:58:08Z"
           },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-05-18T08:02:37Z",
-              "completedTime": "2026-05-18T08:02:40Z",
-              "elapsedTime": 3,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
+              "status": "Failed",
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:26Z",
+              "elapsedTime": 20,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -5716,7 +5704,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0387f952743f64ec0}}"
             },
             {
               "key": "BootMode",
@@ -5728,7 +5716,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
+              "value": "9F574316-EB84-4652-B3FF-92E90421877B"
             },
             {
               "key": "CpuOptions",
@@ -5756,11 +5744,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "InstanceId",
-              "value": "i-0fa2d84cd0c6e08bb"
+              "value": "i-0273cb7e68fdf8fac"
             },
             {
               "key": "InstanceType",
@@ -5768,11 +5756,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd85cetmpr9ha6omvqiog"
+              "value": "tbgkl68qoqbt2irs6nn1"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-18T08:02:07Z"
+              "value": "2026-06-02T11:57:40Z"
             },
             {
               "key": "MetadataOptions",
@@ -5784,7 +5772,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-0638cbee4cdabd7bd,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c1:be:34:65:23,NetworkInterfaceId:eni-0dff89b4de2d2ff27,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.239,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.239}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
             },
             {
               "key": "Placement",
@@ -5792,15 +5780,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-239.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.204"
+              "value": "10.0.1.239"
             },
             {
               "key": "PublicIpAddress",
-              "value": "52.78.166.174"
+              "value": "52.78.4.197"
             },
             {
               "key": "RootDeviceName",
@@ -5812,7 +5800,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
+              "value": "{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}"
             },
             {
               "key": "SourceDestCheck",
@@ -5824,11 +5812,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0695096ac3c17916f"
+              "value": "subnet-005c104e63421b753"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
+              "value": "{Key:Name,Value:tbrh382k22c02gj6or2q}"
             },
             {
               "key": "VirtualizationType",
@@ -5836,7 +5824,7 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-07e218262146e7003"
+              "value": "vpc-00b2b1e59e8d2653d"
             }
           ]
         }
@@ -5852,13 +5840,13 @@
         "results": [
           {
             "infraId": "my01-infra101",
-            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "52.78.166.174",
+            "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "52.78.244.82",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5867,32 +5855,24 @@
           },
           {
             "infraId": "my01-infra101",
-            "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "43.203.239.151",
+            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "52.78.4.197",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {
-              "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
+            "stdout": {},
+            "stderr": {},
             "err": null
           },
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "13.124.168.73",
+            "nodeIp": "43.201.83.130",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {
-              "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
+            "stdout": {},
+            "stderr": {},
             "err": null
           }
         ]
@@ -5901,7 +5881,7 @@
     {
       "resourceType": "infra",
       "id": "my02-infra101",
-      "uid": "tbd85cf3epr9ha6omvqjbg",
+      "uid": "tbv4r5dg0r6ctsgj7tfe",
       "name": "my02-infra101",
       "status": "Creating:3 (R:0/3)",
       "statusCount": {
@@ -5929,7 +5909,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my02-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjbg"
+        "sys.uid": "tbv4r5dg0r6ctsgj7tfe"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5938,7 +5918,7 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85cf3epr9ha6omvqjcg",
+          "uid": "tb81h514blbmih6th0ra",
           "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -5995,8 +5975,8 @@
           "specId": "azure+koreasouth+standard_b2als_v2",
           "cspSpecName": "",
           "spec": {},
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
           "image": {
             "osType": ""
           },
@@ -6015,7 +5995,7 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85cf3epr9ha6omvqjeg",
+          "uid": "tbj3l6ut11ch7mvkq2p2",
           "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -6072,8 +6052,8 @@
           "specId": "azure+koreasouth+standard_b2as_v2",
           "cspSpecName": "",
           "spec": {},
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
           "image": {
             "osType": ""
           },
@@ -6092,7 +6072,7 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85cf3epr9ha6omvqjdg",
+          "uid": "tblumcks3qbld4l0rqdu",
           "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -6149,8 +6129,8 @@
           "specId": "azure+koreasouth+standard_b4as_v2",
           "cspSpecName": "",
           "spec": {},
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
           "image": {
             "osType": ""
           },
@@ -6181,13 +6161,13 @@
     {
       "resourceType": "infra",
       "id": "my04-infra101",
-      "uid": "tbd85cf1upr9ha6omvqj60",
+      "uid": "tbsb9sq51v4fnsipkeap",
       "name": "my04-infra101",
-      "status": "Creating:3 (R:0/3)",
+      "status": "Running:3 (R:3/3)",
       "statusCount": {
         "countTotal": 3,
-        "countCreating": 3,
-        "countRunning": 0,
+        "countCreating": 0,
+        "countRunning": 3,
         "countFailed": 0,
         "countSuspended": 0,
         "countRebooting": 0,
@@ -6198,8 +6178,8 @@
         "countRegistering": 0,
         "countUndefined": 0
       },
-      "targetStatus": "Running",
-      "targetAction": "Create",
+      "targetStatus": "None",
+      "targetAction": "None",
       "installMonAgent": "",
       "configureCloudAdaptiveNetwork": "",
       "label": {
@@ -6209,7 +6189,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my04-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85cf1upr9ha6omvqj60"
+        "sys.uid": "tbsb9sq51v4fnsipkeap"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -6218,7 +6198,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85cf1upr9ha6omvqj70",
+          "uid": "tbhs2tl9c3te0mksjp02",
+          "cspResourceName": "tbhs2tl9c3te0mksjp02",
+          "cspResourceId": "i-mj7e35tls2uwpys3780q",
           "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -6226,26 +6208,43 @@
             "latitude": 37.36,
             "longitude": 126.78
           },
-          "status": "Creating",
-          "targetStatus": "Running",
-          "targetAction": "Create",
-          "monAgentStatus": "",
-          "networkAgentStatus": "",
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "",
-          "label": null,
+          "createdTime": "2026-06-02 11:58:17",
+          "label": {
+            "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.connectionName": "alibaba-ap-northeast-2",
+            "sys.createdTime": "2026-06-02 11:58:17",
+            "sys.cspResourceId": "i-mj7e35tls2uwpys3780q",
+            "sys.cspResourceName": "tbhs2tl9c3te0mksjp02",
+            "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.infraId": "my04-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.subnetId": "my04-subnet-01",
+            "sys.uid": "tbhs2tl9c3te0mksjp02",
+            "sys.vNetId": "my04-vnet-01"
+          },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
           "region": {
-            "region": ""
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
           },
-          "publicIP": "",
-          "sshPort": 0,
+          "publicIP": "8.213.148.90",
+          "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "",
+          "privateIP": "10.0.1.130",
           "privateDNS": "",
-          "rootDiskType": "",
+          "rootDiskType": "cloud_auto",
           "rootDiskSize": 40,
-          "RootDeviceName": "",
+          "RootDeviceName": "/dev/xvda",
           "connectionName": "alibaba-ap-northeast-2",
           "connectionConfig": {
             "configName": "alibaba-ap-northeast-2",
@@ -6276,29 +6275,295 @@
             "verified": true
           },
           "specId": "alibaba+ap-northeast-2+ecs.e-c1m1.large",
-          "cspSpecName": "",
-          "spec": {},
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspSpecName": "ecs.e-c1m1.large",
+          "spec": {
+            "cspSpecName": "ecs.e-c1m1.large",
+            "vCPU": 2,
+            "memoryGiB": 2,
+            "costPerHour": 0.0178
+          },
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
-            "osType": ""
+            "resourceType": "image",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "",
-          "networkInterface": "",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7e35tls2uwpys2lvv7",
           "securityGroupIds": [
             "my04-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": ""
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
+          "nodeUserName": "cb-user",
+          "nodeUserPassword": "$cpn1fbmnt!Abl",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNhMNxzCV4xDgqQZg5+XGyt06ozb7LlWixrfbFJWox/iiHeJdkvx+xu/LmaVx6kjg/KPkOVil3M8LlcpqqmEpdk=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:wyhhKV/Me4xRzt4oodcl1P0bOWE1botx6CeeFuzBOW0",
+            "firstUsedAt": "2026-06-02T11:58:31Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Handling",
+              "startedTime": "2026-06-02T11:58:31Z"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "ImageId",
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
+            },
+            {
+              "key": "InstanceType",
+              "value": "ecs.e-c1m1.large"
+            },
+            {
+              "key": "DeviceAvailable",
+              "value": "true"
+            },
+            {
+              "key": "InstanceNetworkType",
+              "value": "vpc"
+            },
+            {
+              "key": "LocalStorageAmount",
+              "value": "0"
+            },
+            {
+              "key": "IsSpot",
+              "value": "false"
+            },
+            {
+              "key": "InstanceChargeType",
+              "value": "PostPaid"
+            },
+            {
+              "key": "InstanceName",
+              "value": "tbhs2tl9c3te0mksjp02"
+            },
+            {
+              "key": "DeploymentSetGroupNo",
+              "value": "0"
+            },
+            {
+              "key": "GPUAmount",
+              "value": "0"
+            },
+            {
+              "key": "Connected",
+              "value": "false"
+            },
+            {
+              "key": "InvocationCount",
+              "value": "0"
+            },
+            {
+              "key": "StartTime",
+              "value": "2026-06-02T11:57Z"
+            },
+            {
+              "key": "ZoneId",
+              "value": "ap-northeast-2a"
+            },
+            {
+              "key": "InternetMaxBandwidthIn",
+              "value": "200"
+            },
+            {
+              "key": "InternetChargeType",
+              "value": "PayByBandwidth"
+            },
+            {
+              "key": "HostName",
+              "value": "iZmj7e35tls2uwpys3780qZ"
+            },
+            {
+              "key": "Status",
+              "value": "Running"
+            },
+            {
+              "key": "CPU",
+              "value": "0"
+            },
+            {
+              "key": "Cpu",
+              "value": "2"
+            },
+            {
+              "key": "SpotPriceLimit",
+              "value": "0.00"
+            },
+            {
+              "key": "OSName",
+              "value": "Ubuntu  22.04 64位"
+            },
+            {
+              "key": "InstanceOwnerId",
+              "value": "0"
+            },
+            {
+              "key": "OSNameEn",
+              "value": "Ubuntu  22.04 64 bit"
+            },
+            {
+              "key": "SerialNumber",
+              "value": "aaf96940-aed7-409b-939f-aea783b600b6"
+            },
+            {
+              "key": "RegionId",
+              "value": "ap-northeast-2"
+            },
+            {
+              "key": "IoOptimized",
+              "value": "true"
+            },
+            {
+              "key": "InternetMaxBandwidthOut",
+              "value": "5"
+            },
+            {
+              "key": "InstanceTypeFamily",
+              "value": "ecs.e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-mj7e35tls2uwpys3780q"
+            },
+            {
+              "key": "Recyclable",
+              "value": "false"
+            },
+            {
+              "key": "ExpiredTime",
+              "value": "2099-12-31T15:59Z"
+            },
+            {
+              "key": "OSType",
+              "value": "linux"
+            },
+            {
+              "key": "Memory",
+              "value": "2048"
+            },
+            {
+              "key": "CreationTime",
+              "value": "2026-06-02T11:57Z"
+            },
+            {
+              "key": "KeyPairName",
+              "value": "tbkc0tqjtqulqspk3vmj"
+            },
+            {
+              "key": "LocalStorageCapacity",
+              "value": "0"
+            },
+            {
+              "key": "StoppedMode",
+              "value": "Not-applicable"
+            },
+            {
+              "key": "SpotStrategy",
+              "value": "NoSpot"
+            },
+            {
+              "key": "SpotDuration",
+              "value": "0"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "SecurityGroupIds",
+              "value": "{SecurityGroupId:[sg-mj71w6ok3fzhi53tij5j]}"
+            },
+            {
+              "key": "InnerIpAddress",
+              "value": "{IpAddress:[]}"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "{IpAddress:[8.213.148.90]}"
+            },
+            {
+              "key": "RdmaIpAddress",
+              "value": "{IpAddress:null}"
+            },
+            {
+              "key": "DedicatedHostAttribute",
+              "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+            },
+            {
+              "key": "EcsCapacityReservationAttr",
+              "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:1,CoreFactor:0,Numa:ON,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "DedicatedInstanceAttribute",
+              "value": "{Affinity:,Tenancy:}"
+            },
+            {
+              "key": "PrivateDnsNameOptions",
+              "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+            },
+            {
+              "key": "AdditionalInfo",
+              "value": "{EnableHighDensityMode:false}"
+            },
+            {
+              "key": "ImageOptions",
+              "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+            },
+            {
+              "key": "EipAddress",
+              "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+            },
+            {
+              "key": "VpcAttributes",
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.130]}}"
+            },
+            {
+              "key": "Tags",
+              "value": "{Tag:null}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a8,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvv7,PrimaryIpAddress:10.0.1.130,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.130,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+            },
+            {
+              "key": "OperationLocks",
+              "value": "{LockReason:[]}"
+            }
+          ]
         },
         {
           "resourceType": "node",
           "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85cf1upr9ha6omvqj90",
+          "uid": "tbcpprl9juav33e9q3c2",
+          "cspResourceName": "tbcpprl9juav33e9q3c2",
+          "cspResourceId": "i-mj7e35tls2uwpys3780r",
           "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -6306,26 +6571,43 @@
             "latitude": 37.36,
             "longitude": 126.78
           },
-          "status": "Creating",
-          "targetStatus": "Running",
-          "targetAction": "Create",
-          "monAgentStatus": "",
-          "networkAgentStatus": "",
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "",
-          "label": null,
+          "createdTime": "2026-06-02 11:58:24",
+          "label": {
+            "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.connectionName": "alibaba-ap-northeast-2",
+            "sys.createdTime": "2026-06-02 11:58:24",
+            "sys.cspResourceId": "i-mj7e35tls2uwpys3780r",
+            "sys.cspResourceName": "tbcpprl9juav33e9q3c2",
+            "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.infraId": "my04-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.subnetId": "my04-subnet-01",
+            "sys.uid": "tbcpprl9juav33e9q3c2",
+            "sys.vNetId": "my04-vnet-01"
+          },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
           "region": {
-            "region": ""
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
           },
-          "publicIP": "",
-          "sshPort": 0,
+          "publicIP": "47.80.241.105",
+          "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "",
+          "privateIP": "10.0.1.131",
           "privateDNS": "",
-          "rootDiskType": "",
+          "rootDiskType": "cloud_essd_entry",
           "rootDiskSize": 40,
-          "RootDeviceName": "",
+          "RootDeviceName": "/dev/xvda",
           "connectionName": "alibaba-ap-northeast-2",
           "connectionConfig": {
             "configName": "alibaba-ap-northeast-2",
@@ -6356,29 +6638,289 @@
             "verified": true
           },
           "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.large",
-          "cspSpecName": "",
-          "spec": {},
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspSpecName": "ecs.e-c1m4.large",
+          "spec": {
+            "cspSpecName": "ecs.e-c1m4.large",
+            "vCPU": 2,
+            "memoryGiB": 8,
+            "costPerHour": 0.0791
+          },
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
-            "osType": ""
+            "resourceType": "image",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "",
-          "networkInterface": "",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7e35tls2uwpys2lvva",
           "securityGroupIds": [
             "my04-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": ""
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
+          "nodeUserName": "cb-user",
+          "nodeUserPassword": "og1p!0lt8bfAm$",
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Handling",
+              "startedTime": "2026-06-02T11:58:31Z"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "ImageId",
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
+            },
+            {
+              "key": "InstanceType",
+              "value": "ecs.e-c1m4.large"
+            },
+            {
+              "key": "DeviceAvailable",
+              "value": "true"
+            },
+            {
+              "key": "InstanceNetworkType",
+              "value": "vpc"
+            },
+            {
+              "key": "LocalStorageAmount",
+              "value": "0"
+            },
+            {
+              "key": "IsSpot",
+              "value": "false"
+            },
+            {
+              "key": "InstanceChargeType",
+              "value": "PostPaid"
+            },
+            {
+              "key": "InstanceName",
+              "value": "tbcpprl9juav33e9q3c2"
+            },
+            {
+              "key": "DeploymentSetGroupNo",
+              "value": "0"
+            },
+            {
+              "key": "GPUAmount",
+              "value": "0"
+            },
+            {
+              "key": "Connected",
+              "value": "false"
+            },
+            {
+              "key": "InvocationCount",
+              "value": "0"
+            },
+            {
+              "key": "StartTime",
+              "value": "2026-06-02T11:57Z"
+            },
+            {
+              "key": "ZoneId",
+              "value": "ap-northeast-2a"
+            },
+            {
+              "key": "InternetMaxBandwidthIn",
+              "value": "400"
+            },
+            {
+              "key": "InternetChargeType",
+              "value": "PayByBandwidth"
+            },
+            {
+              "key": "HostName",
+              "value": "iZmj7e35tls2uwpys3780rZ"
+            },
+            {
+              "key": "Status",
+              "value": "Running"
+            },
+            {
+              "key": "CPU",
+              "value": "0"
+            },
+            {
+              "key": "Cpu",
+              "value": "2"
+            },
+            {
+              "key": "SpotPriceLimit",
+              "value": "0.00"
+            },
+            {
+              "key": "OSName",
+              "value": "Ubuntu  22.04 64位"
+            },
+            {
+              "key": "InstanceOwnerId",
+              "value": "0"
+            },
+            {
+              "key": "OSNameEn",
+              "value": "Ubuntu  22.04 64 bit"
+            },
+            {
+              "key": "SerialNumber",
+              "value": "769359a1-ff5c-47f6-aa50-705ede2c8b58"
+            },
+            {
+              "key": "RegionId",
+              "value": "ap-northeast-2"
+            },
+            {
+              "key": "IoOptimized",
+              "value": "true"
+            },
+            {
+              "key": "InternetMaxBandwidthOut",
+              "value": "5"
+            },
+            {
+              "key": "InstanceTypeFamily",
+              "value": "ecs.e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-mj7e35tls2uwpys3780r"
+            },
+            {
+              "key": "Recyclable",
+              "value": "false"
+            },
+            {
+              "key": "ExpiredTime",
+              "value": "2099-12-31T15:59Z"
+            },
+            {
+              "key": "OSType",
+              "value": "linux"
+            },
+            {
+              "key": "Memory",
+              "value": "8192"
+            },
+            {
+              "key": "CreationTime",
+              "value": "2026-06-02T11:57Z"
+            },
+            {
+              "key": "KeyPairName",
+              "value": "tbkc0tqjtqulqspk3vmj"
+            },
+            {
+              "key": "LocalStorageCapacity",
+              "value": "0"
+            },
+            {
+              "key": "StoppedMode",
+              "value": "Not-applicable"
+            },
+            {
+              "key": "SpotStrategy",
+              "value": "NoSpot"
+            },
+            {
+              "key": "SpotDuration",
+              "value": "0"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "SecurityGroupIds",
+              "value": "{SecurityGroupId:[sg-mj780ni10nbsxrfvdoxa]}"
+            },
+            {
+              "key": "InnerIpAddress",
+              "value": "{IpAddress:[]}"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "{IpAddress:[47.80.241.105]}"
+            },
+            {
+              "key": "RdmaIpAddress",
+              "value": "{IpAddress:null}"
+            },
+            {
+              "key": "DedicatedHostAttribute",
+              "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+            },
+            {
+              "key": "EcsCapacityReservationAttr",
+              "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:1,CoreFactor:0,Numa:ON,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "DedicatedInstanceAttribute",
+              "value": "{Affinity:,Tenancy:}"
+            },
+            {
+              "key": "PrivateDnsNameOptions",
+              "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+            },
+            {
+              "key": "AdditionalInfo",
+              "value": "{EnableHighDensityMode:false}"
+            },
+            {
+              "key": "ImageOptions",
+              "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+            },
+            {
+              "key": "EipAddress",
+              "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+            },
+            {
+              "key": "VpcAttributes",
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.131]}}"
+            },
+            {
+              "key": "Tags",
+              "value": "{Tag:null}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a9,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvva,PrimaryIpAddress:10.0.1.131,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.131,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+            },
+            {
+              "key": "OperationLocks",
+              "value": "{LockReason:[]}"
+            }
+          ]
         },
         {
           "resourceType": "node",
           "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85cf1upr9ha6omvqj80",
+          "uid": "tb0gc9fc2ec0v7te0en2",
+          "cspResourceName": "tb0gc9fc2ec0v7te0en2",
+          "cspResourceId": "i-mj7caxyslyfjiirlhjj0",
           "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -6386,26 +6928,43 @@
             "latitude": 37.36,
             "longitude": 126.78
           },
-          "status": "Creating",
-          "targetStatus": "Running",
-          "targetAction": "Create",
-          "monAgentStatus": "",
-          "networkAgentStatus": "",
+          "status": "Running",
+          "targetStatus": "None",
+          "targetAction": "None",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "",
-          "label": null,
+          "createdTime": "2026-06-02 11:58:19",
+          "label": {
+            "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.connectionName": "alibaba-ap-northeast-2",
+            "sys.createdTime": "2026-06-02 11:58:19",
+            "sys.cspResourceId": "i-mj7caxyslyfjiirlhjj0",
+            "sys.cspResourceName": "tb0gc9fc2ec0v7te0en2",
+            "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.infraId": "my04-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.subnetId": "my04-subnet-01",
+            "sys.uid": "tb0gc9fc2ec0v7te0en2",
+            "sys.vNetId": "my04-vnet-01"
+          },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
           "region": {
-            "region": ""
+            "region": "ap-northeast-2",
+            "zone": "ap-northeast-2a"
           },
-          "publicIP": "",
-          "sshPort": 0,
+          "publicIP": "47.80.241.200",
+          "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "",
+          "privateIP": "10.0.1.129",
           "privateDNS": "",
-          "rootDiskType": "",
+          "rootDiskType": "cloud_essd_entry",
           "rootDiskSize": 40,
-          "RootDeviceName": "",
+          "RootDeviceName": "/dev/xvda",
           "connectionName": "alibaba-ap-northeast-2",
           "connectionConfig": {
             "configName": "alibaba-ap-northeast-2",
@@ -6436,24 +6995,282 @@
             "verified": true
           },
           "specId": "alibaba+ap-northeast-2+ecs.e-c1m4.xlarge",
-          "cspSpecName": "",
-          "spec": {},
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "cspSpecName": "ecs.e-c1m4.xlarge",
+          "spec": {
+            "cspSpecName": "ecs.e-c1m4.xlarge",
+            "vCPU": 4,
+            "memoryGiB": 16,
+            "costPerHour": 0.1582
+          },
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
-            "osType": ""
+            "resourceType": "image",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "",
-          "networkInterface": "",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7caxyslyfjiirmuk6r",
           "securityGroupIds": [
             "my04-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": ""
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
+          "nodeUserName": "cb-user",
+          "nodeUserPassword": "07qr$1j!1Ab9ot",
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Handling",
+              "startedTime": "2026-06-02T11:58:31Z"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "ImageId",
+              "value": "ubuntu_22_04_x64_20G_alibase_20260506.vhd"
+            },
+            {
+              "key": "InstanceType",
+              "value": "ecs.e-c1m4.xlarge"
+            },
+            {
+              "key": "DeviceAvailable",
+              "value": "true"
+            },
+            {
+              "key": "InstanceNetworkType",
+              "value": "vpc"
+            },
+            {
+              "key": "LocalStorageAmount",
+              "value": "0"
+            },
+            {
+              "key": "IsSpot",
+              "value": "false"
+            },
+            {
+              "key": "InstanceChargeType",
+              "value": "PostPaid"
+            },
+            {
+              "key": "InstanceName",
+              "value": "tb0gc9fc2ec0v7te0en2"
+            },
+            {
+              "key": "DeploymentSetGroupNo",
+              "value": "0"
+            },
+            {
+              "key": "GPUAmount",
+              "value": "0"
+            },
+            {
+              "key": "Connected",
+              "value": "false"
+            },
+            {
+              "key": "InvocationCount",
+              "value": "0"
+            },
+            {
+              "key": "StartTime",
+              "value": "2026-06-02T11:57Z"
+            },
+            {
+              "key": "ZoneId",
+              "value": "ap-northeast-2a"
+            },
+            {
+              "key": "InternetMaxBandwidthIn",
+              "value": "800"
+            },
+            {
+              "key": "InternetChargeType",
+              "value": "PayByBandwidth"
+            },
+            {
+              "key": "HostName",
+              "value": "iZmj7caxyslyfjiirlhjj0Z"
+            },
+            {
+              "key": "Status",
+              "value": "Running"
+            },
+            {
+              "key": "CPU",
+              "value": "0"
+            },
+            {
+              "key": "Cpu",
+              "value": "4"
+            },
+            {
+              "key": "SpotPriceLimit",
+              "value": "0.00"
+            },
+            {
+              "key": "OSName",
+              "value": "Ubuntu  22.04 64位"
+            },
+            {
+              "key": "InstanceOwnerId",
+              "value": "0"
+            },
+            {
+              "key": "OSNameEn",
+              "value": "Ubuntu  22.04 64 bit"
+            },
+            {
+              "key": "SerialNumber",
+              "value": "6ea8094f-30c3-4bf8-b920-8f69ab5460e0"
+            },
+            {
+              "key": "RegionId",
+              "value": "ap-northeast-2"
+            },
+            {
+              "key": "IoOptimized",
+              "value": "true"
+            },
+            {
+              "key": "InternetMaxBandwidthOut",
+              "value": "5"
+            },
+            {
+              "key": "InstanceTypeFamily",
+              "value": "ecs.e"
+            },
+            {
+              "key": "InstanceId",
+              "value": "i-mj7caxyslyfjiirlhjj0"
+            },
+            {
+              "key": "Recyclable",
+              "value": "false"
+            },
+            {
+              "key": "ExpiredTime",
+              "value": "2099-12-31T15:59Z"
+            },
+            {
+              "key": "OSType",
+              "value": "linux"
+            },
+            {
+              "key": "Memory",
+              "value": "16384"
+            },
+            {
+              "key": "CreationTime",
+              "value": "2026-06-02T11:57Z"
+            },
+            {
+              "key": "KeyPairName",
+              "value": "tbkc0tqjtqulqspk3vmj"
+            },
+            {
+              "key": "LocalStorageCapacity",
+              "value": "0"
+            },
+            {
+              "key": "StoppedMode",
+              "value": "Not-applicable"
+            },
+            {
+              "key": "SpotStrategy",
+              "value": "NoSpot"
+            },
+            {
+              "key": "SpotDuration",
+              "value": "0"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "SecurityGroupIds",
+              "value": "{SecurityGroupId:[sg-mj7d6hrwmdy4yo1s8y96]}"
+            },
+            {
+              "key": "InnerIpAddress",
+              "value": "{IpAddress:[]}"
+            },
+            {
+              "key": "PublicIpAddress",
+              "value": "{IpAddress:[47.80.241.200]}"
+            },
+            {
+              "key": "RdmaIpAddress",
+              "value": "{IpAddress:null}"
+            },
+            {
+              "key": "DedicatedHostAttribute",
+              "value": "{DedicatedHostName:,DedicatedHostClusterId:,DedicatedHostId:}"
+            },
+            {
+              "key": "EcsCapacityReservationAttr",
+              "value": "{CapacityReservationPreference:,CapacityReservationId:}"
+            },
+            {
+              "key": "CpuOptions",
+              "value": "{Core:0,HyperThreadingAdjustable:false,CoreCount:2,CoreFactor:0,Numa:,TopologyType:,ThreadsPerCore:2,SupportedTopologyTypes:{SupportedTopologyType:null}}"
+            },
+            {
+              "key": "HibernationOptions",
+              "value": "{Configured:false}"
+            },
+            {
+              "key": "DedicatedInstanceAttribute",
+              "value": "{Affinity:,Tenancy:}"
+            },
+            {
+              "key": "PrivateDnsNameOptions",
+              "value": "{EnableInstanceIdDnsARecord:false,EnableInstanceIdDnsAAAARecord:false,EnableIpDnsARecord:false,EnableIpDnsPtrRecord:false,HostnameType:}"
+            },
+            {
+              "key": "AdditionalInfo",
+              "value": "{EnableHighDensityMode:false}"
+            },
+            {
+              "key": "ImageOptions",
+              "value": "{ImageFamily:,LoginAsNonRoot:false,ImageName:,Description:,CurrentOSNVMeSupported:false,ImageFeatures:{NvmeSupport:},ImageTags:{ImageTag:null}}"
+            },
+            {
+              "key": "EipAddress",
+              "value": "{IsSupportUnassociate:false,InternetChargeType:,IpAddress:,Bandwidth:0,AllocationId:}"
+            },
+            {
+              "key": "MetadataOptions",
+              "value": "{HttpEndpoint:,HttpPutResponseHopLimit:0,HttpTokens:}"
+            },
+            {
+              "key": "VpcAttributes",
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.129]}}"
+            },
+            {
+              "key": "Tags",
+              "value": "{Tag:null}"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a7,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7caxyslyfjiirmuk6r,PrimaryIpAddress:10.0.1.129,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.129,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+            },
+            {
+              "key": "OperationLocks",
+              "value": "{LockReason:[]}"
+            }
+          ]
         }
       ],
       "newNodeList": null,
@@ -6522,7 +7339,7 @@
 {
   "resourceType": "infra",
   "id": "my01-infra101",
-  "uid": "tbd85cevepr9ha6omvqit0",
+  "uid": "tb2drt09mfdcqasro93p",
   "name": "my01-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -6550,7 +7367,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my01-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85cevepr9ha6omvqit0"
+    "sys.uid": "tb2drt09mfdcqasro93p"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -6559,9 +7376,9 @@
     {
       "resourceType": "node",
       "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85cevepr9ha6omvqiu0",
-      "cspResourceName": "tbd85cevepr9ha6omvqiu0",
-      "cspResourceId": "i-05cc436e2832ffd93",
+      "uid": "tb9lrr7qljeqacqgv2u5",
+      "cspResourceName": "tb9lrr7qljeqacqgv2u5",
+      "cspResourceId": "i-06534a82f97650b25",
       "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -6575,14 +7392,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:02:29",
+      "createdTime": "2026-06-02 11:57:58",
       "label": {
-        "Name": "tbd85cevepr9ha6omvqiu0",
+        "Name": "tb9lrr7qljeqacqgv2u5",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 08:02:29",
-        "sys.cspResourceId": "i-05cc436e2832ffd93",
-        "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
+        "sys.createdTime": "2026-06-02 11:57:58",
+        "sys.cspResourceId": "i-06534a82f97650b25",
+        "sys.cspResourceName": "tb9lrr7qljeqacqgv2u5",
         "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6591,7 +7408,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd85cevepr9ha6omvqiu0",
+        "sys.uid": "tb9lrr7qljeqacqgv2u5",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6599,11 +7416,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "43.203.239.151",
+      "publicIP": "52.78.244.82",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.41",
-      "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.140",
+      "privateDNS": "ip-10-0-1-140.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -6646,32 +7463,32 @@
         "memoryGiB": 2,
         "costPerHour": 0.0234
       },
-      "imageId": "ami-08a1c21841a4c7a5f",
-      "cspImageName": "ami-08a1c21841a4c7a5f",
+      "imageId": "ami-0596f7562954deb8e",
+      "cspImageName": "ami-0596f7562954deb8e",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ami-08a1c21841a4c7a5f",
+        "cspImageName": "ami-0596f7562954deb8e",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-07e218262146e7003",
+      "cspVNetId": "vpc-00b2b1e59e8d2653d",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0695096ac3c17916f",
-      "networkInterface": "eni-attach-04753091ce5855ac2",
+      "cspSubnetId": "subnet-005c104e63421b753",
+      "networkInterface": "eni-attach-05d9a8c5dc9658780",
       "securityGroupIds": [
         "my01-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+      "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJTQ3SSJJ7tSaj0WZyFGnlovTpmAJ3neLicuOZcZ8+5894+2Fg7gxHO3jPuVAXf7mjQZiXmXhr3ebTh7z3C5fNk=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
-        "firstUsedAt": "2026-05-18T08:02:39Z"
+        "fingerprint": "SHA256:3SwXDiiyzPRZcm7FKBhxVlokHTSSsW+3aNJln+hby+Y",
+        "firstUsedAt": "2026-06-02T11:58:07Z"
       },
       "commandStatus": [
         {
@@ -6679,11 +7496,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:02:37Z",
-          "completedTime": "2026-05-18T08:02:40Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-06-02T11:58:06Z",
+          "completedTime": "2026-06-02T11:58:08Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6698,7 +7515,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:39Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0e1622ebc7e0ae0be}}"
         },
         {
           "key": "BootMode",
@@ -6710,7 +7527,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
+          "value": "2A6DB7BA-D37C-45E3-8AFE-B062DEC1496A"
         },
         {
           "key": "CpuOptions",
@@ -6738,11 +7555,11 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-08a1c21841a4c7a5f"
+          "value": "ami-0596f7562954deb8e"
         },
         {
           "key": "InstanceId",
-          "value": "i-05cc436e2832ffd93"
+          "value": "i-06534a82f97650b25"
         },
         {
           "key": "InstanceType",
@@ -6750,11 +7567,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd85cetmpr9ha6omvqiog"
+          "value": "tbgkl68qoqbt2irs6nn1"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-18T08:02:08Z"
+          "value": "2026-06-02T11:57:38Z"
         },
         {
           "key": "MetadataOptions",
@@ -6766,7 +7583,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Attachment:{AttachTime:2026-06-02T11:57:38Z,AttachmentId:eni-attach-05d9a8c5dc9658780,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:55:94:dc:34:3b,NetworkInterfaceId:eni-04ea4fac87e5ad333,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.140,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.140}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
         },
         {
           "key": "Placement",
@@ -6774,15 +7591,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-140.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.41"
+          "value": "10.0.1.140"
         },
         {
           "key": "PublicIpAddress",
-          "value": "43.203.239.151"
+          "value": "52.78.244.82"
         },
         {
           "key": "RootDeviceName",
@@ -6794,7 +7611,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
+          "value": "{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}"
         },
         {
           "key": "SourceDestCheck",
@@ -6806,11 +7623,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0695096ac3c17916f"
+          "value": "subnet-005c104e63421b753"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
+          "value": "{Key:Name,Value:tb9lrr7qljeqacqgv2u5}"
         },
         {
           "key": "VirtualizationType",
@@ -6818,16 +7635,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-07e218262146e7003"
+          "value": "vpc-00b2b1e59e8d2653d"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85cevepr9ha6omvqj00",
-      "cspResourceName": "tbd85cevepr9ha6omvqj00",
-      "cspResourceId": "i-055c3be58ba3b717a",
+      "uid": "tbd9vt5h7b3mi7hlnsrl",
+      "cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
+      "cspResourceId": "i-0b8bf7f9b3b9876c4",
       "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6841,14 +7658,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:02:31",
+      "createdTime": "2026-06-02 11:58:01",
       "label": {
-        "Name": "tbd85cevepr9ha6omvqj00",
+        "Name": "tbd9vt5h7b3mi7hlnsrl",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 08:02:31",
-        "sys.cspResourceId": "i-055c3be58ba3b717a",
-        "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
+        "sys.createdTime": "2026-06-02 11:58:01",
+        "sys.cspResourceId": "i-0b8bf7f9b3b9876c4",
+        "sys.cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
         "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -6857,7 +7674,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd85cevepr9ha6omvqj00",
+        "sys.uid": "tbd9vt5h7b3mi7hlnsrl",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6865,11 +7682,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "13.124.168.73",
+      "publicIP": "43.201.83.130",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.46",
-      "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.136",
+      "privateDNS": "ip-10-0-1-136.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -6912,45 +7729,44 @@
         "memoryGiB": 8,
         "costPerHour": 0.0936
       },
-      "imageId": "ami-08a1c21841a4c7a5f",
-      "cspImageName": "ami-08a1c21841a4c7a5f",
+      "imageId": "ami-0596f7562954deb8e",
+      "cspImageName": "ami-0596f7562954deb8e",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ami-08a1c21841a4c7a5f",
+        "cspImageName": "ami-0596f7562954deb8e",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-07e218262146e7003",
+      "cspVNetId": "vpc-00b2b1e59e8d2653d",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0695096ac3c17916f",
-      "networkInterface": "eni-attach-0512107afc0efe575",
+      "cspSubnetId": "subnet-005c104e63421b753",
+      "networkInterface": "eni-attach-00d6d6972528706c2",
       "securityGroupIds": [
         "my01-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+      "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtx2r8Ou4fXFF0/0OPQ0Rk+x8nxvnqwJeTL+9tBaIzgNXkZJMZ89BpJskE2U2XGlPGjmzheQYG3idrFrwV6U98=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
-        "firstUsedAt": "2026-05-18T08:02:39Z"
+        "fingerprint": "SHA256:kledbHEJr8DxkYCKFS+YqOfbAGwfb7bYstah9IAFp4U",
+        "firstUsedAt": "2026-06-02T11:58:08Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-05-18T08:02:37Z",
-          "completedTime": "2026-05-18T08:02:40Z",
-          "elapsedTime": 3,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-06-02T11:58:06Z",
+          "completedTime": "2026-06-02T11:58:26Z",
+          "elapsedTime": 20,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -6964,7 +7780,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd90939abf365ee0}}"
         },
         {
           "key": "BootMode",
@@ -6976,7 +7792,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
+          "value": "8A15C17A-F15C-460F-A71C-A57EF5F8E78E"
         },
         {
           "key": "CpuOptions",
@@ -7004,11 +7820,11 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-08a1c21841a4c7a5f"
+          "value": "ami-0596f7562954deb8e"
         },
         {
           "key": "InstanceId",
-          "value": "i-055c3be58ba3b717a"
+          "value": "i-0b8bf7f9b3b9876c4"
         },
         {
           "key": "InstanceType",
@@ -7016,11 +7832,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd85cetmpr9ha6omvqiog"
+          "value": "tbgkl68qoqbt2irs6nn1"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-18T08:02:08Z"
+          "value": "2026-06-02T11:57:40Z"
         },
         {
           "key": "MetadataOptions",
@@ -7032,7 +7848,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-00d6d6972528706c2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:67:60:31:ee:45,NetworkInterfaceId:eni-010ee71d81f863c52,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.136,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.136}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
         },
         {
           "key": "Placement",
@@ -7040,15 +7856,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-136.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.46"
+          "value": "10.0.1.136"
         },
         {
           "key": "PublicIpAddress",
-          "value": "13.124.168.73"
+          "value": "43.201.83.130"
         },
         {
           "key": "RootDeviceName",
@@ -7060,7 +7876,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
+          "value": "{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}"
         },
         {
           "key": "SourceDestCheck",
@@ -7072,11 +7888,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0695096ac3c17916f"
+          "value": "subnet-005c104e63421b753"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
+          "value": "{Key:Name,Value:tbd9vt5h7b3mi7hlnsrl}"
         },
         {
           "key": "VirtualizationType",
@@ -7084,16 +7900,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-07e218262146e7003"
+          "value": "vpc-00b2b1e59e8d2653d"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85cevepr9ha6omvqiv0",
-      "cspResourceName": "tbd85cevepr9ha6omvqiv0",
-      "cspResourceId": "i-0fa2d84cd0c6e08bb",
+      "uid": "tbrh382k22c02gj6or2q",
+      "cspResourceName": "tbrh382k22c02gj6or2q",
+      "cspResourceId": "i-0273cb7e68fdf8fac",
       "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -7107,14 +7923,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:02:28",
+      "createdTime": "2026-06-02 11:58:00",
       "label": {
-        "Name": "tbd85cevepr9ha6omvqiv0",
+        "Name": "tbrh382k22c02gj6or2q",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-05-18 08:02:28",
-        "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
-        "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
+        "sys.createdTime": "2026-06-02 11:58:00",
+        "sys.cspResourceId": "i-0273cb7e68fdf8fac",
+        "sys.cspResourceName": "tbrh382k22c02gj6or2q",
         "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my01-infra101",
         "sys.labelType": "node",
@@ -7123,7 +7939,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my01-subnet-01",
-        "sys.uid": "tbd85cevepr9ha6omvqiv0",
+        "sys.uid": "tbrh382k22c02gj6or2q",
         "sys.vNetId": "my01-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -7131,11 +7947,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "52.78.166.174",
+      "publicIP": "52.78.4.197",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.204",
-      "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.239",
+      "privateDNS": "ip-10-0-1-239.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -7178,45 +7994,44 @@
         "memoryGiB": 16,
         "costPerHour": 0.1872
       },
-      "imageId": "ami-08a1c21841a4c7a5f",
-      "cspImageName": "ami-08a1c21841a4c7a5f",
+      "imageId": "ami-0596f7562954deb8e",
+      "cspImageName": "ami-0596f7562954deb8e",
       "image": {
         "resourceType": "image",
-        "cspImageName": "ami-08a1c21841a4c7a5f",
+        "cspImageName": "ami-0596f7562954deb8e",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+        "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
       },
       "vNetId": "my01-vnet-01",
-      "cspVNetId": "vpc-07e218262146e7003",
+      "cspVNetId": "vpc-00b2b1e59e8d2653d",
       "subnetId": "my01-subnet-01",
-      "cspSubnetId": "subnet-0695096ac3c17916f",
-      "networkInterface": "eni-attach-0dacfd07e29c82162",
+      "cspSubnetId": "subnet-005c104e63421b753",
+      "networkInterface": "eni-attach-0638cbee4cdabd7bd",
       "securityGroupIds": [
         "my01-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my01-sshkey-01",
-      "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+      "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBH97D952EztvAI/plpOdoCRtd21dx035GA7gRqjte2Nms1wIDFCgt9jQFauHyJRz8HXg/43acRo6d4xSZzc2ACw=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
-        "firstUsedAt": "2026-05-18T08:02:37Z"
+        "fingerprint": "SHA256:Fk9INcBJUzgOLcr6k2etg2P8ucfdRb5QkjAk/dNW5Bo",
+        "firstUsedAt": "2026-06-02T11:58:08Z"
       },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Completed",
-          "startedTime": "2026-05-18T08:02:37Z",
-          "completedTime": "2026-05-18T08:02:40Z",
-          "elapsedTime": 3,
-          "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-          "stderr": "\n"
+          "status": "Failed",
+          "startedTime": "2026-06-02T11:58:06Z",
+          "completedTime": "2026-06-02T11:58:26Z",
+          "elapsedTime": 20,
+          "resultSummary": "Command execution failed",
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -7230,7 +8045,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0387f952743f64ec0}}"
         },
         {
           "key": "BootMode",
@@ -7242,7 +8057,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
+          "value": "9F574316-EB84-4652-B3FF-92E90421877B"
         },
         {
           "key": "CpuOptions",
@@ -7270,11 +8085,11 @@
         },
         {
           "key": "ImageId",
-          "value": "ami-08a1c21841a4c7a5f"
+          "value": "ami-0596f7562954deb8e"
         },
         {
           "key": "InstanceId",
-          "value": "i-0fa2d84cd0c6e08bb"
+          "value": "i-0273cb7e68fdf8fac"
         },
         {
           "key": "InstanceType",
@@ -7282,11 +8097,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbd85cetmpr9ha6omvqiog"
+          "value": "tbgkl68qoqbt2irs6nn1"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-05-18T08:02:07Z"
+          "value": "2026-06-02T11:57:40Z"
         },
         {
           "key": "MetadataOptions",
@@ -7298,7 +8113,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-0638cbee4cdabd7bd,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c1:be:34:65:23,NetworkInterfaceId:eni-0dff89b4de2d2ff27,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.239,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.239}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
         },
         {
           "key": "Placement",
@@ -7306,15 +8121,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-239.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.204"
+          "value": "10.0.1.239"
         },
         {
           "key": "PublicIpAddress",
-          "value": "52.78.166.174"
+          "value": "52.78.4.197"
         },
         {
           "key": "RootDeviceName",
@@ -7326,7 +8141,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
+          "value": "{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}"
         },
         {
           "key": "SourceDestCheck",
@@ -7338,11 +8153,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0695096ac3c17916f"
+          "value": "subnet-005c104e63421b753"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
+          "value": "{Key:Name,Value:tbrh382k22c02gj6or2q}"
         },
         {
           "key": "VirtualizationType",
@@ -7350,7 +8165,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-07e218262146e7003"
+          "value": "vpc-00b2b1e59e8d2653d"
         }
       ]
     }
@@ -7366,13 +8181,13 @@
     "results": [
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "52.78.166.174",
+        "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "52.78.244.82",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -7381,32 +8196,24 @@
       },
       {
         "infraId": "my01-infra101",
-        "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "43.203.239.151",
+        "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "52.78.4.197",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       },
       {
         "infraId": "my01-infra101",
         "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "13.124.168.73",
+        "nodeIp": "43.201.83.130",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {
-          "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
+        "stdout": {},
+        "stderr": {},
         "err": null
       }
     ]
@@ -7460,8 +8267,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "43.203.239.151",
+      "output": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "52.78.244.82",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -7472,8 +8279,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "13.124.168.73",
+      "output": "Linux ip-10-0-1-136 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "43.201.83.130",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -7484,8 +8291,8 @@
       "command": "uname -a",
       "nodeGroup": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "52.78.166.174",
+      "output": "Linux ip-10-0-1-239 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "52.78.4.197",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -7515,7 +8322,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:03:08
+**Generated At:** 2026-06-02 11:58:56
 
 **Namespace:** mig01
 
@@ -7543,23 +8350,23 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
-| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 | t3a.small | 2 | 2.0 | - | x86_64 |  | $0.0234 | 1 |
 | t3a.large | 2 | 8.0 | - | x86_64 |  | $0.0936 | 1 |
+| t3a.xlarge | 4 | 16.0 | - | x86_64 |  | $0.1872 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| ami-08a1c21841a4c7a5f | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | Ubuntu 22.04 | Linux/UNIX | x86_64 | ebs | - | 3 |
+| ami-0596f7562954deb8e | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | Ubuntu 22.04 | Linux/UNIX | x86_64 | ebs | - | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-05cc436e2832ffd93 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.203.239.151<br>**Private IP:** 10.0.1.41<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-055c3be58ba3b717a | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 13.124.168.73<br>**Private IP:** 10.0.1.46<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
-| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0fa2d84cd0c6e08bb | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.166.174<br>**Private IP:** 10.0.1.204<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | i-06534a82f97650b25 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.244.82<br>**Private IP:** 10.0.1.140<br>**SGs:** my01-sg-01<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | i-0b8bf7f9b3b9876c4 | Running | 2 vCPU, 8.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 43.201.83.130<br>**Private IP:** 10.0.1.136<br>**SGs:** my01-sg-03<br>**SSH:** my01-sshkey-01 |
+| my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | i-0273cb7e68fdf8fac | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521) | **VNet:** my01-vnet-01<br>**Subnet:** my01-subnet-01<br>**Public IP:** 52.78.4.197<br>**Private IP:** 10.0.1.239<br>**SGs:** my01-sg-02<br>**SSH:** my01-sshkey-01 |
 
 
 ## Network Resources
@@ -7571,7 +8378,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-vnet-01 |
-| **CSP VNet ID** | vpc-07e218262146e7003 |
+| **CSP VNet ID** | vpc-00b2b1e59e8d2653d |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -7580,7 +8387,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my01-subnet-01 | subnet-0695096ac3c17916f | 10.0.1.0/24 | ap-northeast-2a |
+| my01-subnet-01 | subnet-005c104e63421b753 | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -7589,7 +8396,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my01-sshkey-01 | tbd85cetmpr9ha6omvqiog |  | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 |
+| my01-sshkey-01 | tbgkl68qoqbt2irs6nn1 |  | 7c:ce:de:29:6e:56:dd:19:56:2c:0e:6a:3c:ff:d0:56:d1:64:f5:30 |
 
 ### Security Groups
 
@@ -7598,7 +8405,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-01 |
-| **CSP Security Group ID** | sg-094d187b192dfdf77 |
+| **CSP Security Group ID** | sg-073146fb5cc82a36a |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -7626,7 +8433,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-02 |
-| **CSP Security Group ID** | sg-014a3bc57edc785c7 |
+| **CSP Security Group ID** | sg-0ce7c1c68b49dfdfd |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7659,7 +8466,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my01-sg-03 |
-| **CSP Security Group ID** | sg-0b2020b2fa704162e |
+| **CSP Security Group ID** | sg-0199f16c43ae8cc63 |
 | **VNet** | my01-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7734,7 +8541,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:03:11*
+*Report generated: 2026-06-02 11:59:02*
 
 ---
 
@@ -7778,9 +8585,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-05cc436e2832ffd93<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-055c3be58ba3b717a<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0fa2d84cd0c6e08bb<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-06534a82f97650b25<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** i-0b8bf7f9b3b9876c4<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** i-0273cb7e68fdf8fac<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7802,9 +8609,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-08a1c21841a4c7a5f<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ami-08a1c21841a4c7a5f<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ami-08a1c21841a4c7a5f<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-0596f7562954deb8e<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** ami-0596f7562954deb8e<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** ami-0596f7562954deb8e<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -7814,7 +8621,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-01
 
-**CSP ID:** sg-094d187b192dfdf77 | **VNet:** my01-vnet-01 | **Rules:** 14
+**CSP ID:** sg-073146fb5cc82a36a | **VNet:** my01-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7842,7 +8649,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-02
 
-**CSP ID:** sg-014a3bc57edc785c7 | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0ce7c1c68b49dfdfd | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7875,7 +8682,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my01-sg-03
 
-**CSP ID:** sg-0b2020b2fa704162e | **VNet:** my01-vnet-01 | **Rules:** 19
+**CSP ID:** sg-0199f16c43ae8cc63 | **VNet:** my01-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7916,13 +8723,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-07e218262146e7003 | 10.0.0.0/21 |
+| 1 | **Name:** my01-vnet-01<br>**ID:** vpc-00b2b1e59e8d2653d | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-0695096ac3c17916f | 10.0.1.0/24 | my01-vnet-01 |
+| 1 | **Name:** my01-subnet-01<br>**ID:** subnet-005c104e63421b753 | 10.0.1.0/24 | my01-vnet-01 |
 
 ### Source Network Information
 
@@ -7964,7 +8771,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my01-sshkey-01 | tbd85cetmpr9ha6omvqiog | 21:b8:cc:99:fa:54:b6:c7:a7:07:6d:c8:04:eb:50:97:a4:ca:5a:49 | Used by all 3 VMs |
+| 1 | my01-sshkey-01 | tbgkl68qoqbt2irs6nn1 | 7c:ce:de:29:6e:56:dd:19:56:2c:0e:6a:3c:ff:d0:56:d1:64:f5:30 | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-azure.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-azure.md
@@ -7,19 +7,19 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (c574040)
-- cm-model: unknown
-- CB-Tumblebug: vunknown
-- CB-Spider: vunknown
-- CB-MapUI: vunknown
+- CM-Beetle: imdl/v0.1.5+ (4987539)
+- imdl: v0.1.5+ (4987539)
+- CB-Tumblebug: v0.12.13
+- CB-Spider: v0.12.26
+- CB-MapUI: v0.12.34
 - Target CSP: AZURE
 - Target Region: koreasouth
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 18, 2026
-- Test Time: 17:01:38 KST
-- Test Execution: 2026-05-18 17:01:38 KST
+- Test Date: June 2, 2026
+- Test Time: 20:57:03 KST
+- Test Execution: 2026-06-02 20:57:03 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 7.581s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m39.898s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 42ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 4ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 13.084s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m36.82s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 126ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 16ms | Pass |
 | 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 28ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.269s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.399s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m48.41s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.584s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.604s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m47.036s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 4m56.692755828s
+**Total Duration**: 4m57.44799377s
 
-*Test executed on May 18, 2026 at 17:01:38 KST (2026-05-18 17:01:38 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 20:57:03 KST (2026-06-02 20:57:03 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1967,8 +1967,8 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2als_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -1987,8 +1987,8 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b4as_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2007,8 +2007,8 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2as_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2052,7 +2052,7 @@
       "targetSpecList": [
         {
           "id": "azure+koreasouth+standard_b2als_v2",
-          "uid": "d7k8jatq1uu3ogms3t1g",
+          "uid": "tbu3qnmmi15svg3cnahm",
           "cspSpecName": "Standard_B2als_v2",
           "name": "azure+koreasouth+standard_b2als_v2",
           "namespace": "system",
@@ -2240,7 +2240,7 @@
         },
         {
           "id": "azure+koreasouth+standard_b4as_v2",
-          "uid": "d7k8jatq1uu3ogms3t3g",
+          "uid": "tbclu29d1tthdaa1orf0",
           "cspSpecName": "Standard_B4as_v2",
           "name": "azure+koreasouth+standard_b4as_v2",
           "namespace": "system",
@@ -2428,7 +2428,7 @@
         },
         {
           "id": "azure+koreasouth+standard_b2as_v2",
-          "uid": "d7k8jatq1uu3ogms3t20",
+          "uid": "tb3h0eijnsghu8e1q6t8",
           "cspSpecName": "Standard_B2as_v2",
           "name": "azure+koreasouth+standard_b2as_v2",
           "namespace": "system",
@@ -2620,18 +2620,18 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "azure",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
           "regionList": [
             "common"
           ],
-          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "uid": "d7k8lctq1uu3ogn5gg20",
-          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "uid": "tbpgo13bkvl7mci3fmno",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "azure-australiacentral",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:45:39 Wed",
+          "fetchedTime": "2026.05.27 06:36:46 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -2639,80 +2639,7 @@
           "osType": "Ubuntu 22.04",
           "osArchitecture": "x86_64",
           "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "osDiskType": "default",
-          "osDiskSizeGB": -1,
-          "imageStatus": "Available",
-          "details": [
-            {
-              "key": "Location",
-              "value": "australiacentral"
-            },
-            {
-              "key": "Publisher",
-              "value": "Canonical"
-            },
-            {
-              "key": "Offer",
-              "value": "0001-com-ubuntu-server-jammy-daily"
-            },
-            {
-              "key": "SKU",
-              "value": "22_04-daily-lts"
-            },
-            {
-              "key": "Version",
-              "value": "22.04.202604160"
-            },
-            {
-              "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts/Versions/22.04.202604160"
-            },
-            {
-              "key": "HyperVGeneration",
-              "value": "V1"
-            },
-            {
-              "key": "Features",
-              "value": "IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, IsHibernateSupported=True"
-            },
-            {
-              "key": "FeatureCount",
-              "value": "3"
-            },
-            {
-              "key": "ImageDeprecationState",
-              "value": "Active"
-            }
-          ],
-          "systemLabel": "",
-          "description": "",
-          "commandHistory": null
-        },
-        {
-          "resourceType": "image",
-          "namespace": "system",
-          "providerName": "azure",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "regionList": [
-            "common"
-          ],
-          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "uid": "d7k8lctq1uu3ogn5gg30",
-          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "sourceNodeUid": "",
-          "sourceCspImageName": "",
-          "connectionName": "azure-australiacentral",
-          "infraType": "",
-          "fetchedTime": "2026.04.22 08:45:39 Wed",
-          "creationDate": "",
-          "isGPUImage": false,
-          "isKubernetesImage": false,
-          "isBasicImage": false,
-          "osType": "Ubuntu 22.04",
-          "osArchitecture": "x86_64",
-          "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
           "osDiskType": "default",
           "osDiskSizeGB": -1,
           "imageStatus": "Available",
@@ -2735,11 +2662,11 @@
             },
             {
               "key": "Version",
-              "value": "22.04.202604160"
+              "value": "22.04.202605260"
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202604160"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202605260"
             },
             {
               "key": "HyperVGeneration",
@@ -2752,6 +2679,79 @@
             {
               "key": "FeatureCount",
               "value": "4"
+            },
+            {
+              "key": "ImageDeprecationState",
+              "value": "Active"
+            }
+          ],
+          "systemLabel": "",
+          "description": "",
+          "commandHistory": null
+        },
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "azure",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "regionList": [
+            "common"
+          ],
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "uid": "tbgtm1agmi0me5fnfl35",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "azure-australiacentral",
+          "infraType": "",
+          "fetchedTime": "2026.05.27 06:36:46 Wed",
+          "creationDate": "",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "osDiskType": "default",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Location",
+              "value": "australiacentral"
+            },
+            {
+              "key": "Publisher",
+              "value": "Canonical"
+            },
+            {
+              "key": "Offer",
+              "value": "0001-com-ubuntu-server-jammy-daily"
+            },
+            {
+              "key": "SKU",
+              "value": "22_04-daily-lts"
+            },
+            {
+              "key": "Version",
+              "value": "22.04.202605260"
+            },
+            {
+              "key": "ID",
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts/Versions/22.04.202605260"
+            },
+            {
+              "key": "HyperVGeneration",
+              "value": "V1"
+            },
+            {
+              "key": "Features",
+              "value": "IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, IsHibernateSupported=True"
+            },
+            {
+              "key": "FeatureCount",
+              "value": "3"
             },
             {
               "key": "ImageDeprecationState",
@@ -3110,8 +3110,8 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2ls_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -3130,8 +3130,8 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b4s_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -3150,8 +3150,8 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "azure-koreasouth",
             "specId": "azure+koreasouth+standard_b2s_v2",
-            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -3195,7 +3195,7 @@
       "targetSpecList": [
         {
           "id": "azure+koreasouth+standard_b2als_v2",
-          "uid": "d7k8jatq1uu3ogms3t1g",
+          "uid": "tbu3qnmmi15svg3cnahm",
           "cspSpecName": "Standard_B2als_v2",
           "name": "azure+koreasouth+standard_b2als_v2",
           "namespace": "system",
@@ -3383,7 +3383,7 @@
         },
         {
           "id": "azure+koreasouth+standard_b4as_v2",
-          "uid": "d7k8jatq1uu3ogms3t3g",
+          "uid": "tbclu29d1tthdaa1orf0",
           "cspSpecName": "Standard_B4as_v2",
           "name": "azure+koreasouth+standard_b4as_v2",
           "namespace": "system",
@@ -3571,7 +3571,7 @@
         },
         {
           "id": "azure+koreasouth+standard_b2as_v2",
-          "uid": "d7k8jatq1uu3ogms3t20",
+          "uid": "tb3h0eijnsghu8e1q6t8",
           "cspSpecName": "Standard_B2as_v2",
           "name": "azure+koreasouth+standard_b2as_v2",
           "namespace": "system",
@@ -3759,7 +3759,7 @@
         },
         {
           "id": "azure+koreasouth+standard_b2ls_v2",
-          "uid": "d7k8jatq1uu3ogms3qjg",
+          "uid": "tbe2su80r3g6ipn1o5c4",
           "cspSpecName": "Standard_B2ls_v2",
           "name": "azure+koreasouth+standard_b2ls_v2",
           "namespace": "system",
@@ -3947,7 +3947,7 @@
         },
         {
           "id": "azure+koreasouth+standard_b4s_v2",
-          "uid": "d7k8jatq1uu3ogms3qlg",
+          "uid": "tbafcljckm3ds559b5ti",
           "cspSpecName": "Standard_B4s_v2",
           "name": "azure+koreasouth+standard_b4s_v2",
           "namespace": "system",
@@ -4135,7 +4135,7 @@
         },
         {
           "id": "azure+koreasouth+standard_b2s_v2",
-          "uid": "d7k8jatq1uu3ogms3qk0",
+          "uid": "tb6a6lihtts92j0q40ol",
           "cspSpecName": "Standard_B2s_v2",
           "name": "azure+koreasouth+standard_b2s_v2",
           "namespace": "system",
@@ -4327,18 +4327,18 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "azure",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
           "regionList": [
             "common"
           ],
-          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "uid": "d7k8lctq1uu3ogn5gg20",
-          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "uid": "tbpgo13bkvl7mci3fmno",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "azure-australiacentral",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:45:39 Wed",
+          "fetchedTime": "2026.05.27 06:36:46 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -4346,80 +4346,7 @@
           "osType": "Ubuntu 22.04",
           "osArchitecture": "x86_64",
           "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "osDiskType": "default",
-          "osDiskSizeGB": -1,
-          "imageStatus": "Available",
-          "details": [
-            {
-              "key": "Location",
-              "value": "australiacentral"
-            },
-            {
-              "key": "Publisher",
-              "value": "Canonical"
-            },
-            {
-              "key": "Offer",
-              "value": "0001-com-ubuntu-server-jammy-daily"
-            },
-            {
-              "key": "SKU",
-              "value": "22_04-daily-lts"
-            },
-            {
-              "key": "Version",
-              "value": "22.04.202604160"
-            },
-            {
-              "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts/Versions/22.04.202604160"
-            },
-            {
-              "key": "HyperVGeneration",
-              "value": "V1"
-            },
-            {
-              "key": "Features",
-              "value": "IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, IsHibernateSupported=True"
-            },
-            {
-              "key": "FeatureCount",
-              "value": "3"
-            },
-            {
-              "key": "ImageDeprecationState",
-              "value": "Active"
-            }
-          ],
-          "systemLabel": "",
-          "description": "",
-          "commandHistory": null
-        },
-        {
-          "resourceType": "image",
-          "namespace": "system",
-          "providerName": "azure",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "regionList": [
-            "common"
-          ],
-          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "uid": "d7k8lctq1uu3ogn5gg30",
-          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "sourceNodeUid": "",
-          "sourceCspImageName": "",
-          "connectionName": "azure-australiacentral",
-          "infraType": "",
-          "fetchedTime": "2026.04.22 08:45:39 Wed",
-          "creationDate": "",
-          "isGPUImage": false,
-          "isKubernetesImage": false,
-          "isBasicImage": false,
-          "osType": "Ubuntu 22.04",
-          "osArchitecture": "x86_64",
-          "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
           "osDiskType": "default",
           "osDiskSizeGB": -1,
           "imageStatus": "Available",
@@ -4442,11 +4369,11 @@
             },
             {
               "key": "Version",
-              "value": "22.04.202604160"
+              "value": "22.04.202605260"
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202604160"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202605260"
             },
             {
               "key": "HyperVGeneration",
@@ -4459,6 +4386,79 @@
             {
               "key": "FeatureCount",
               "value": "4"
+            },
+            {
+              "key": "ImageDeprecationState",
+              "value": "Active"
+            }
+          ],
+          "systemLabel": "",
+          "description": "",
+          "commandHistory": null
+        },
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "azure",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "regionList": [
+            "common"
+          ],
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "uid": "tbgtm1agmi0me5fnfl35",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "azure-australiacentral",
+          "infraType": "",
+          "fetchedTime": "2026.05.27 06:36:46 Wed",
+          "creationDate": "",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "osDiskType": "default",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Location",
+              "value": "australiacentral"
+            },
+            {
+              "key": "Publisher",
+              "value": "Canonical"
+            },
+            {
+              "key": "Offer",
+              "value": "0001-com-ubuntu-server-jammy-daily"
+            },
+            {
+              "key": "SKU",
+              "value": "22_04-daily-lts"
+            },
+            {
+              "key": "Version",
+              "value": "22.04.202605260"
+            },
+            {
+              "key": "ID",
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts/Versions/22.04.202605260"
+            },
+            {
+              "key": "HyperVGeneration",
+              "value": "V1"
+            },
+            {
+              "key": "Features",
+              "value": "IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, IsHibernateSupported=True"
+            },
+            {
+              "key": "FeatureCount",
+              "value": "3"
             },
             {
               "key": "ImageDeprecationState",
@@ -4823,7 +4823,7 @@
 {
   "resourceType": "infra",
   "id": "my02-infra101",
-  "uid": "tbd85cf3epr9ha6omvqjbg",
+  "uid": "tbv4r5dg0r6ctsgj7tfe",
   "name": "my02-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -4851,7 +4851,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my02-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85cf3epr9ha6omvqjbg"
+    "sys.uid": "tbv4r5dg0r6ctsgj7tfe"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -4860,9 +4860,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85cf3epr9ha6omvqjcg",
-      "cspResourceName": "tbd85cf3epr9ha6omvqjcg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
+      "uid": "tb81h514blbmih6th0ra",
+      "cspResourceName": "tb81h514blbmih6th0ra",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
       "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -4876,16 +4876,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:03:14",
+      "createdTime": "2026-06-02 11:58:51",
       "label": {
-        "createdBy": "tbd85cf3epr9ha6omvqjcg",
-        "keypair": "tbd85cf06pr9ha6omvqj3g",
-        "publicip": "tbd85cf3epr9ha6omvqjcg-42454-PublicIP",
+        "createdBy": "tb81h514blbmih6th0ra",
+        "keypair": "tbmeu2jlibrbjhpqt6ks",
+        "publicip": "tb81h514blbmih6th0ra-51215-PublicIP",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-18 08:03:14",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
-        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjcg",
+        "sys.createdTime": "2026-06-02 11:58:51",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
+        "sys.cspResourceName": "tb81h514blbmih6th0ra",
         "sys.id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -4894,17 +4894,17 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjcg",
+        "sys.uid": "tb81h514blbmih6th0ra",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "20.214.25.229",
+      "publicIP": "40.89.209.210",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.5",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
       "rootDiskSize": 30,
@@ -4943,32 +4943,32 @@
         "memoryGiB": 3.90625,
         "costPerHour": 0.0432
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-      "networkInterface": "tbd85cf3epr9ha6omvqjcg-39198-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+      "networkInterface": "tb81h514blbmih6th0ra-74785-VNic",
       "securityGroupIds": [
         "my02-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL0VTwP0mj+c6VjV8msgi3Q9eibNRewPMT54DUhTIpAg1Sht7ha22G1ufqkYptq1cFE80rR711dScHPLLhmJ+q8=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFW7tvj2HzsClA8X1H26zUY4x8P6NQYpxpab+6eweSK3WB1Z7hjR9loeEmmH+DcvmhMv+MY0Rswn2avB6fUySUc=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:L+I1/Qhho+5MTJJQUC536mZqODIvIydVP6vJjVbdai0",
-        "firstUsedAt": "2026-05-18T08:03:23Z"
+        "fingerprint": "SHA256:iARQFNvURLH907WgwzHgMJPVSWgoyBhMXtYvYWM/db0",
+        "firstUsedAt": "2026-06-02T11:58:58Z"
       },
       "commandStatus": [
         {
@@ -4976,11 +4976,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:03:23Z",
-          "completedTime": "2026-05-18T08:03:26Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-06-02T11:58:57Z",
+          "completedTime": "2026-06-02T11:59:01Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4991,11 +4991,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjcg-39198-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjcg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,osType:Linux}},timeCreated:2026-05-18T08:02:26.9394222Z,vmId:66b1ceb1-9da8-497a-ab77-8e1d40b4f26c}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tb81h514blbmih6th0ra-74785-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tb81h514blbmih6th0ra,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,storageAccountType:Premium_LRS},name:tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,osType:Linux}},timeCreated:2026-06-02T11:58:00.0230074Z,vmId:a194131f-a308-4f9e-bd5f-1954226d1a73}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd85cf3epr9ha6omvqjcg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjcg-42454-PublicIP}"
+          "value": "{createdBy:tb81h514blbmih6th0ra,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tb81h514blbmih6th0ra-51215-PublicIP}"
         },
         {
           "key": "Etag",
@@ -5003,11 +5003,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra"
         },
         {
           "key": "Name",
-          "value": "tbd85cf3epr9ha6omvqjcg"
+          "value": "tb81h514blbmih6th0ra"
         },
         {
           "key": "Type",
@@ -5018,9 +5018,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85cf3epr9ha6omvqjeg",
-      "cspResourceName": "tbd85cf3epr9ha6omvqjeg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
+      "uid": "tbj3l6ut11ch7mvkq2p2",
+      "cspResourceName": "tbj3l6ut11ch7mvkq2p2",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
       "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -5034,16 +5034,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:03:17",
+      "createdTime": "2026-06-02 11:58:51",
       "label": {
-        "createdBy": "tbd85cf3epr9ha6omvqjeg",
-        "keypair": "tbd85cf06pr9ha6omvqj3g",
-        "publicip": "tbd85cf3epr9ha6omvqjeg-83151-PublicIP",
+        "createdBy": "tbj3l6ut11ch7mvkq2p2",
+        "keypair": "tbmeu2jlibrbjhpqt6ks",
+        "publicip": "tbj3l6ut11ch7mvkq2p2-63146-PublicIP",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-18 08:03:17",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
-        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjeg",
+        "sys.createdTime": "2026-06-02 11:58:51",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
+        "sys.cspResourceName": "tbj3l6ut11ch7mvkq2p2",
         "sys.id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -5052,14 +5052,14 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjeg",
+        "sys.uid": "tbj3l6ut11ch7mvkq2p2",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "20.214.26.6",
+      "publicIP": "52.231.195.8",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.6",
@@ -5101,32 +5101,32 @@
         "memoryGiB": 7.8125,
         "costPerHour": 0.0865
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-      "networkInterface": "tbd85cf3epr9ha6omvqjeg-47871-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+      "networkInterface": "tbj3l6ut11ch7mvkq2p2-3298-VNic",
       "securityGroupIds": [
         "my02-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEjxGVDmlxPviCew7MPsxQCg/SbRH0g1LPINkzdzqnLKnu1r1BVcN2sOxPrrm4d3ektW4i1wjM5H3IyYVNdYIXM=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJtUMh1cIUNrdvxDyS/sX2gg1UlgprQImyTmtt571zIcfmNpvML9//EZjbJhwyEPPk1DSV9P+GsLYIsancoLI2Q=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:kXaggWkouCHVkByZEeZ7WbredHOydMu4PhHCk95sdGA",
-        "firstUsedAt": "2026-05-18T08:03:25Z"
+        "fingerprint": "SHA256:vHAecS7HpoCmHLAn96798w3BOcO14c/PF8E2f32n6W4",
+        "firstUsedAt": "2026-06-02T11:59:00Z"
       },
       "commandStatus": [
         {
@@ -5134,11 +5134,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:03:23Z",
-          "completedTime": "2026-05-18T08:03:27Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-06-02T11:58:57Z",
+          "completedTime": "2026-06-02T11:59:03Z",
+          "elapsedTime": 6,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -5149,11 +5149,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjeg-47871-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjeg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,osType:Linux}},timeCreated:2026-05-18T08:02:28.9784295Z,vmId:85838c4c-38c3-4641-9333-9b5b9ab4769a}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbj3l6ut11ch7mvkq2p2-3298-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbj3l6ut11ch7mvkq2p2,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,storageAccountType:Premium_LRS},name:tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,osType:Linux}},timeCreated:2026-06-02T11:58:02.5923143Z,vmId:26a400ec-766d-4066-a986-31dee1af0a49}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd85cf3epr9ha6omvqjeg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjeg-83151-PublicIP}"
+          "value": "{createdBy:tbj3l6ut11ch7mvkq2p2,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tbj3l6ut11ch7mvkq2p2-63146-PublicIP}"
         },
         {
           "key": "Etag",
@@ -5161,11 +5161,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2"
         },
         {
           "key": "Name",
-          "value": "tbd85cf3epr9ha6omvqjeg"
+          "value": "tbj3l6ut11ch7mvkq2p2"
         },
         {
           "key": "Type",
@@ -5176,9 +5176,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85cf3epr9ha6omvqjdg",
-      "cspResourceName": "tbd85cf3epr9ha6omvqjdg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
+      "uid": "tblumcks3qbld4l0rqdu",
+      "cspResourceName": "tblumcks3qbld4l0rqdu",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
       "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -5192,16 +5192,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:03:15",
+      "createdTime": "2026-06-02 11:58:51",
       "label": {
-        "createdBy": "tbd85cf3epr9ha6omvqjdg",
-        "keypair": "tbd85cf06pr9ha6omvqj3g",
-        "publicip": "tbd85cf3epr9ha6omvqjdg-86268-PublicIP",
+        "createdBy": "tblumcks3qbld4l0rqdu",
+        "keypair": "tbmeu2jlibrbjhpqt6ks",
+        "publicip": "tblumcks3qbld4l0rqdu-15505-PublicIP",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-18 08:03:15",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
-        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjdg",
+        "sys.createdTime": "2026-06-02 11:58:51",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
+        "sys.cspResourceName": "tblumcks3qbld4l0rqdu",
         "sys.id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -5210,17 +5210,17 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjdg",
+        "sys.uid": "tblumcks3qbld4l0rqdu",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "52.231.195.68",
+      "publicIP": "20.214.40.12",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.5",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
       "rootDiskSize": 30,
@@ -5259,32 +5259,32 @@
         "memoryGiB": 15.625,
         "costPerHour": 0.173
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-      "networkInterface": "tbd85cf3epr9ha6omvqjdg-3065-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+      "networkInterface": "tblumcks3qbld4l0rqdu-93021-VNic",
       "securityGroupIds": [
         "my02-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTNwiwA06iMy3QoeSkT4pJXpOsH22Jn6+LnZ+ak239UDz03i5xCcIOmCYDASX7JMLHv1NfehWWjviZjXQOCm0A=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTL9uzNQSU1yXWyoHY8FKtgjUxNkaKpGjhn6dtQjVMVJC3cpROCI06y1MwW8elX7OtijS4pmgWxkK29xA0kJ80=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:zSgb3/NtuvOcCa3S2XoWo/Kj3Tpb4B15i3wLbr896JA",
-        "firstUsedAt": "2026-05-18T08:03:25Z"
+        "fingerprint": "SHA256:lVsWJmS92R46BkqahsTpl8eAW8rA6D39KJOZaJA3sj8",
+        "firstUsedAt": "2026-06-02T11:59:00Z"
       },
       "commandStatus": [
         {
@@ -5292,11 +5292,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:03:23Z",
-          "completedTime": "2026-05-18T08:03:28Z",
+          "startedTime": "2026-06-02T11:58:57Z",
+          "completedTime": "2026-06-02T11:59:02Z",
           "elapsedTime": 5,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -5307,11 +5307,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjdg-3065-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjdg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,osType:Linux}},timeCreated:2026-05-18T08:02:27.2996702Z,vmId:9f82564d-bc46-434c-955e-4e8a0c6ad147}"
+          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tblumcks3qbld4l0rqdu-93021-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tblumcks3qbld4l0rqdu,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,storageAccountType:Premium_LRS},name:tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,osType:Linux}},timeCreated:2026-06-02T11:58:00.3944037Z,vmId:bb9a97ea-bbc0-4b18-b394-cb1accf01389}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd85cf3epr9ha6omvqjdg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjdg-86268-PublicIP}"
+          "value": "{createdBy:tblumcks3qbld4l0rqdu,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tblumcks3qbld4l0rqdu-15505-PublicIP}"
         },
         {
           "key": "Etag",
@@ -5319,11 +5319,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu"
         },
         {
           "key": "Name",
-          "value": "tbd85cf3epr9ha6omvqjdg"
+          "value": "tblumcks3qbld4l0rqdu"
         },
         {
           "key": "Type",
@@ -5344,27 +5344,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "20.214.25.229",
+        "nodeIp": "40.89.209.210",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my02-infra101",
-        "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "20.214.26.6",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -5374,12 +5359,27 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "52.231.195.68",
+        "nodeIp": "20.214.40.12",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my02-infra101",
+        "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "52.231.195.8",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -5415,7 +5415,7 @@
     {
       "resourceType": "infra",
       "id": "my01-infra101",
-      "uid": "tbd85cevepr9ha6omvqit0",
+      "uid": "tb2drt09mfdcqasro93p",
       "name": "my01-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -5443,7 +5443,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my01-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85cevepr9ha6omvqit0"
+        "sys.uid": "tb2drt09mfdcqasro93p"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5452,9 +5452,9 @@
         {
           "resourceType": "node",
           "id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85cevepr9ha6omvqiu0",
-          "cspResourceName": "tbd85cevepr9ha6omvqiu0",
-          "cspResourceId": "i-05cc436e2832ffd93",
+          "uid": "tb9lrr7qljeqacqgv2u5",
+          "cspResourceName": "tb9lrr7qljeqacqgv2u5",
+          "cspResourceId": "i-06534a82f97650b25",
           "name": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -5468,14 +5468,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:29",
+          "createdTime": "2026-06-02 11:57:58",
           "label": {
-            "Name": "tbd85cevepr9ha6omvqiu0",
+            "Name": "tb9lrr7qljeqacqgv2u5",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:29",
-            "sys.cspResourceId": "i-05cc436e2832ffd93",
-            "sys.cspResourceName": "tbd85cevepr9ha6omvqiu0",
+            "sys.createdTime": "2026-06-02 11:57:58",
+            "sys.cspResourceId": "i-06534a82f97650b25",
+            "sys.cspResourceName": "tb9lrr7qljeqacqgv2u5",
             "sys.id": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5484,7 +5484,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd85cevepr9ha6omvqiu0",
+            "sys.uid": "tb9lrr7qljeqacqgv2u5",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5492,11 +5492,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "43.203.239.151",
+          "publicIP": "52.78.244.82",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.41",
-          "privateDNS": "ip-10-0-1-41.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.140",
+          "privateDNS": "ip-10-0-1-140.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
@@ -5539,32 +5539,32 @@
             "memoryGiB": 2,
             "costPerHour": 0.0234
           },
-          "imageId": "ami-08a1c21841a4c7a5f",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "cspImageName": "ami-0596f7562954deb8e",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-07e218262146e7003",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0695096ac3c17916f",
-          "networkInterface": "eni-attach-04753091ce5855ac2",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-05d9a8c5dc9658780",
           "securityGroupIds": [
             "my01-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL9WpZDZ14fXmSWHWCNYrwkApOqX/SoVpoE9eR/XjTGoct1jqM8ZiZGyiZe2PnPcV5WkwUfFRJGmIJ72lSHwRyU=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJTQ3SSJJ7tSaj0WZyFGnlovTpmAJ3neLicuOZcZ8+5894+2Fg7gxHO3jPuVAXf7mjQZiXmXhr3ebTh7z3C5fNk=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:L/BdBg26WaqVC1vQRLLOePkyYT/RR3AJ6iJqZ8JNevs",
-            "firstUsedAt": "2026-05-18T08:02:39Z"
+            "fingerprint": "SHA256:3SwXDiiyzPRZcm7FKBhxVlokHTSSsW+3aNJln+hby+Y",
+            "firstUsedAt": "2026-06-02T11:58:07Z"
           },
           "commandStatus": [
             {
@@ -5572,11 +5572,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:02:37Z",
-              "completedTime": "2026-05-18T08:02:40Z",
-              "elapsedTime": 3,
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:08Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5591,7 +5591,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:08Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c33945aafaedb72d}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:39Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0e1622ebc7e0ae0be}}"
             },
             {
               "key": "BootMode",
@@ -5603,7 +5603,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "368C7E62-3F66-4741-941F-5D64BEAB1E56"
+              "value": "2A6DB7BA-D37C-45E3-8AFE-B062DEC1496A"
             },
             {
               "key": "CpuOptions",
@@ -5631,11 +5631,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "InstanceId",
-              "value": "i-05cc436e2832ffd93"
+              "value": "i-06534a82f97650b25"
             },
             {
               "key": "InstanceType",
@@ -5643,11 +5643,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd85cetmpr9ha6omvqiog"
+              "value": "tbgkl68qoqbt2irs6nn1"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-18T08:02:08Z"
+              "value": "2026-06-02T11:57:38Z"
             },
             {
               "key": "MetadataOptions",
@@ -5659,7 +5659,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-04753091ce5855ac2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:20:f5:c8:48:cb,NetworkInterfaceId:eni-095815b03a754c42c,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.41,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.239.151},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.41}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Attachment:{AttachTime:2026-06-02T11:57:38Z,AttachmentId:eni-attach-05d9a8c5dc9658780,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:55:94:dc:34:3b,NetworkInterfaceId:eni-04ea4fac87e5ad333,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.140,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.244.82},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.140}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
             },
             {
               "key": "Placement",
@@ -5667,15 +5667,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-41.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-140.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.41"
+              "value": "10.0.1.140"
             },
             {
               "key": "PublicIpAddress",
-              "value": "43.203.239.151"
+              "value": "52.78.244.82"
             },
             {
               "key": "RootDeviceName",
@@ -5687,7 +5687,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-094d187b192dfdf77,GroupName:tbd85cetupr9ha6omvqip0}"
+              "value": "{GroupId:sg-073146fb5cc82a36a,GroupName:tbqf93ju7qe7u9ri3rs4}"
             },
             {
               "key": "SourceDestCheck",
@@ -5699,11 +5699,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0695096ac3c17916f"
+              "value": "subnet-005c104e63421b753"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiu0}"
+              "value": "{Key:Name,Value:tb9lrr7qljeqacqgv2u5}"
             },
             {
               "key": "VirtualizationType",
@@ -5711,16 +5711,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-07e218262146e7003"
+              "value": "vpc-00b2b1e59e8d2653d"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85cevepr9ha6omvqj00",
-          "cspResourceName": "tbd85cevepr9ha6omvqj00",
-          "cspResourceId": "i-055c3be58ba3b717a",
+          "uid": "tbd9vt5h7b3mi7hlnsrl",
+          "cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
+          "cspResourceId": "i-0b8bf7f9b3b9876c4",
           "name": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5734,14 +5734,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:31",
+          "createdTime": "2026-06-02 11:58:01",
           "label": {
-            "Name": "tbd85cevepr9ha6omvqj00",
+            "Name": "tbd9vt5h7b3mi7hlnsrl",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:31",
-            "sys.cspResourceId": "i-055c3be58ba3b717a",
-            "sys.cspResourceName": "tbd85cevepr9ha6omvqj00",
+            "sys.createdTime": "2026-06-02 11:58:01",
+            "sys.cspResourceId": "i-0b8bf7f9b3b9876c4",
+            "sys.cspResourceName": "tbd9vt5h7b3mi7hlnsrl",
             "sys.id": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -5750,7 +5750,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd85cevepr9ha6omvqj00",
+            "sys.uid": "tbd9vt5h7b3mi7hlnsrl",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5758,11 +5758,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "13.124.168.73",
+          "publicIP": "43.201.83.130",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.46",
-          "privateDNS": "ip-10-0-1-46.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.136",
+          "privateDNS": "ip-10-0-1-136.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
@@ -5805,45 +5805,44 @@
             "memoryGiB": 8,
             "costPerHour": 0.0936
           },
-          "imageId": "ami-08a1c21841a4c7a5f",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "cspImageName": "ami-0596f7562954deb8e",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-07e218262146e7003",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0695096ac3c17916f",
-          "networkInterface": "eni-attach-0512107afc0efe575",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-00d6d6972528706c2",
           "securityGroupIds": [
             "my01-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF+I10zmH+ojLGsV4az5CwdBc9/041SKt5GPUc/YqKVNPxdyQITwRs/cLqkZHw97eOVFlKJAHO8SmQpMotHG9ek=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtx2r8Ou4fXFF0/0OPQ0Rk+x8nxvnqwJeTL+9tBaIzgNXkZJMZ89BpJskE2U2XGlPGjmzheQYG3idrFrwV6U98=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:JIQ/foOGdNVKJH+QeoKeGnpkqZ050cJXHJqCN63pMLY",
-            "firstUsedAt": "2026-05-18T08:02:39Z"
+            "fingerprint": "SHA256:kledbHEJr8DxkYCKFS+YqOfbAGwfb7bYstah9IAFp4U",
+            "firstUsedAt": "2026-06-02T11:58:08Z"
           },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-05-18T08:02:37Z",
-              "completedTime": "2026-05-18T08:02:40Z",
-              "elapsedTime": 3,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
+              "status": "Failed",
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:26Z",
+              "elapsedTime": 20,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -5857,7 +5856,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:09Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0574dd1a09d5c632d}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0cd90939abf365ee0}}"
             },
             {
               "key": "BootMode",
@@ -5869,7 +5868,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "1FF0C9D1-BAAF-4015-A570-54CE3F1704A3"
+              "value": "8A15C17A-F15C-460F-A71C-A57EF5F8E78E"
             },
             {
               "key": "CpuOptions",
@@ -5897,11 +5896,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "InstanceId",
-              "value": "i-055c3be58ba3b717a"
+              "value": "i-0b8bf7f9b3b9876c4"
             },
             {
               "key": "InstanceType",
@@ -5909,11 +5908,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd85cetmpr9ha6omvqiog"
+              "value": "tbgkl68qoqbt2irs6nn1"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-18T08:02:08Z"
+              "value": "2026-06-02T11:57:40Z"
             },
             {
               "key": "MetadataOptions",
@@ -5925,7 +5924,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Attachment:{AttachTime:2026-05-18T08:02:08Z,AttachmentId:eni-attach-0512107afc0efe575,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f4:96:e2:c0:8b,NetworkInterfaceId:eni-0c3a984205d7629b3,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.46,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.124.168.73},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.46}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-00d6d6972528706c2,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:67:60:31:ee:45,NetworkInterfaceId:eni-010ee71d81f863c52,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.136,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.201.83.130},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.136}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
             },
             {
               "key": "Placement",
@@ -5933,15 +5932,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-46.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-136.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.46"
+              "value": "10.0.1.136"
             },
             {
               "key": "PublicIpAddress",
-              "value": "13.124.168.73"
+              "value": "43.201.83.130"
             },
             {
               "key": "RootDeviceName",
@@ -5953,7 +5952,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-0b2020b2fa704162e,GroupName:tbd85ceuupr9ha6omvqis0}"
+              "value": "{GroupId:sg-0199f16c43ae8cc63,GroupName:tb6qo7797mvvc05iul83}"
             },
             {
               "key": "SourceDestCheck",
@@ -5965,11 +5964,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0695096ac3c17916f"
+              "value": "subnet-005c104e63421b753"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqj00}"
+              "value": "{Key:Name,Value:tbd9vt5h7b3mi7hlnsrl}"
             },
             {
               "key": "VirtualizationType",
@@ -5977,16 +5976,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-07e218262146e7003"
+              "value": "vpc-00b2b1e59e8d2653d"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85cevepr9ha6omvqiv0",
-          "cspResourceName": "tbd85cevepr9ha6omvqiv0",
-          "cspResourceId": "i-0fa2d84cd0c6e08bb",
+          "uid": "tbrh382k22c02gj6or2q",
+          "cspResourceName": "tbrh382k22c02gj6or2q",
+          "cspResourceId": "i-0273cb7e68fdf8fac",
           "name": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -6000,14 +5999,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:28",
+          "createdTime": "2026-06-02 11:58:00",
           "label": {
-            "Name": "tbd85cevepr9ha6omvqiv0",
+            "Name": "tbrh382k22c02gj6or2q",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:28",
-            "sys.cspResourceId": "i-0fa2d84cd0c6e08bb",
-            "sys.cspResourceName": "tbd85cevepr9ha6omvqiv0",
+            "sys.createdTime": "2026-06-02 11:58:00",
+            "sys.cspResourceId": "i-0273cb7e68fdf8fac",
+            "sys.cspResourceName": "tbrh382k22c02gj6or2q",
             "sys.id": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my01-infra101",
             "sys.labelType": "node",
@@ -6016,7 +6015,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my01-subnet-01",
-            "sys.uid": "tbd85cevepr9ha6omvqiv0",
+            "sys.uid": "tbrh382k22c02gj6or2q",
             "sys.vNetId": "my01-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6024,11 +6023,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "52.78.166.174",
+          "publicIP": "52.78.4.197",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.204",
-          "privateDNS": "ip-10-0-1-204.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.239",
+          "privateDNS": "ip-10-0-1-239.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
@@ -6071,45 +6070,44 @@
             "memoryGiB": 16,
             "costPerHour": 0.1872
           },
-          "imageId": "ami-08a1c21841a4c7a5f",
-          "cspImageName": "ami-08a1c21841a4c7a5f",
+          "imageId": "ami-0596f7562954deb8e",
+          "cspImageName": "ami-0596f7562954deb8e",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ami-08a1c21841a4c7a5f",
+            "cspImageName": "ami-0596f7562954deb8e",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410"
+            "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260521"
           },
           "vNetId": "my01-vnet-01",
-          "cspVNetId": "vpc-07e218262146e7003",
+          "cspVNetId": "vpc-00b2b1e59e8d2653d",
           "subnetId": "my01-subnet-01",
-          "cspSubnetId": "subnet-0695096ac3c17916f",
-          "networkInterface": "eni-attach-0dacfd07e29c82162",
+          "cspSubnetId": "subnet-005c104e63421b753",
+          "networkInterface": "eni-attach-0638cbee4cdabd7bd",
           "securityGroupIds": [
             "my01-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my01-sshkey-01",
-          "cspSshKeyId": "tbd85cetmpr9ha6omvqiog",
+          "cspSshKeyId": "tbgkl68qoqbt2irs6nn1",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJyKArhSkC+xcVNnvzj9CwMwKnXva6HvRVhVO1h0wfBpcTDP/ViBWoe96OAkh9DZCT1QWtAcmhnEDgJ5jAGXLnE=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBH97D952EztvAI/plpOdoCRtd21dx035GA7gRqjte2Nms1wIDFCgt9jQFauHyJRz8HXg/43acRo6d4xSZzc2ACw=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:PhaxYolMCyF8JSnMZ5JzXZ8GWc+VS+x3YRIZQ/caJN4",
-            "firstUsedAt": "2026-05-18T08:02:37Z"
+            "fingerprint": "SHA256:Fk9INcBJUzgOLcr6k2etg2P8ucfdRb5QkjAk/dNW5Bo",
+            "firstUsedAt": "2026-06-02T11:58:08Z"
           },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Completed",
-              "startedTime": "2026-05-18T08:02:37Z",
-              "completedTime": "2026-05-18T08:02:40Z",
-              "elapsedTime": 3,
-              "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
-              "stderr": "\n"
+              "status": "Failed",
+              "startedTime": "2026-06-02T11:58:06Z",
+              "completedTime": "2026-06-02T11:58:26Z",
+              "elapsedTime": 20,
+              "resultSummary": "Command execution failed",
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -6123,7 +6121,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-05-18T08:02:07Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-072521d142190aba5}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-06-02T11:57:41Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0387f952743f64ec0}}"
             },
             {
               "key": "BootMode",
@@ -6135,7 +6133,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "FDE8AD79-2C70-4CD5-B35E-3DBC181BEDD7"
+              "value": "9F574316-EB84-4652-B3FF-92E90421877B"
             },
             {
               "key": "CpuOptions",
@@ -6163,11 +6161,11 @@
             },
             {
               "key": "ImageId",
-              "value": "ami-08a1c21841a4c7a5f"
+              "value": "ami-0596f7562954deb8e"
             },
             {
               "key": "InstanceId",
-              "value": "i-0fa2d84cd0c6e08bb"
+              "value": "i-0273cb7e68fdf8fac"
             },
             {
               "key": "InstanceType",
@@ -6175,11 +6173,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbd85cetmpr9ha6omvqiog"
+              "value": "tbgkl68qoqbt2irs6nn1"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-05-18T08:02:07Z"
+              "value": "2026-06-02T11:57:40Z"
             },
             {
               "key": "MetadataOptions",
@@ -6191,7 +6189,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Attachment:{AttachTime:2026-05-18T08:02:07Z,AttachmentId:eni-attach-0dacfd07e29c82162,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:06:f2:cb:48:2b,NetworkInterfaceId:eni-071a58e90add5f477,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.204,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.166.174},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.204}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0695096ac3c17916f,VpcId:vpc-07e218262146e7003}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Attachment:{AttachTime:2026-06-02T11:57:40Z,AttachmentId:eni-attach-0638cbee4cdabd7bd,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c1:be:34:65:23,NetworkInterfaceId:eni-0dff89b4de2d2ff27,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.239,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:52.78.4.197},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.239}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-005c104e63421b753,VpcId:vpc-00b2b1e59e8d2653d}"
             },
             {
               "key": "Placement",
@@ -6199,15 +6197,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-204.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-239.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.204"
+              "value": "10.0.1.239"
             },
             {
               "key": "PublicIpAddress",
-              "value": "52.78.166.174"
+              "value": "52.78.4.197"
             },
             {
               "key": "RootDeviceName",
@@ -6219,7 +6217,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-014a3bc57edc785c7,GroupName:tbd85ceuepr9ha6omvqirg}"
+              "value": "{GroupId:sg-0ce7c1c68b49dfdfd,GroupName:tbgd82m18cv28pblnuad}"
             },
             {
               "key": "SourceDestCheck",
@@ -6231,11 +6229,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0695096ac3c17916f"
+              "value": "subnet-005c104e63421b753"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbd85cevepr9ha6omvqiv0}"
+              "value": "{Key:Name,Value:tbrh382k22c02gj6or2q}"
             },
             {
               "key": "VirtualizationType",
@@ -6243,7 +6241,7 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-07e218262146e7003"
+              "value": "vpc-00b2b1e59e8d2653d"
             }
           ]
         }
@@ -6259,13 +6257,13 @@
         "results": [
           {
             "infraId": "my01-infra101",
-            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "52.78.166.174",
+            "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "52.78.244.82",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-204 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-140 6.8.0-1055-aws #58~22.04.1-Ubuntu SMP Thu May  7 22:16:53 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6274,32 +6272,24 @@
           },
           {
             "infraId": "my01-infra101",
-            "nodeId": "my01-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "43.203.239.151",
+            "nodeId": "my01-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "52.78.4.197",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {
-              "0": "Linux ip-10-0-1-41 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
+            "stdout": {},
+            "stderr": {},
             "err": null
           },
           {
             "infraId": "my01-infra101",
             "nodeId": "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "13.124.168.73",
+            "nodeIp": "43.201.83.130",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {
-              "0": "Linux ip-10-0-1-46 6.8.0-1051-aws #54~22.04.1-Ubuntu SMP Wed Mar 25 15:41:00 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
+            "stdout": {},
+            "stderr": {},
             "err": null
           }
         ]
@@ -6308,7 +6298,7 @@
     {
       "resourceType": "infra",
       "id": "my02-infra101",
-      "uid": "tbd85cf3epr9ha6omvqjbg",
+      "uid": "tbv4r5dg0r6ctsgj7tfe",
       "name": "my02-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -6336,7 +6326,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my02-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjbg"
+        "sys.uid": "tbv4r5dg0r6ctsgj7tfe"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -6345,9 +6335,9 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85cf3epr9ha6omvqjcg",
-          "cspResourceName": "tbd85cf3epr9ha6omvqjcg",
-          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
+          "uid": "tb81h514blbmih6th0ra",
+          "cspResourceName": "tb81h514blbmih6th0ra",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
           "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -6361,16 +6351,16 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:03:14",
+          "createdTime": "2026-06-02 11:58:51",
           "label": {
-            "createdBy": "tbd85cf3epr9ha6omvqjcg",
-            "keypair": "tbd85cf06pr9ha6omvqj3g",
-            "publicip": "tbd85cf3epr9ha6omvqjcg-42454-PublicIP",
+            "createdBy": "tb81h514blbmih6th0ra",
+            "keypair": "tbmeu2jlibrbjhpqt6ks",
+            "publicip": "tb81h514blbmih6th0ra-51215-PublicIP",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "azure-koreasouth",
-            "sys.createdTime": "2026-05-18 08:03:14",
-            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
-            "sys.cspResourceName": "tbd85cf3epr9ha6omvqjcg",
+            "sys.createdTime": "2026-06-02 11:58:51",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
+            "sys.cspResourceName": "tb81h514blbmih6th0ra",
             "sys.id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my02-infra101",
             "sys.labelType": "node",
@@ -6379,17 +6369,17 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my02-subnet-01",
-            "sys.uid": "tbd85cf3epr9ha6omvqjcg",
+            "sys.uid": "tb81h514blbmih6th0ra",
             "sys.vNetId": "my02-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
           "region": {
             "region": "koreasouth"
           },
-          "publicIP": "20.214.25.229",
+          "publicIP": "40.89.209.210",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.5",
+          "privateIP": "10.0.1.4",
           "privateDNS": "",
           "rootDiskType": "PremiumSSD",
           "rootDiskSize": 30,
@@ -6428,32 +6418,32 @@
             "memoryGiB": 3.90625,
             "costPerHour": 0.0432
           },
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
           "image": {
             "resourceType": "image",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
           },
           "vNetId": "my02-vnet-01",
-          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
           "subnetId": "my02-subnet-01",
-          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-          "networkInterface": "tbd85cf3epr9ha6omvqjcg-39198-VNic",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+          "networkInterface": "tb81h514blbmih6th0ra-74785-VNic",
           "securityGroupIds": [
             "my02-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my02-sshkey-01",
-          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL0VTwP0mj+c6VjV8msgi3Q9eibNRewPMT54DUhTIpAg1Sht7ha22G1ufqkYptq1cFE80rR711dScHPLLhmJ+q8=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFW7tvj2HzsClA8X1H26zUY4x8P6NQYpxpab+6eweSK3WB1Z7hjR9loeEmmH+DcvmhMv+MY0Rswn2avB6fUySUc=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:L+I1/Qhho+5MTJJQUC536mZqODIvIydVP6vJjVbdai0",
-            "firstUsedAt": "2026-05-18T08:03:23Z"
+            "fingerprint": "SHA256:iARQFNvURLH907WgwzHgMJPVSWgoyBhMXtYvYWM/db0",
+            "firstUsedAt": "2026-06-02T11:58:58Z"
           },
           "commandStatus": [
             {
@@ -6461,11 +6451,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:03:23Z",
-              "completedTime": "2026-05-18T08:03:26Z",
-              "elapsedTime": 3,
+              "startedTime": "2026-06-02T11:58:57Z",
+              "completedTime": "2026-06-02T11:59:01Z",
+              "elapsedTime": 4,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -6476,11 +6466,11 @@
             },
             {
               "key": "Properties",
-              "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjcg-39198-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjcg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,osType:Linux}},timeCreated:2026-05-18T08:02:26.9394222Z,vmId:66b1ceb1-9da8-497a-ab77-8e1d40b4f26c}"
+              "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tb81h514blbmih6th0ra-74785-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tb81h514blbmih6th0ra,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,storageAccountType:Premium_LRS},name:tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,osType:Linux}},timeCreated:2026-06-02T11:58:00.0230074Z,vmId:a194131f-a308-4f9e-bd5f-1954226d1a73}"
             },
             {
               "key": "Tags",
-              "value": "{createdBy:tbd85cf3epr9ha6omvqjcg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjcg-42454-PublicIP}"
+              "value": "{createdBy:tb81h514blbmih6th0ra,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tb81h514blbmih6th0ra-51215-PublicIP}"
             },
             {
               "key": "Etag",
@@ -6488,11 +6478,11 @@
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra"
             },
             {
               "key": "Name",
-              "value": "tbd85cf3epr9ha6omvqjcg"
+              "value": "tb81h514blbmih6th0ra"
             },
             {
               "key": "Type",
@@ -6503,9 +6493,9 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85cf3epr9ha6omvqjeg",
-          "cspResourceName": "tbd85cf3epr9ha6omvqjeg",
-          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
+          "uid": "tbj3l6ut11ch7mvkq2p2",
+          "cspResourceName": "tbj3l6ut11ch7mvkq2p2",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
           "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -6519,16 +6509,16 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:03:17",
+          "createdTime": "2026-06-02 11:58:51",
           "label": {
-            "createdBy": "tbd85cf3epr9ha6omvqjeg",
-            "keypair": "tbd85cf06pr9ha6omvqj3g",
-            "publicip": "tbd85cf3epr9ha6omvqjeg-83151-PublicIP",
+            "createdBy": "tbj3l6ut11ch7mvkq2p2",
+            "keypair": "tbmeu2jlibrbjhpqt6ks",
+            "publicip": "tbj3l6ut11ch7mvkq2p2-63146-PublicIP",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "azure-koreasouth",
-            "sys.createdTime": "2026-05-18 08:03:17",
-            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
-            "sys.cspResourceName": "tbd85cf3epr9ha6omvqjeg",
+            "sys.createdTime": "2026-06-02 11:58:51",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
+            "sys.cspResourceName": "tbj3l6ut11ch7mvkq2p2",
             "sys.id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my02-infra101",
             "sys.labelType": "node",
@@ -6537,14 +6527,14 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my02-subnet-01",
-            "sys.uid": "tbd85cf3epr9ha6omvqjeg",
+            "sys.uid": "tbj3l6ut11ch7mvkq2p2",
             "sys.vNetId": "my02-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
           "region": {
             "region": "koreasouth"
           },
-          "publicIP": "20.214.26.6",
+          "publicIP": "52.231.195.8",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.6",
@@ -6586,32 +6576,32 @@
             "memoryGiB": 7.8125,
             "costPerHour": 0.0865
           },
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
           "image": {
             "resourceType": "image",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
           },
           "vNetId": "my02-vnet-01",
-          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
           "subnetId": "my02-subnet-01",
-          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-          "networkInterface": "tbd85cf3epr9ha6omvqjeg-47871-VNic",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+          "networkInterface": "tbj3l6ut11ch7mvkq2p2-3298-VNic",
           "securityGroupIds": [
             "my02-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my02-sshkey-01",
-          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEjxGVDmlxPviCew7MPsxQCg/SbRH0g1LPINkzdzqnLKnu1r1BVcN2sOxPrrm4d3ektW4i1wjM5H3IyYVNdYIXM=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJtUMh1cIUNrdvxDyS/sX2gg1UlgprQImyTmtt571zIcfmNpvML9//EZjbJhwyEPPk1DSV9P+GsLYIsancoLI2Q=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:kXaggWkouCHVkByZEeZ7WbredHOydMu4PhHCk95sdGA",
-            "firstUsedAt": "2026-05-18T08:03:25Z"
+            "fingerprint": "SHA256:vHAecS7HpoCmHLAn96798w3BOcO14c/PF8E2f32n6W4",
+            "firstUsedAt": "2026-06-02T11:59:00Z"
           },
           "commandStatus": [
             {
@@ -6619,11 +6609,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:03:23Z",
-              "completedTime": "2026-05-18T08:03:27Z",
-              "elapsedTime": 4,
+              "startedTime": "2026-06-02T11:58:57Z",
+              "completedTime": "2026-06-02T11:59:03Z",
+              "elapsedTime": 6,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -6634,11 +6624,11 @@
             },
             {
               "key": "Properties",
-              "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjeg-47871-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjeg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,osType:Linux}},timeCreated:2026-05-18T08:02:28.9784295Z,vmId:85838c4c-38c3-4641-9333-9b5b9ab4769a}"
+              "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbj3l6ut11ch7mvkq2p2-3298-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbj3l6ut11ch7mvkq2p2,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,storageAccountType:Premium_LRS},name:tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,osType:Linux}},timeCreated:2026-06-02T11:58:02.5923143Z,vmId:26a400ec-766d-4066-a986-31dee1af0a49}"
             },
             {
               "key": "Tags",
-              "value": "{createdBy:tbd85cf3epr9ha6omvqjeg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjeg-83151-PublicIP}"
+              "value": "{createdBy:tbj3l6ut11ch7mvkq2p2,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tbj3l6ut11ch7mvkq2p2-63146-PublicIP}"
             },
             {
               "key": "Etag",
@@ -6646,11 +6636,11 @@
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2"
             },
             {
               "key": "Name",
-              "value": "tbd85cf3epr9ha6omvqjeg"
+              "value": "tbj3l6ut11ch7mvkq2p2"
             },
             {
               "key": "Type",
@@ -6661,9 +6651,9 @@
         {
           "resourceType": "node",
           "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85cf3epr9ha6omvqjdg",
-          "cspResourceName": "tbd85cf3epr9ha6omvqjdg",
-          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
+          "uid": "tblumcks3qbld4l0rqdu",
+          "cspResourceName": "tblumcks3qbld4l0rqdu",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
           "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -6677,16 +6667,16 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:03:15",
+          "createdTime": "2026-06-02 11:58:51",
           "label": {
-            "createdBy": "tbd85cf3epr9ha6omvqjdg",
-            "keypair": "tbd85cf06pr9ha6omvqj3g",
-            "publicip": "tbd85cf3epr9ha6omvqjdg-86268-PublicIP",
+            "createdBy": "tblumcks3qbld4l0rqdu",
+            "keypair": "tbmeu2jlibrbjhpqt6ks",
+            "publicip": "tblumcks3qbld4l0rqdu-15505-PublicIP",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "azure-koreasouth",
-            "sys.createdTime": "2026-05-18 08:03:15",
-            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
-            "sys.cspResourceName": "tbd85cf3epr9ha6omvqjdg",
+            "sys.createdTime": "2026-06-02 11:58:51",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
+            "sys.cspResourceName": "tblumcks3qbld4l0rqdu",
             "sys.id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my02-infra101",
             "sys.labelType": "node",
@@ -6695,17 +6685,17 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my02-subnet-01",
-            "sys.uid": "tbd85cf3epr9ha6omvqjdg",
+            "sys.uid": "tblumcks3qbld4l0rqdu",
             "sys.vNetId": "my02-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
           "region": {
             "region": "koreasouth"
           },
-          "publicIP": "52.231.195.68",
+          "publicIP": "20.214.40.12",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.4",
+          "privateIP": "10.0.1.5",
           "privateDNS": "",
           "rootDiskType": "PremiumSSD",
           "rootDiskSize": 30,
@@ -6744,32 +6734,32 @@
             "memoryGiB": 15.625,
             "costPerHour": 0.173
           },
-          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
           "image": {
             "resourceType": "image",
-            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260"
           },
           "vNetId": "my02-vnet-01",
-          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
           "subnetId": "my02-subnet-01",
-          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-          "networkInterface": "tbd85cf3epr9ha6omvqjdg-3065-VNic",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+          "networkInterface": "tblumcks3qbld4l0rqdu-93021-VNic",
           "securityGroupIds": [
             "my02-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my02-sshkey-01",
-          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTNwiwA06iMy3QoeSkT4pJXpOsH22Jn6+LnZ+ak239UDz03i5xCcIOmCYDASX7JMLHv1NfehWWjviZjXQOCm0A=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTL9uzNQSU1yXWyoHY8FKtgjUxNkaKpGjhn6dtQjVMVJC3cpROCI06y1MwW8elX7OtijS4pmgWxkK29xA0kJ80=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:zSgb3/NtuvOcCa3S2XoWo/Kj3Tpb4B15i3wLbr896JA",
-            "firstUsedAt": "2026-05-18T08:03:25Z"
+            "fingerprint": "SHA256:lVsWJmS92R46BkqahsTpl8eAW8rA6D39KJOZaJA3sj8",
+            "firstUsedAt": "2026-06-02T11:59:00Z"
           },
           "commandStatus": [
             {
@@ -6777,11 +6767,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:03:23Z",
-              "completedTime": "2026-05-18T08:03:28Z",
+              "startedTime": "2026-06-02T11:58:57Z",
+              "completedTime": "2026-06-02T11:59:02Z",
               "elapsedTime": 5,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -6792,11 +6782,11 @@
             },
             {
               "key": "Properties",
-              "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjdg-3065-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjdg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,osType:Linux}},timeCreated:2026-05-18T08:02:27.2996702Z,vmId:9f82564d-bc46-434c-955e-4e8a0c6ad147}"
+              "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tblumcks3qbld4l0rqdu-93021-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tblumcks3qbld4l0rqdu,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,storageAccountType:Premium_LRS},name:tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,osType:Linux}},timeCreated:2026-06-02T11:58:00.3944037Z,vmId:bb9a97ea-bbc0-4b18-b394-cb1accf01389}"
             },
             {
               "key": "Tags",
-              "value": "{createdBy:tbd85cf3epr9ha6omvqjdg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjdg-86268-PublicIP}"
+              "value": "{createdBy:tblumcks3qbld4l0rqdu,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tblumcks3qbld4l0rqdu-15505-PublicIP}"
             },
             {
               "key": "Etag",
@@ -6804,11 +6794,11 @@
             },
             {
               "key": "ID",
-              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg"
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu"
             },
             {
               "key": "Name",
-              "value": "tbd85cf3epr9ha6omvqjdg"
+              "value": "tblumcks3qbld4l0rqdu"
             },
             {
               "key": "Type",
@@ -6829,27 +6819,12 @@
           {
             "infraId": "my02-infra101",
             "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "20.214.25.229",
+            "nodeIp": "40.89.209.210",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
-            "err": null
-          },
-          {
-            "infraId": "my02-infra101",
-            "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "20.214.26.6",
-            "command": {
-              "0": "uname -a"
-            },
-            "stdout": {
-              "0": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6859,12 +6834,27 @@
           {
             "infraId": "my02-infra101",
             "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "52.231.195.68",
+            "nodeIp": "20.214.40.12",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my02-infra101",
+            "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "52.231.195.8",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -6877,7 +6867,7 @@
     {
       "resourceType": "infra",
       "id": "my04-infra101",
-      "uid": "tbd85cf1upr9ha6omvqj60",
+      "uid": "tbsb9sq51v4fnsipkeap",
       "name": "my04-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -6905,7 +6895,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my04-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85cf1upr9ha6omvqj60"
+        "sys.uid": "tbsb9sq51v4fnsipkeap"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -6914,9 +6904,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85cf1upr9ha6omvqj70",
-          "cspResourceName": "tbd85cf1upr9ha6omvqj70",
-          "cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
+          "uid": "tbhs2tl9c3te0mksjp02",
+          "cspResourceName": "tbhs2tl9c3te0mksjp02",
+          "cspResourceId": "i-mj7e35tls2uwpys3780q",
           "name": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -6930,13 +6920,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:47",
+          "createdTime": "2026-06-02 11:58:17",
           "label": {
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:47",
-            "sys.cspResourceId": "i-mj7ctm2infbmnn6vq0ex",
-            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj70",
+            "sys.createdTime": "2026-06-02 11:58:17",
+            "sys.cspResourceId": "i-mj7e35tls2uwpys3780q",
+            "sys.cspResourceName": "tbhs2tl9c3te0mksjp02",
             "sys.id": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -6945,7 +6935,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd85cf1upr9ha6omvqj70",
+            "sys.uid": "tbhs2tl9c3te0mksjp02",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -6953,12 +6943,12 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "47.80.240.250",
+          "publicIP": "8.213.148.90",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.15",
+          "privateIP": "10.0.1.130",
           "privateDNS": "",
-          "rootDiskType": "cloud_essd",
+          "rootDiskType": "cloud_auto",
           "rootDiskSize": 40,
           "RootDeviceName": "/dev/xvda",
           "connectionName": "alibaba-ap-northeast-2",
@@ -6998,33 +6988,33 @@
             "memoryGiB": 2,
             "costPerHour": 0.0178
           },
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
-          "networkInterface": "eni-mj7ctm2infbmnn6uucox",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7e35tls2uwpys2lvv7",
           "securityGroupIds": [
             "my04-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "upb!t1$1fd8c5A",
+          "nodeUserPassword": "$cpn1fbmnt!Abl",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIxjgydAuYGlPu0chuI8q9j7hzoY0Rq4M/6ULrhSpcsPA78KSE4g2MEgG2KnC/Y9kaOYioaIMVk355QCS+/2JM=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNhMNxzCV4xDgqQZg5+XGyt06ozb7LlWixrfbFJWox/iiHeJdkvx+xu/LmaVx6kjg/KPkOVil3M8LlcpqqmEpdk=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:ElR8y8aTDUmfc8Kf9iCIhXjocBPKZg5jjX79lSxer8U",
-            "firstUsedAt": "2026-05-18T08:02:56Z"
+            "fingerprint": "SHA256:wyhhKV/Me4xRzt4oodcl1P0bOWE1botx6CeeFuzBOW0",
+            "firstUsedAt": "2026-06-02T11:58:31Z"
           },
           "commandStatus": [
             {
@@ -7032,11 +7022,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:02:55Z",
-              "completedTime": "2026-05-18T08:02:57Z",
+              "startedTime": "2026-06-02T11:58:31Z",
+              "completedTime": "2026-06-02T11:58:33Z",
               "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -7071,7 +7061,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbd85cf1upr9ha6omvqj70"
+              "value": "tbhs2tl9c3te0mksjp02"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -7091,7 +7081,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-18T08:02Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "ZoneId",
@@ -7107,7 +7097,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj7ctm2infbmnn6vq0exZ"
+              "value": "iZmj7e35tls2uwpys3780qZ"
             },
             {
               "key": "Status",
@@ -7139,7 +7129,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "13344c44-f69b-4fdb-bc04-e9e4756fde66"
+              "value": "aaf96940-aed7-409b-939f-aea783b600b6"
             },
             {
               "key": "RegionId",
@@ -7159,7 +7149,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj7ctm2infbmnn6vq0ex"
+              "value": "i-mj7e35tls2uwpys3780q"
             },
             {
               "key": "Recyclable",
@@ -7179,11 +7169,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-18T08:02Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbd85ceuupr9ha6omvqisg"
+              "value": "tbkc0tqjtqulqspk3vmj"
             },
             {
               "key": "LocalStorageCapacity",
@@ -7207,7 +7197,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj75hai0hn9b26o6u0lu]}"
+              "value": "{SecurityGroupId:[sg-mj71w6ok3fzhi53tij5j]}"
             },
             {
               "key": "InnerIpAddress",
@@ -7215,7 +7205,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[47.80.240.250]}"
+              "value": "{IpAddress:[8.213.148.90]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -7263,7 +7253,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.15]}}"
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.130]}}"
             },
             {
               "key": "Tags",
@@ -7271,7 +7261,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:30,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7ctm2infbmnn6uucox,PrimaryIpAddress:10.0.1.15,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.15,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a8,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvv7,PrimaryIpAddress:10.0.1.130,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.130,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -7282,9 +7272,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85cf1upr9ha6omvqj90",
-          "cspResourceName": "tbd85cf1upr9ha6omvqj90",
-          "cspResourceId": "i-mj70qfjkj53k1lfmwem5",
+          "uid": "tbcpprl9juav33e9q3c2",
+          "cspResourceName": "tbcpprl9juav33e9q3c2",
+          "cspResourceId": "i-mj7e35tls2uwpys3780r",
           "name": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -7298,13 +7288,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:47",
+          "createdTime": "2026-06-02 11:58:24",
           "label": {
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:47",
-            "sys.cspResourceId": "i-mj70qfjkj53k1lfmwem5",
-            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj90",
+            "sys.createdTime": "2026-06-02 11:58:24",
+            "sys.cspResourceId": "i-mj7e35tls2uwpys3780r",
+            "sys.cspResourceName": "tbcpprl9juav33e9q3c2",
             "sys.id": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -7313,7 +7303,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd85cf1upr9ha6omvqj90",
+            "sys.uid": "tbcpprl9juav33e9q3c2",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -7321,12 +7311,12 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "8.220.222.227",
+          "publicIP": "47.80.241.105",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.17",
+          "privateIP": "10.0.1.131",
           "privateDNS": "",
-          "rootDiskType": "cloud_essd",
+          "rootDiskType": "cloud_essd_entry",
           "rootDiskSize": 40,
           "RootDeviceName": "/dev/xvda",
           "connectionName": "alibaba-ap-northeast-2",
@@ -7366,33 +7356,33 @@
             "memoryGiB": 8,
             "costPerHour": 0.0791
           },
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
-          "networkInterface": "eni-mj70qfjkj53k1lfk3g4v",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7e35tls2uwpys2lvva",
           "securityGroupIds": [
             "my04-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "1bc15$udf8pAt!",
+          "nodeUserPassword": "og1p!0lt8bfAm$",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjpJO+iCEU9UWWxdK8tLAyQm+wo3x/MrYpIbM/i6AEC/aXL7gIArd+gJWLDbG4U7beYUDeqNCYoNaQ84LkntQ4=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD1gzSk9e926lbr/5G5aVaQiCrn/ll3UEMwqHa/mQNWN3remyRmCxaVjOBpRTG6Oq8982X2IJ403G4BSAEzHBmg=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:CN3Vr5UeDqGvqf+08il0YBKW/Q92T5KR3JBAFnULA/I",
-            "firstUsedAt": "2026-05-18T08:02:56Z"
+            "fingerprint": "SHA256:riHiQusw8+6WASDQXHPWeQ9s9W79YdIKy6bv+E597Kc",
+            "firstUsedAt": "2026-06-02T11:58:32Z"
           },
           "commandStatus": [
             {
@@ -7400,11 +7390,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:02:55Z",
-              "completedTime": "2026-05-18T08:02:57Z",
+              "startedTime": "2026-06-02T11:58:31Z",
+              "completedTime": "2026-06-02T11:58:33Z",
               "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -7439,7 +7429,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbd85cf1upr9ha6omvqj90"
+              "value": "tbcpprl9juav33e9q3c2"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -7459,7 +7449,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-18T08:02Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "ZoneId",
@@ -7475,7 +7465,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj70qfjkj53k1lfmwem5Z"
+              "value": "iZmj7e35tls2uwpys3780rZ"
             },
             {
               "key": "Status",
@@ -7507,7 +7497,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "59a11a5d-1a8e-4b85-8c4f-4e84016912bd"
+              "value": "769359a1-ff5c-47f6-aa50-705ede2c8b58"
             },
             {
               "key": "RegionId",
@@ -7527,7 +7517,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj70qfjkj53k1lfmwem5"
+              "value": "i-mj7e35tls2uwpys3780r"
             },
             {
               "key": "Recyclable",
@@ -7547,11 +7537,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-18T08:02Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbd85ceuupr9ha6omvqisg"
+              "value": "tbkc0tqjtqulqspk3vmj"
             },
             {
               "key": "LocalStorageCapacity",
@@ -7575,7 +7565,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj78vtpurhkjrhyd2zt7]}"
+              "value": "{SecurityGroupId:[sg-mj780ni10nbsxrfvdoxa]}"
             },
             {
               "key": "InnerIpAddress",
@@ -7583,7 +7573,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[8.220.222.227]}"
+              "value": "{IpAddress:[47.80.241.105]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -7631,7 +7621,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.17]}}"
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.131]}}"
             },
             {
               "key": "Tags",
@@ -7639,7 +7629,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:32,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj70qfjkj53k1lfk3g4v,PrimaryIpAddress:10.0.1.17,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.17,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a9,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7e35tls2uwpys2lvva,PrimaryIpAddress:10.0.1.131,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.131,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -7650,9 +7640,9 @@
         {
           "resourceType": "node",
           "id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85cf1upr9ha6omvqj80",
-          "cspResourceName": "tbd85cf1upr9ha6omvqj80",
-          "cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
+          "uid": "tb0gc9fc2ec0v7te0en2",
+          "cspResourceName": "tb0gc9fc2ec0v7te0en2",
+          "cspResourceId": "i-mj7caxyslyfjiirlhjj0",
           "name": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -7666,13 +7656,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:02:47",
+          "createdTime": "2026-06-02 11:58:19",
           "label": {
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "alibaba-ap-northeast-2",
-            "sys.createdTime": "2026-05-18 08:02:47",
-            "sys.cspResourceId": "i-mj7bmodw2wgq13tm2g8j",
-            "sys.cspResourceName": "tbd85cf1upr9ha6omvqj80",
+            "sys.createdTime": "2026-06-02 11:58:19",
+            "sys.cspResourceId": "i-mj7caxyslyfjiirlhjj0",
+            "sys.cspResourceName": "tb0gc9fc2ec0v7te0en2",
             "sys.id": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my04-infra101",
             "sys.labelType": "node",
@@ -7681,7 +7671,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my04-subnet-01",
-            "sys.uid": "tbd85cf1upr9ha6omvqj80",
+            "sys.uid": "tb0gc9fc2ec0v7te0en2",
             "sys.vNetId": "my04-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -7689,12 +7679,12 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "47.80.57.53",
+          "publicIP": "47.80.241.200",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.16",
+          "privateIP": "10.0.1.129",
           "privateDNS": "",
-          "rootDiskType": "cloud_essd",
+          "rootDiskType": "cloud_essd_entry",
           "rootDiskSize": 40,
           "RootDeviceName": "/dev/xvda",
           "connectionName": "alibaba-ap-northeast-2",
@@ -7734,33 +7724,33 @@
             "memoryGiB": 16,
             "costPerHour": 0.1582
           },
-          "imageId": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+          "imageId": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
           "image": {
             "resourceType": "image",
-            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260316.vhd",
+            "cspImageName": "ubuntu_22_04_x64_20G_alibase_20260506.vhd",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu  22.04 64 bit"
           },
           "vNetId": "my04-vnet-01",
-          "cspVNetId": "vpc-mj7kupnhl8vcko5nzmtjs",
+          "cspVNetId": "vpc-mj77rilp5f4fn312w79hj",
           "subnetId": "my04-subnet-01",
-          "cspSubnetId": "vsw-mj7noc100izqdsv9ei3ge",
-          "networkInterface": "eni-mj7bmodw2wgq13tslyzg",
+          "cspSubnetId": "vsw-mj713tfhuu6jxzc6pn93z",
+          "networkInterface": "eni-mj7caxyslyfjiirmuk6r",
           "securityGroupIds": [
             "my04-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my04-sshkey-01",
-          "cspSshKeyId": "tbd85ceuupr9ha6omvqisg",
+          "cspSshKeyId": "tbkc0tqjtqulqspk3vmj",
           "nodeUserName": "cb-user",
-          "nodeUserPassword": "$dA5bucp!f1t81",
+          "nodeUserPassword": "07qr$1j!1Ab9ot",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIoOQ2gvfcNkTlNvuqkusRt8H2qhBA89swB2tyZNTyPQI6IG5Rq30BzABy4uD/mVN5T1FFu4vaI+o5kEgApc87Q=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA36aUcHKHQ+RZ14yQy69ODrhFbF5gSjK7aKhCsDtxNKCAhSEkZ/x4ee4OO+z34nzoF7nlslcVVpwf2C1pOA02k=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:Y6GQw48WwR78o9JdeZKtnxMOFr9e5MIESK+ZhUdpvPM",
-            "firstUsedAt": "2026-05-18T08:02:55Z"
+            "fingerprint": "SHA256:Il27QVw0TAS24BNoLHeyuwBFqvo13kGaDO+NVrf6Roo",
+            "firstUsedAt": "2026-06-02T11:58:32Z"
           },
           "commandStatus": [
             {
@@ -7768,11 +7758,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:02:55Z",
-              "completedTime": "2026-05-18T08:02:56Z",
-              "elapsedTime": 1,
+              "startedTime": "2026-06-02T11:58:31Z",
+              "completedTime": "2026-06-02T11:58:33Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -7807,7 +7797,7 @@
             },
             {
               "key": "InstanceName",
-              "value": "tbd85cf1upr9ha6omvqj80"
+              "value": "tb0gc9fc2ec0v7te0en2"
             },
             {
               "key": "DeploymentSetGroupNo",
@@ -7827,7 +7817,7 @@
             },
             {
               "key": "StartTime",
-              "value": "2026-05-18T08:02Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "ZoneId",
@@ -7843,7 +7833,7 @@
             },
             {
               "key": "HostName",
-              "value": "iZmj7bmodw2wgq13tm2g8jZ"
+              "value": "iZmj7caxyslyfjiirlhjj0Z"
             },
             {
               "key": "Status",
@@ -7875,7 +7865,7 @@
             },
             {
               "key": "SerialNumber",
-              "value": "3e72e546-fbd2-4921-a2ff-d588c6c712fc"
+              "value": "6ea8094f-30c3-4bf8-b920-8f69ab5460e0"
             },
             {
               "key": "RegionId",
@@ -7895,7 +7885,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-mj7bmodw2wgq13tm2g8j"
+              "value": "i-mj7caxyslyfjiirlhjj0"
             },
             {
               "key": "Recyclable",
@@ -7915,11 +7905,11 @@
             },
             {
               "key": "CreationTime",
-              "value": "2026-05-18T08:02Z"
+              "value": "2026-06-02T11:57Z"
             },
             {
               "key": "KeyPairName",
-              "value": "tbd85ceuupr9ha6omvqisg"
+              "value": "tbkc0tqjtqulqspk3vmj"
             },
             {
               "key": "LocalStorageCapacity",
@@ -7943,7 +7933,7 @@
             },
             {
               "key": "SecurityGroupIds",
-              "value": "{SecurityGroupId:[sg-mj71whg4s0wud8qlexce]}"
+              "value": "{SecurityGroupId:[sg-mj7d6hrwmdy4yo1s8y96]}"
             },
             {
               "key": "InnerIpAddress",
@@ -7951,7 +7941,7 @@
             },
             {
               "key": "PublicIpAddress",
-              "value": "{IpAddress:[47.80.57.53]}"
+              "value": "{IpAddress:[47.80.241.200]}"
             },
             {
               "key": "RdmaIpAddress",
@@ -7999,7 +7989,7 @@
             },
             {
               "key": "VpcAttributes",
-              "value": "{VSwitchId:vsw-mj7noc100izqdsv9ei3ge,VpcId:vpc-mj7kupnhl8vcko5nzmtjs,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.16]}}"
+              "value": "{VSwitchId:vsw-mj713tfhuu6jxzc6pn93z,VpcId:vpc-mj77rilp5f4fn312w79hj,NatIpAddress:,PrivateIpAddress:{IpAddress:[10.0.1.129]}}"
             },
             {
               "key": "Tags",
@@ -8007,7 +7997,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:08:0e:31,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7bmodw2wgq13tslyzg,PrimaryIpAddress:10.0.1.16,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.16,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
+              "value": "{NetworkInterface:[{SecurityGroupId:,VSwitchId:,DeleteOnRelease:false,InstanceType:,MacAddress:00:16:3e:06:b8:a7,NetworkInterfaceTrafficMode:,NetworkInterfaceName:,NetworkInterfaceId:eni-mj7caxyslyfjiirmuk6r,PrimaryIpAddress:10.0.1.129,Description:,Type:Primary,SecurityGroupIds:{SecurityGroupId:null},Ipv6PrefixSets:{Ipv6PrefixSet:null},Ipv4PrefixSets:{Ipv4PrefixSet:null},Ipv6Sets:{Ipv6Set:null},PrivateIpSets:{PrivateIpSet:[{PrivateIpAddress:10.0.1.129,PrivateDnsName:,Primary:true,AssociatedPublicIp:{PublicIpAddress:,AllocationId:}}]}}]}"
             },
             {
               "key": "OperationLocks",
@@ -8027,13 +8017,13 @@
         "results": [
           {
             "infraId": "my04-infra101",
-            "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "47.80.57.53",
+            "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "8.213.148.90",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj7bmodw2wgq13tm2g8jZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj7e35tls2uwpys3780qZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -8042,13 +8032,13 @@
           },
           {
             "infraId": "my04-infra101",
-            "nodeId": "my04-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "47.80.240.250",
+            "nodeId": "my04-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "47.80.241.200",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj7ctm2infbmnn6vq0exZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj7caxyslyfjiirlhjj0Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -8058,12 +8048,12 @@
           {
             "infraId": "my04-infra101",
             "nodeId": "my04-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "8.220.222.227",
+            "nodeIp": "47.80.241.105",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux iZmj70qfjkj53k1lfmwem5Z 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux iZmj7e35tls2uwpys3780rZ 5.15.0-177-generic #187-Ubuntu SMP Sat Apr 11 22:54:33 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -8071,6 +8061,298 @@
             "err": null
           }
         ]
+      }
+    },
+    {
+      "resourceType": "infra",
+      "id": "my06-infra101",
+      "uid": "tbb155e34rt94il69ph3",
+      "name": "my06-infra101",
+      "status": "Creating:3 (R:0/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 3,
+        "countRunning": 0,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "Running",
+      "targetAction": "Create",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my06-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my06-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbb155e34rt94il69ph3"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tbt7k7116g5o02ekkgfm",
+          "name": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "Australia (Sydney)",
+            "latitude": -33.86882,
+            "longitude": 151.209296
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 100,
+          "RootDeviceName": "",
+          "connectionName": "ibm-au-syd",
+          "connectionConfig": {
+            "configName": "ibm-au-syd",
+            "providerName": "ibm",
+            "driverName": "ibm-driver-v1.0.so",
+            "credentialName": "ibm",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "ibm-au-syd",
+            "regionZoneInfo": {
+              "assignedRegion": "au-syd",
+              "assignedZone": "au-syd-1"
+            },
+            "regionDetail": {
+              "regionId": "au-syd",
+              "regionName": "au-syd",
+              "description": "Sydney (Australia)",
+              "location": {
+                "display": "Australia (Sydney)",
+                "latitude": -33.86882,
+                "longitude": 151.209296
+              },
+              "zones": [
+                "au-syd-1",
+                "au-syd-2",
+                "au-syd-3"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "ibm+au-syd+nxf-2x2",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my06-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my06-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my06-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my06-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tb1h7ijtv4sdjjt74cq4",
+          "name": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "Australia (Sydney)",
+            "latitude": -33.86882,
+            "longitude": 151.209296
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 100,
+          "RootDeviceName": "",
+          "connectionName": "ibm-au-syd",
+          "connectionConfig": {
+            "configName": "ibm-au-syd",
+            "providerName": "ibm",
+            "driverName": "ibm-driver-v1.0.so",
+            "credentialName": "ibm",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "ibm-au-syd",
+            "regionZoneInfo": {
+              "assignedRegion": "au-syd",
+              "assignedZone": "au-syd-1"
+            },
+            "regionDetail": {
+              "regionId": "au-syd",
+              "regionName": "au-syd",
+              "description": "Sydney (Australia)",
+              "location": {
+                "display": "Australia (Sydney)",
+                "latitude": -33.86882,
+                "longitude": 151.209296
+              },
+              "zones": [
+                "au-syd-1",
+                "au-syd-2",
+                "au-syd-3"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "ibm+au-syd+bxf-2x8",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my06-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my06-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my06-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my06-sshkey-01",
+          "cspSshKeyId": ""
+        },
+        {
+          "resourceType": "node",
+          "id": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbfb0c8hrtma9tjabtm6",
+          "name": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "Australia (Sydney)",
+            "latitude": -33.86882,
+            "longitude": 151.209296
+          },
+          "status": "Creating",
+          "targetStatus": "Running",
+          "targetAction": "Create",
+          "monAgentStatus": "",
+          "networkAgentStatus": "",
+          "systemMessage": "",
+          "createdTime": "",
+          "label": null,
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+          "region": {
+            "region": ""
+          },
+          "publicIP": "",
+          "sshPort": 0,
+          "publicDNS": "",
+          "privateIP": "",
+          "privateDNS": "",
+          "rootDiskType": "",
+          "rootDiskSize": 100,
+          "RootDeviceName": "",
+          "connectionName": "ibm-au-syd",
+          "connectionConfig": {
+            "configName": "ibm-au-syd",
+            "providerName": "ibm",
+            "driverName": "ibm-driver-v1.0.so",
+            "credentialName": "ibm",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "ibm-au-syd",
+            "regionZoneInfo": {
+              "assignedRegion": "au-syd",
+              "assignedZone": "au-syd-1"
+            },
+            "regionDetail": {
+              "regionId": "au-syd",
+              "regionName": "au-syd",
+              "description": "Sydney (Australia)",
+              "location": {
+                "display": "Australia (Sydney)",
+                "latitude": -33.86882,
+                "longitude": 151.209296
+              },
+              "zones": [
+                "au-syd-1",
+                "au-syd-2",
+                "au-syd-3"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "ibm+au-syd+bxf-4x16",
+          "cspSpecName": "",
+          "spec": {},
+          "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "image": {
+            "osType": ""
+          },
+          "vNetId": "my06-vnet-01",
+          "cspVNetId": "",
+          "subnetId": "my06-subnet-01",
+          "cspSubnetId": "",
+          "networkInterface": "",
+          "securityGroupIds": [
+            "my06-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my06-sshkey-01",
+          "cspSshKeyId": ""
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": null
       }
     }
   ]
@@ -8099,7 +8381,8 @@
   "idList": [
     "my01-infra101",
     "my02-infra101",
-    "my04-infra101"
+    "my04-infra101",
+    "my06-infra101"
   ]
 }
 ```
@@ -8128,7 +8411,7 @@
 {
   "resourceType": "infra",
   "id": "my02-infra101",
-  "uid": "tbd85cf3epr9ha6omvqjbg",
+  "uid": "tbv4r5dg0r6ctsgj7tfe",
   "name": "my02-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -8156,7 +8439,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my02-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85cf3epr9ha6omvqjbg"
+    "sys.uid": "tbv4r5dg0r6ctsgj7tfe"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -8165,9 +8448,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85cf3epr9ha6omvqjcg",
-      "cspResourceName": "tbd85cf3epr9ha6omvqjcg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
+      "uid": "tb81h514blbmih6th0ra",
+      "cspResourceName": "tb81h514blbmih6th0ra",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
       "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -8181,16 +8464,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:03:14",
+      "createdTime": "2026-06-02 11:58:51",
       "label": {
-        "createdBy": "tbd85cf3epr9ha6omvqjcg",
-        "keypair": "tbd85cf06pr9ha6omvqj3g",
-        "publicip": "tbd85cf3epr9ha6omvqjcg-42454-PublicIP",
+        "createdBy": "tb81h514blbmih6th0ra",
+        "keypair": "tbmeu2jlibrbjhpqt6ks",
+        "publicip": "tb81h514blbmih6th0ra-51215-PublicIP",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-18 08:03:14",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg",
-        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjcg",
+        "sys.createdTime": "2026-06-02 11:58:51",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
+        "sys.cspResourceName": "tb81h514blbmih6th0ra",
         "sys.id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -8199,17 +8482,17 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjcg",
+        "sys.uid": "tb81h514blbmih6th0ra",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "20.214.25.229",
+      "publicIP": "40.89.209.210",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.5",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
       "rootDiskSize": 30,
@@ -8248,32 +8531,32 @@
         "memoryGiB": 3.90625,
         "costPerHour": 0.0432
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-      "networkInterface": "tbd85cf3epr9ha6omvqjcg-39198-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+      "networkInterface": "tb81h514blbmih6th0ra-74785-VNic",
       "securityGroupIds": [
         "my02-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL0VTwP0mj+c6VjV8msgi3Q9eibNRewPMT54DUhTIpAg1Sht7ha22G1ufqkYptq1cFE80rR711dScHPLLhmJ+q8=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFW7tvj2HzsClA8X1H26zUY4x8P6NQYpxpab+6eweSK3WB1Z7hjR9loeEmmH+DcvmhMv+MY0Rswn2avB6fUySUc=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:L+I1/Qhho+5MTJJQUC536mZqODIvIydVP6vJjVbdai0",
-        "firstUsedAt": "2026-05-18T08:03:23Z"
+        "fingerprint": "SHA256:iARQFNvURLH907WgwzHgMJPVSWgoyBhMXtYvYWM/db0",
+        "firstUsedAt": "2026-06-02T11:58:58Z"
       },
       "commandStatus": [
         {
@@ -8281,11 +8564,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:03:23Z",
-          "completedTime": "2026-05-18T08:03:26Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-06-02T11:58:57Z",
+          "completedTime": "2026-06-02T11:59:01Z",
+          "elapsedTime": 4,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -8296,11 +8579,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjcg-39198-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjcg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjcg_OsDisk_1_15c2d99efd01471b8724e152bfe481ca,osType:Linux}},timeCreated:2026-05-18T08:02:26.9394222Z,vmId:66b1ceb1-9da8-497a-ab77-8e1d40b4f26c}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tb81h514blbmih6th0ra-74785-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tb81h514blbmih6th0ra,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,storageAccountType:Premium_LRS},name:tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,osType:Linux}},timeCreated:2026-06-02T11:58:00.0230074Z,vmId:a194131f-a308-4f9e-bd5f-1954226d1a73}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd85cf3epr9ha6omvqjcg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjcg-42454-PublicIP}"
+          "value": "{createdBy:tb81h514blbmih6th0ra,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tb81h514blbmih6th0ra-51215-PublicIP}"
         },
         {
           "key": "Etag",
@@ -8308,11 +8591,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra"
         },
         {
           "key": "Name",
-          "value": "tbd85cf3epr9ha6omvqjcg"
+          "value": "tb81h514blbmih6th0ra"
         },
         {
           "key": "Type",
@@ -8323,9 +8606,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85cf3epr9ha6omvqjeg",
-      "cspResourceName": "tbd85cf3epr9ha6omvqjeg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
+      "uid": "tbj3l6ut11ch7mvkq2p2",
+      "cspResourceName": "tbj3l6ut11ch7mvkq2p2",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
       "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -8339,16 +8622,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:03:17",
+      "createdTime": "2026-06-02 11:58:51",
       "label": {
-        "createdBy": "tbd85cf3epr9ha6omvqjeg",
-        "keypair": "tbd85cf06pr9ha6omvqj3g",
-        "publicip": "tbd85cf3epr9ha6omvqjeg-83151-PublicIP",
+        "createdBy": "tbj3l6ut11ch7mvkq2p2",
+        "keypair": "tbmeu2jlibrbjhpqt6ks",
+        "publicip": "tbj3l6ut11ch7mvkq2p2-63146-PublicIP",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-18 08:03:17",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg",
-        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjeg",
+        "sys.createdTime": "2026-06-02 11:58:51",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
+        "sys.cspResourceName": "tbj3l6ut11ch7mvkq2p2",
         "sys.id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -8357,14 +8640,14 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjeg",
+        "sys.uid": "tbj3l6ut11ch7mvkq2p2",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "20.214.26.6",
+      "publicIP": "52.231.195.8",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.6",
@@ -8406,32 +8689,32 @@
         "memoryGiB": 7.8125,
         "costPerHour": 0.0865
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605150",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-      "networkInterface": "tbd85cf3epr9ha6omvqjeg-47871-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+      "networkInterface": "tbj3l6ut11ch7mvkq2p2-3298-VNic",
       "securityGroupIds": [
         "my02-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEjxGVDmlxPviCew7MPsxQCg/SbRH0g1LPINkzdzqnLKnu1r1BVcN2sOxPrrm4d3ektW4i1wjM5H3IyYVNdYIXM=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJtUMh1cIUNrdvxDyS/sX2gg1UlgprQImyTmtt571zIcfmNpvML9//EZjbJhwyEPPk1DSV9P+GsLYIsancoLI2Q=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:kXaggWkouCHVkByZEeZ7WbredHOydMu4PhHCk95sdGA",
-        "firstUsedAt": "2026-05-18T08:03:25Z"
+        "fingerprint": "SHA256:vHAecS7HpoCmHLAn96798w3BOcO14c/PF8E2f32n6W4",
+        "firstUsedAt": "2026-06-02T11:59:00Z"
       },
       "commandStatus": [
         {
@@ -8439,11 +8722,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:03:23Z",
-          "completedTime": "2026-05-18T08:03:27Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-06-02T11:58:57Z",
+          "completedTime": "2026-06-02T11:59:03Z",
+          "elapsedTime": 6,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -8454,11 +8737,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjeg-47871-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjeg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjeg_OsDisk_1_8aaddc61d3c5476e8e7f50a0be8384c8,osType:Linux}},timeCreated:2026-05-18T08:02:28.9784295Z,vmId:85838c4c-38c3-4641-9333-9b5b9ab4769a}"
+          "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbj3l6ut11ch7mvkq2p2-3298-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbj3l6ut11ch7mvkq2p2,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,storageAccountType:Premium_LRS},name:tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,osType:Linux}},timeCreated:2026-06-02T11:58:02.5923143Z,vmId:26a400ec-766d-4066-a986-31dee1af0a49}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd85cf3epr9ha6omvqjeg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjeg-83151-PublicIP}"
+          "value": "{createdBy:tbj3l6ut11ch7mvkq2p2,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tbj3l6ut11ch7mvkq2p2-63146-PublicIP}"
         },
         {
           "key": "Etag",
@@ -8466,11 +8749,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2"
         },
         {
           "key": "Name",
-          "value": "tbd85cf3epr9ha6omvqjeg"
+          "value": "tbj3l6ut11ch7mvkq2p2"
         },
         {
           "key": "Type",
@@ -8481,9 +8764,9 @@
     {
       "resourceType": "node",
       "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85cf3epr9ha6omvqjdg",
-      "cspResourceName": "tbd85cf3epr9ha6omvqjdg",
-      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
+      "uid": "tblumcks3qbld4l0rqdu",
+      "cspResourceName": "tblumcks3qbld4l0rqdu",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
       "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -8497,16 +8780,16 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:03:15",
+      "createdTime": "2026-06-02 11:58:51",
       "label": {
-        "createdBy": "tbd85cf3epr9ha6omvqjdg",
-        "keypair": "tbd85cf06pr9ha6omvqj3g",
-        "publicip": "tbd85cf3epr9ha6omvqjdg-86268-PublicIP",
+        "createdBy": "tblumcks3qbld4l0rqdu",
+        "keypair": "tbmeu2jlibrbjhpqt6ks",
+        "publicip": "tblumcks3qbld4l0rqdu-15505-PublicIP",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "azure-koreasouth",
-        "sys.createdTime": "2026-05-18 08:03:15",
-        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg",
-        "sys.cspResourceName": "tbd85cf3epr9ha6omvqjdg",
+        "sys.createdTime": "2026-06-02 11:58:51",
+        "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
+        "sys.cspResourceName": "tblumcks3qbld4l0rqdu",
         "sys.id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my02-infra101",
         "sys.labelType": "node",
@@ -8515,17 +8798,17 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my02-subnet-01",
-        "sys.uid": "tbd85cf3epr9ha6omvqjdg",
+        "sys.uid": "tblumcks3qbld4l0rqdu",
         "sys.vNetId": "my02-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
       "region": {
         "region": "koreasouth"
       },
-      "publicIP": "52.231.195.68",
+      "publicIP": "20.214.40.12",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.5",
       "privateDNS": "",
       "rootDiskType": "PremiumSSD",
       "rootDiskSize": 30,
@@ -8564,32 +8847,32 @@
         "memoryGiB": 15.625,
         "costPerHour": 0.173
       },
-      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
-      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605150",
+      "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+      "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
       "image": {
         "resourceType": "image",
-        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160",
+        "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160"
+        "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260"
       },
       "vNetId": "my02-vnet-01",
-      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg",
+      "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
       "subnetId": "my02-subnet-01",
-      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0",
-      "networkInterface": "tbd85cf3epr9ha6omvqjdg-3065-VNic",
+      "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+      "networkInterface": "tblumcks3qbld4l0rqdu-93021-VNic",
       "securityGroupIds": [
         "my02-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my02-sshkey-01",
-      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g",
+      "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTNwiwA06iMy3QoeSkT4pJXpOsH22Jn6+LnZ+ak239UDz03i5xCcIOmCYDASX7JMLHv1NfehWWjviZjXQOCm0A=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTL9uzNQSU1yXWyoHY8FKtgjUxNkaKpGjhn6dtQjVMVJC3cpROCI06y1MwW8elX7OtijS4pmgWxkK29xA0kJ80=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:zSgb3/NtuvOcCa3S2XoWo/Kj3Tpb4B15i3wLbr896JA",
-        "firstUsedAt": "2026-05-18T08:03:25Z"
+        "fingerprint": "SHA256:lVsWJmS92R46BkqahsTpl8eAW8rA6D39KJOZaJA3sj8",
+        "firstUsedAt": "2026-06-02T11:59:00Z"
       },
       "commandStatus": [
         {
@@ -8597,11 +8880,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:03:23Z",
-          "completedTime": "2026-05-18T08:03:28Z",
+          "startedTime": "2026-06-02T11:58:57Z",
+          "completedTime": "2026-06-02T11:59:02Z",
           "elapsedTime": 5,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -8612,11 +8895,11 @@
         },
         {
           "key": "Properties",
-          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbd85cf3epr9ha6omvqjdg-3065-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbd85cf3epr9ha6omvqjdg,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpWcbrhtQvDFRYHly+CcVE71id44biB3QrFVXkBa7y8vHQa3Kj2v668qxkIfYEMUzInhuyqssv3AM5dKNvdl2cKz2BIBRNzpNxjGKEoHGNikkeKpFuEZxMhR5iIv1E36MU5mv6iAXDScum56Tp/97kKRSBMeZZo0Dq6b+SYUvFRUkBCBf84aIlQFD4KqiZ+Fe8j7V+vfOirroTVwZEaIUOSzfBvkZvKbpk8b86GzrxhnSgJyedkl7VoG+xpVg9iC7FjmIzyg9FK/8tk/FIje3BBmx2p83xhMyzquSopaJ4irYgDHRk5NWucds+nlJht5Zv9oxNsVXvo0eXu5Gg6EIi1S1zpPi6pEu1B9wx+0K5I93ZCMTrS2kbjnsPC/hubwXwGSAOdrm2uZAo8XYNH2LY8AyKHBAmBGtUwol7X7Dis4PLFkbApL2PLNovAHtLwpb0/+Zbqif4jMNV1ijaNsmN8n65MxuZ09SubadWql6JMh4glfS/8Rt7b0TJ/B9HtFSF1e+hGkt6nfxFtjT9ucyJvzQ+s+H6RZFUQYltLPFmqX0LSef1/xEVooKDofYtT5yFy/cE5/kFMbkKg2uWe1MkOlzwsBOXlmWDWX1U5pyZ9vg9wbtLM38qh+2Q3yBaroftUBxXy/nt9lDdPj/KnZV0NxGw4gQ82BBPYD80pfCZsw==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605150,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605150},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,storageAccountType:Premium_LRS},name:tbd85cf3epr9ha6omvqjdg_OsDisk_1_c531642e3a2143bc9b21c3a62be80a3d,osType:Linux}},timeCreated:2026-05-18T08:02:27.2996702Z,vmId:9f82564d-bc46-434c-955e-4e8a0c6ad147}"
+          "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tblumcks3qbld4l0rqdu-93021-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tblumcks3qbld4l0rqdu,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,storageAccountType:Premium_LRS},name:tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,osType:Linux}},timeCreated:2026-06-02T11:58:00.3944037Z,vmId:bb9a97ea-bbc0-4b18-b394-cb1accf01389}"
         },
         {
           "key": "Tags",
-          "value": "{createdBy:tbd85cf3epr9ha6omvqjdg,keypair:tbd85cf06pr9ha6omvqj3g,publicip:tbd85cf3epr9ha6omvqjdg-86268-PublicIP}"
+          "value": "{createdBy:tblumcks3qbld4l0rqdu,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tblumcks3qbld4l0rqdu-15505-PublicIP}"
         },
         {
           "key": "Etag",
@@ -8624,11 +8907,11 @@
         },
         {
           "key": "ID",
-          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg"
+          "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu"
         },
         {
           "key": "Name",
-          "value": "tbd85cf3epr9ha6omvqjdg"
+          "value": "tblumcks3qbld4l0rqdu"
         },
         {
           "key": "Type",
@@ -8649,27 +8932,12 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "20.214.25.229",
+        "nodeIp": "40.89.209.210",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my02-infra101",
-        "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "20.214.26.6",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -8679,12 +8947,27 @@
       {
         "infraId": "my02-infra101",
         "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "52.231.195.68",
+        "nodeIp": "20.214.40.12",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my02-infra101",
+        "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+        "nodeIp": "52.231.195.8",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -8742,8 +9025,8 @@
       "command": "uname -a",
       "nodeGroup": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux tbd85cf3epr9ha6omvqjcg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "20.214.25.229",
+      "output": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "40.89.209.210",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -8754,8 +9037,8 @@
       "command": "uname -a",
       "nodeGroup": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux tbd85cf3epr9ha6omvqjeg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "20.214.26.6",
+      "output": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "52.231.195.8",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -8766,8 +9049,8 @@
       "command": "uname -a",
       "nodeGroup": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux tbd85cf3epr9ha6omvqjdg 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "52.231.195.68",
+      "output": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "20.214.40.12",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -8797,7 +9080,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:04:01
+**Generated At:** 2026-06-02 11:59:38
 
 **Namespace:** mig01
 
@@ -8825,24 +9108,24 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
+| Standard_B2as_v2 | 2 | 7.8 | - | x86_64 |  | $0.0865 | 1 |
 | Standard_B4as_v2 | 4 | 15.6 | - | x86_64 |  | $0.1730 | 1 |
 | Standard_B2als_v2 | 2 | 3.9 | - | x86_64 |  | $0.0432 | 1 |
-| Standard_B2as_v2 | 2 | 7.8 | - | x86_64 |  | $0.0865 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 2 |
-| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
+| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 2 |
+| Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 | Ubuntu 22.04 | Linux/UNIX | x86_64 | default | - | 1 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.25.229<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.26.6<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
-| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.195.68<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra | Running | 2 vCPU, 3.9 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 40.89.209.210<br>**Private IP:** 10.0.1.4<br>**SGs:** my02-sg-01<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2 | Running | 2 vCPU, 7.8 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 52.231.195.8<br>**Private IP:** 10.0.1.6<br>**SGs:** my02-sg-03<br>**SSH:** my02-sshkey-01 |
+| my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu | Running | 4 vCPU, 15.6 GiB | Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 (Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260) | **VNet:** my02-vnet-01<br>**Subnet:** my02-subnet-01<br>**Public IP:** 20.214.40.12<br>**Private IP:** 10.0.1.5<br>**SGs:** my02-sg-02<br>**SSH:** my02-sshkey-01 |
 
 
 ## Network Resources
@@ -8854,7 +9137,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-vnet-01 |
-| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg |
+| **CSP VNet ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | azure-koreasouth |
 | **Subnet Count** | 1 |
@@ -8863,7 +9146,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 |  |
+| my02-subnet-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -8872,7 +9155,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  |  |
+| my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks |  |  |
 
 ### Security Groups
 
@@ -8881,7 +9164,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-01 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tba5q2q197u97gaalfpr |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -8909,7 +9192,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-02 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbfrrlj3eu12v1kqh8rp |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -8942,7 +9225,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my02-sg-03 |
-| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 |
+| **CSP Security Group ID** | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tb5vuraeoacia4ihdkd6 |
 | **VNet** | my02-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -9017,7 +9300,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:04:07*
+*Report generated: 2026-06-02 11:59:44*
 
 ---
 
@@ -9046,7 +9329,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B2as_v2, Standard_B4as_v2, Standard_B2als_v2 |
+| 2 | **VM Spec** | 3 | ✅ Selected | Standard_B2als_v2, Standard_B2as_v2, Standard_B4as_v2 |
 | 3 | **VM OS Image** | 2 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my02-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my02-vnet-01) |
@@ -9061,9 +9344,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjcg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjeg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbd85cf3epr9ha6omvqjdg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -9085,9 +9368,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202604160 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -9097,7 +9380,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-01
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf0mpr9ha6omvqj4g | **VNet:** my02-vnet-01 | **Rules:** 14
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tba5q2q197u97gaalfpr | **VNet:** my02-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -9125,7 +9408,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-02
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf1mpr9ha6omvqj5g | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbfrrlj3eu12v1kqh8rp | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -9158,7 +9441,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my02-sg-03
 
-**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tbd85cf2mpr9ha6omvqjb0 | **VNet:** my02-vnet-01 | **Rules:** 19
+**CSP ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkSecurityGroups/tb5vuraeoacia4ihdkd6 | **VNet:** my02-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -9199,13 +9482,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg | 10.0.0.0/21 |
+| 1 | **Name:** my02-vnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbd85cetupr9ha6omvqiqg/subnets/tbd85cetupr9ha6omvqir0 | 10.0.1.0/24 | my02-vnet-01 |
+| 1 | **Name:** my02-subnet-01<br>**ID:** /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr | 10.0.1.0/24 | my02-vnet-01 |
 
 ### Source Network Information
 
@@ -9247,7 +9530,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbd85cf06pr9ha6omvqj3g |  | Used by all 3 VMs |
+| 1 | my02-sshkey-01 | /subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/KOREASOUTH/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-gcp.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-gcp.md
@@ -7,19 +7,19 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (c574040)
-- cm-model: unknown
-- CB-Tumblebug: vunknown
-- CB-Spider: vunknown
-- CB-MapUI: vunknown
+- CM-Beetle: imdl/v0.1.5+ (7e4bd21)
+- imdl: v0.1.5+ (7e4bd21)
+- CB-Tumblebug: v0.12.13
+- CB-Spider: v0.12.26
+- CB-MapUI: v0.12.34
 - Target CSP: GCP
 - Target Region: asia-northeast3
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 18, 2026
-- Test Time: 17:01:39 KST
-- Test Execution: 2026-05-18 17:01:39 KST
+- Test Date: June 2, 2026
+- Test Time: 20:57:06 KST
+- Test Execution: 2026-06-02 20:57:06 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 14.596s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 7m1.616s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 26ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 5ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 21ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 16.118s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 7m45.076s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 56ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 3ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 17ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.257s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.286s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 7m18.663s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.398s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.324s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 8m39.645s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 15m57.052183758s
+**Total Duration**: 18m4.998807873s
 
-*Test executed on May 18, 2026 at 17:01:39 KST (2026-05-18 17:01:39 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 20:57:06 KST (2026-06-02 20:57:06 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1967,7 +1967,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "gcp-asia-northeast3",
             "specId": "gcp+asia-northeast3+e2-highcpu-2",
-            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -1986,7 +1986,7 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "gcp-asia-northeast3",
             "specId": "gcp+asia-northeast3+e2-standard-4",
-            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2005,7 +2005,7 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "gcp-asia-northeast3",
             "specId": "gcp+asia-northeast3+e2-standard-2",
-            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2049,7 +2049,7 @@
       "targetSpecList": [
         {
           "id": "gcp+asia-northeast3+e2-highcpu-2",
-          "uid": "d7k8jalq1uu3ogms0sv0",
+          "uid": "tbcc93a1p5n56k19otsf",
           "cspSpecName": "e2-highcpu-2",
           "name": "gcp+asia-northeast3+e2-highcpu-2",
           "namespace": "system",
@@ -2134,7 +2134,7 @@
         },
         {
           "id": "gcp+asia-northeast3+e2-standard-4",
-          "uid": "d7k8jalq1uu3ogms0t60",
+          "uid": "tb5975k7le38srmmfk9h",
           "cspSpecName": "e2-standard-4",
           "name": "gcp+asia-northeast3+e2-standard-4",
           "namespace": "system",
@@ -2219,7 +2219,7 @@
         },
         {
           "id": "gcp+asia-northeast3+e2-standard-2",
-          "uid": "d7k8jalq1uu3ogms0t50",
+          "uid": "tbffdojr1di2meul86qs",
           "cspSpecName": "e2-standard-2",
           "name": "gcp+asia-northeast3+e2-standard-2",
           "namespace": "system",
@@ -2308,18 +2308,18 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "gcp",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
           "regionList": [
             "common"
           ],
-          "id": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "uid": "d7k8jt5q1uu3ogmul5pg",
-          "name": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+          "id": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "uid": "tbgdnmsbvpt4jshnhko9",
+          "name": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "gcp-africa-south1",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:28 Wed",
+          "fetchedTime": "2026.05.27 06:33:12 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -2327,7 +2327,7 @@
           "osType": "Ubuntu 22.04",
           "osArchitecture": "x86_64",
           "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21",
+          "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20",
           "osDiskType": "NA",
           "osDiskSizeGB": 10,
           "imageStatus": "Available",
@@ -2338,15 +2338,15 @@
             },
             {
               "key": "ArchiveSizeBytes",
-              "value": "3954534912"
+              "value": "3627045888"
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-04-21T10:21:22.706-07:00"
+              "value": "2026-05-20T08:32:15.503-07:00"
             },
             {
               "key": "Description",
-              "value": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+              "value": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
             },
             {
               "key": "DiskSizeGb",
@@ -2366,7 +2366,7 @@
             },
             {
               "key": "Id",
-              "value": "2480962478352764157"
+              "value": "6975877308143922448"
             },
             {
               "key": "Kind",
@@ -2390,7 +2390,7 @@
             },
             {
               "key": "Name",
-              "value": "ubuntu-2204-jammy-v20260421"
+              "value": "ubuntu-2204-jammy-v20260520"
             },
             {
               "key": "RawDisk",
@@ -2406,7 +2406,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520"
             },
             {
               "key": "SourceType",
@@ -2418,11 +2418,11 @@
             },
             {
               "key": "StorageLocations",
-              "value": "eu; us; asia"
+              "value": "asia; us; eu"
             }
           ],
           "systemLabel": "",
-          "description": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21",
+          "description": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20",
           "commandHistory": null
         }
       ],
@@ -2773,7 +2773,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "gcp-asia-northeast3",
             "specId": "gcp+asia-northeast3+n2d-highcpu-2",
-            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2792,7 +2792,7 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "gcp-asia-northeast3",
             "specId": "gcp+asia-northeast3+n2d-standard-4",
-            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2811,7 +2811,7 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
             "connectionName": "gcp-asia-northeast3",
             "specId": "gcp+asia-northeast3+n2d-standard-2",
-            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2855,7 +2855,7 @@
       "targetSpecList": [
         {
           "id": "gcp+asia-northeast3+e2-highcpu-2",
-          "uid": "d7k8jalq1uu3ogms0sv0",
+          "uid": "tbcc93a1p5n56k19otsf",
           "cspSpecName": "e2-highcpu-2",
           "name": "gcp+asia-northeast3+e2-highcpu-2",
           "namespace": "system",
@@ -2940,7 +2940,7 @@
         },
         {
           "id": "gcp+asia-northeast3+e2-standard-4",
-          "uid": "d7k8jalq1uu3ogms0t60",
+          "uid": "tb5975k7le38srmmfk9h",
           "cspSpecName": "e2-standard-4",
           "name": "gcp+asia-northeast3+e2-standard-4",
           "namespace": "system",
@@ -3025,7 +3025,7 @@
         },
         {
           "id": "gcp+asia-northeast3+e2-standard-2",
-          "uid": "d7k8jalq1uu3ogms0t50",
+          "uid": "tbffdojr1di2meul86qs",
           "cspSpecName": "e2-standard-2",
           "name": "gcp+asia-northeast3+e2-standard-2",
           "namespace": "system",
@@ -3110,7 +3110,7 @@
         },
         {
           "id": "gcp+asia-northeast3+n2d-highcpu-2",
-          "uid": "d7k8jalq1uu3ogms0ue0",
+          "uid": "tbglosuecufkhjvvp1af",
           "cspSpecName": "n2d-highcpu-2",
           "name": "gcp+asia-northeast3+n2d-highcpu-2",
           "namespace": "system",
@@ -3195,7 +3195,7 @@
         },
         {
           "id": "gcp+asia-northeast3+n2d-standard-4",
-          "uid": "d7k8jalq1uu3ogms0upg",
+          "uid": "tb9m7md76i629qb2ueif",
           "cspSpecName": "n2d-standard-4",
           "name": "gcp+asia-northeast3+n2d-standard-4",
           "namespace": "system",
@@ -3280,7 +3280,7 @@
         },
         {
           "id": "gcp+asia-northeast3+n2d-standard-2",
-          "uid": "d7k8jalq1uu3ogms0uo0",
+          "uid": "tboh5avn1ne3o7gmjpda",
           "cspSpecName": "n2d-standard-2",
           "name": "gcp+asia-northeast3+n2d-standard-2",
           "namespace": "system",
@@ -3369,18 +3369,18 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "gcp",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
           "regionList": [
             "common"
           ],
-          "id": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "uid": "d7k8jt5q1uu3ogmul5pg",
-          "name": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+          "id": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "uid": "tbgdnmsbvpt4jshnhko9",
+          "name": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "gcp-africa-south1",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:28 Wed",
+          "fetchedTime": "2026.05.27 06:33:12 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -3388,7 +3388,7 @@
           "osType": "Ubuntu 22.04",
           "osArchitecture": "x86_64",
           "osPlatform": "Linux/UNIX",
-          "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21",
+          "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20",
           "osDiskType": "NA",
           "osDiskSizeGB": 10,
           "imageStatus": "Available",
@@ -3399,15 +3399,15 @@
             },
             {
               "key": "ArchiveSizeBytes",
-              "value": "3954534912"
+              "value": "3627045888"
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-04-21T10:21:22.706-07:00"
+              "value": "2026-05-20T08:32:15.503-07:00"
             },
             {
               "key": "Description",
-              "value": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+              "value": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
             },
             {
               "key": "DiskSizeGb",
@@ -3427,7 +3427,7 @@
             },
             {
               "key": "Id",
-              "value": "2480962478352764157"
+              "value": "6975877308143922448"
             },
             {
               "key": "Kind",
@@ -3451,7 +3451,7 @@
             },
             {
               "key": "Name",
-              "value": "ubuntu-2204-jammy-v20260421"
+              "value": "ubuntu-2204-jammy-v20260520"
             },
             {
               "key": "RawDisk",
@@ -3467,7 +3467,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520"
             },
             {
               "key": "SourceType",
@@ -3479,11 +3479,11 @@
             },
             {
               "key": "StorageLocations",
-              "value": "eu; us; asia"
+              "value": "asia; us; eu"
             }
           ],
           "systemLabel": "",
-          "description": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21",
+          "description": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20",
           "commandHistory": null
         }
       ],
@@ -3840,7 +3840,7 @@
 {
   "resourceType": "infra",
   "id": "my03-infra101",
-  "uid": "tbd85chgupr9ha6omvqjqg",
+  "uid": "tb9k0f3jkc5cjd97jlad",
   "name": "my03-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -3868,7 +3868,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my03-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85chgupr9ha6omvqjqg"
+    "sys.uid": "tb9k0f3jkc5cjd97jlad"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -3877,9 +3877,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85chgupr9ha6omvqjrg",
-      "cspResourceName": "tbd85chgupr9ha6omvqjrg",
-      "cspResourceId": "tbd85chgupr9ha6omvqjrg",
+      "uid": "tb5aad3lmo0gt6dfk9uj",
+      "cspResourceName": "tb5aad3lmo0gt6dfk9uj",
+      "cspResourceId": "tb5aad3lmo0gt6dfk9uj",
       "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -3893,14 +3893,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:08:17",
+      "createdTime": "2026-06-02 12:05:04",
       "label": {
-        "keypair": "tbd85cf76pr9ha6omvqjgg",
+        "keypair": "tb6kf3c8jjcig0aqofjm",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-18 08:08:17",
-        "sys.cspResourceId": "tbd85chgupr9ha6omvqjrg",
-        "sys.cspResourceName": "tbd85chgupr9ha6omvqjrg",
+        "sys.createdTime": "2026-06-02 12:05:04",
+        "sys.cspResourceId": "tb5aad3lmo0gt6dfk9uj",
+        "sys.cspResourceName": "tb5aad3lmo0gt6dfk9uj",
         "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -3909,7 +3909,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd85chgupr9ha6omvqjrg",
+        "sys.uid": "tb5aad3lmo0gt6dfk9uj",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -3917,7 +3917,7 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.47.88.87",
+      "publicIP": "34.158.221.135",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.2",
@@ -3963,32 +3963,32 @@
         "memoryGiB": 1.953125,
         "costPerHour": 0.063531
       },
-      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
       "image": {
         "resourceType": "image",
-        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd85cevepr9ha6omvqj20",
+      "cspVNetId": "tbf2lc0iranl4gr0qrj1",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+      "cspSubnetId": "tbbbfhl31q35cvclvii0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+      "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBTyrjHSxt6qZWbQxMqqRCjxDmjtrH2Dnopziy9PbQzxGqw76v+iZm/EYFqx+pxvqaTUNBU++J92lq0WuBr7i68=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBvJlaJerWk572CnkFTR7M94expQ/gc1Y521sL4DISJuWcZnTsKXnKMP14jgZ54TuwCwQX3rfhM+cuwwgNMIyGM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:Epg/2q2Z05YyN084hOeTw4hNiR7NjcMSq43lf/yocK4",
-        "firstUsedAt": "2026-05-18T08:08:32Z"
+        "fingerprint": "SHA256:ERrBquVmt2+syALqxO7DyelFE+vt+aUmNJYSSa2rB4o",
+        "firstUsedAt": "2026-06-02T12:05:16Z"
       },
       "commandStatus": [
         {
@@ -3996,11 +3996,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:08:29Z",
-          "completedTime": "2026-05-18T08:08:33Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-06-02T12:05:14Z",
+          "completedTime": "2026-06-02T12:05:17Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4015,7 +4015,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-18T01:07:34.217-07:00"
+          "value": "2026-06-02T05:04:17.129-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -4027,15 +4027,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjrg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb5aad3lmo0gt6dfk9uj,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "9VP4LLWbIfc="
+          "value": "ZggRLCXPGm4="
         },
         {
           "key": "Id",
-          "value": "485614543392175657"
+          "value": "4544156388102993967"
         },
         {
           "key": "Kind",
@@ -4043,15 +4043,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "K4XUyTdV-uk="
+          "value": "gdrn9ZcdtK4="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+          "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-18T01:07:42.548-07:00"
+          "value": "2026-06-02T05:04:37.007-07:00"
         },
         {
           "key": "MachineType",
@@ -4059,15 +4059,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd85chgupr9ha6omvqjrg"
+          "value": "tb5aad3lmo0gt6dfk9uj"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.47.88.87,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:ihh_BNv7Hgc=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.221.135,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:78EyTGfFAXw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
         },
         {
           "key": "ResourceStatus",
@@ -4087,7 +4087,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjrg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb5aad3lmo0gt6dfk9uj"
         },
         {
           "key": "ServiceAccounts",
@@ -4111,7 +4111,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:VTjLFnAOyhg=,items:[tbd85cf7epr9ha6omvqjh0]}"
+          "value": "{fingerprint:HLOb1PbD2RI=,items:[tbn194eshutbrfcgotga]}"
         },
         {
           "key": "Zone",
@@ -4122,9 +4122,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85chgupr9ha6omvqjtg",
-      "cspResourceName": "tbd85chgupr9ha6omvqjtg",
-      "cspResourceId": "tbd85chgupr9ha6omvqjtg",
+      "uid": "tb25cler8rpicfonum0j",
+      "cspResourceName": "tb25cler8rpicfonum0j",
+      "cspResourceId": "tb25cler8rpicfonum0j",
       "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -4138,14 +4138,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:08:19",
+      "createdTime": "2026-06-02 12:05:04",
       "label": {
-        "keypair": "tbd85cf76pr9ha6omvqjgg",
+        "keypair": "tb6kf3c8jjcig0aqofjm",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-18 08:08:19",
-        "sys.cspResourceId": "tbd85chgupr9ha6omvqjtg",
-        "sys.cspResourceName": "tbd85chgupr9ha6omvqjtg",
+        "sys.createdTime": "2026-06-02 12:05:04",
+        "sys.cspResourceId": "tb25cler8rpicfonum0j",
+        "sys.cspResourceName": "tb25cler8rpicfonum0j",
         "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -4154,7 +4154,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd85chgupr9ha6omvqjtg",
+        "sys.uid": "tb25cler8rpicfonum0j",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -4162,10 +4162,10 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.234.91",
+      "publicIP": "34.64.204.98",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.3",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
       "rootDiskSize": 10,
@@ -4208,32 +4208,32 @@
         "memoryGiB": 7.8125,
         "costPerHour": 0.085966
       },
-      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
       "image": {
         "resourceType": "image",
-        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd85cevepr9ha6omvqj20",
+      "cspVNetId": "tbf2lc0iranl4gr0qrj1",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+      "cspSubnetId": "tbbbfhl31q35cvclvii0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+      "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGvD1KU1+ZJdf79GZ9H34PziLBJYb01WxzgNS5tWz0GeOpGg8L88IGpPqPfqdXKb5bROJbby0KOvfhdVCVUmLQM=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLUgTpq0/v92+Ov2nKeXig6AWK4yF0Gc1ZxosnLKf8lPmjXRFSkHJsCD0YZDOfiGUBlUww8UeS2xVqwC4870/oQ=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:DYAWOOMoPbZPyNgE6XOiqkS7jz5oAKe042rekh/h+a0",
-        "firstUsedAt": "2026-05-18T08:08:29Z"
+        "fingerprint": "SHA256:WFzUU+3UDSttNynTqwpHaMgj53E6aCNppI9EW+XJ0RU",
+        "firstUsedAt": "2026-06-02T12:05:14Z"
       },
       "commandStatus": [
         {
@@ -4241,11 +4241,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:08:29Z",
-          "completedTime": "2026-05-18T08:08:32Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-06-02T12:05:14Z",
+          "completedTime": "2026-06-02T12:05:16Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4260,7 +4260,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-18T01:07:35.886-07:00"
+          "value": "2026-06-02T05:04:17.589-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -4272,15 +4272,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjtg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb25cler8rpicfonum0j,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "DWOIQhWVgNc="
+          "value": "69YQphFs3wM="
         },
         {
           "key": "Id",
-          "value": "1272312304157292072"
+          "value": "8018957467993208878"
         },
         {
           "key": "Kind",
@@ -4288,15 +4288,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "K4XUyTdV-uk="
+          "value": "gdrn9ZcdtK4="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+          "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-18T01:07:42.684-07:00"
+          "value": "2026-06-02T05:04:29.800-07:00"
         },
         {
           "key": "MachineType",
@@ -4304,15 +4304,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd85chgupr9ha6omvqjtg"
+          "value": "tb25cler8rpicfonum0j"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.234.91,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:eL5WeVK8vho=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.204.98,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:1Wsh4ie-ycE=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
         },
         {
           "key": "ResourceStatus",
@@ -4332,7 +4332,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjtg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb25cler8rpicfonum0j"
         },
         {
           "key": "ServiceAccounts",
@@ -4356,7 +4356,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:AiAynOHHwpk=,items:[tbd85cgkmpr9ha6omvqjkg]}"
+          "value": "{fingerprint:MvS1ld5KqfI=,items:[tbol4toon26c949hihp0]}"
         },
         {
           "key": "Zone",
@@ -4367,9 +4367,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85chgupr9ha6omvqjsg",
-      "cspResourceName": "tbd85chgupr9ha6omvqjsg",
-      "cspResourceId": "tbd85chgupr9ha6omvqjsg",
+      "uid": "tbk09te5ihs839lat9rh",
+      "cspResourceName": "tbk09te5ihs839lat9rh",
+      "cspResourceId": "tbk09te5ihs839lat9rh",
       "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4383,14 +4383,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:08:17",
+      "createdTime": "2026-06-02 12:05:04",
       "label": {
-        "keypair": "tbd85cf76pr9ha6omvqjgg",
+        "keypair": "tb6kf3c8jjcig0aqofjm",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-18 08:08:17",
-        "sys.cspResourceId": "tbd85chgupr9ha6omvqjsg",
-        "sys.cspResourceName": "tbd85chgupr9ha6omvqjsg",
+        "sys.createdTime": "2026-06-02 12:05:04",
+        "sys.cspResourceId": "tbk09te5ihs839lat9rh",
+        "sys.cspResourceName": "tbk09te5ihs839lat9rh",
         "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -4399,7 +4399,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd85chgupr9ha6omvqjsg",
+        "sys.uid": "tbk09te5ihs839lat9rh",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -4407,10 +4407,10 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.135.175",
+      "publicIP": "8.230.18.51",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.3",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
       "rootDiskSize": 10,
@@ -4453,32 +4453,32 @@
         "memoryGiB": 15.625,
         "costPerHour": 0.171931
       },
-      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
       "image": {
         "resourceType": "image",
-        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd85cevepr9ha6omvqj20",
+      "cspVNetId": "tbf2lc0iranl4gr0qrj1",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+      "cspSubnetId": "tbbbfhl31q35cvclvii0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+      "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI/QnYwHOlz6TT2SILbnQJKkPJsNlnr8GTuR0+y0rv+tXXMbYs1SIKMw1M8Q1VVNZyJfvqytUW8Pk/1tpGi6xa4=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLyLErlt9S67FpIuIuIgk56BGEfqpZgEudzYRmYFTrRy7e5hTNnW2GA56f4iE0yzvF8jAxTnq+P7z7YvWQO6coU=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:aEf3AqgSAOIliyJaPgDKOhdH5uP8vR/tFTEZIp+gcMw",
-        "firstUsedAt": "2026-05-18T08:08:32Z"
+        "fingerprint": "SHA256:dxmTL8Z4RRRFIztfhrxzp6jxm7GWvtYNV5kDjJtoz1k",
+        "firstUsedAt": "2026-06-02T12:05:16Z"
       },
       "commandStatus": [
         {
@@ -4486,11 +4486,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:08:29Z",
-          "completedTime": "2026-05-18T08:08:33Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-06-02T12:05:14Z",
+          "completedTime": "2026-06-02T12:05:17Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4505,7 +4505,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-18T01:07:35.010-07:00"
+          "value": "2026-06-02T05:04:20.591-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -4517,15 +4517,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjsg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbk09te5ihs839lat9rh,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "HMqjE_xTr3c="
+          "value": "5TwSnPdL_r8="
         },
         {
           "key": "Id",
-          "value": "4838453238055794217"
+          "value": "3160271724368590891"
         },
         {
           "key": "Kind",
@@ -4533,15 +4533,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "K4XUyTdV-uk="
+          "value": "gdrn9ZcdtK4="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+          "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-18T01:07:43.230-07:00"
+          "value": "2026-06-02T05:04:30.378-07:00"
         },
         {
           "key": "MachineType",
@@ -4549,15 +4549,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd85chgupr9ha6omvqjsg"
+          "value": "tbk09te5ihs839lat9rh"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.135.175,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:aInRVIK88Rw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:8.230.18.51,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lOZ6jix2v68=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
         },
         {
           "key": "ResourceStatus",
@@ -4577,7 +4577,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjsg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbk09te5ihs839lat9rh"
         },
         {
           "key": "ServiceAccounts",
@@ -4601,7 +4601,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:iDI4EcKiK68=,items:[tbd85cfrepr9ha6omvqjhg]}"
+          "value": "{fingerprint:DSXaZ9BoiC0=,items:[tbd6ae36tqdum3bvi8od]}"
         },
         {
           "key": "Zone",
@@ -4622,27 +4622,12 @@
       {
         "infraId": "my03-infra101",
         "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "34.64.234.91",
+        "nodeIp": "34.64.204.98",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my03-infra101",
-        "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "34.64.135.175",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4652,12 +4637,27 @@
       {
         "infraId": "my03-infra101",
         "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "34.47.88.87",
+        "nodeIp": "34.158.221.135",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my03-infra101",
+        "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "8.230.18.51",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4693,7 +4693,7 @@
     {
       "resourceType": "infra",
       "id": "my03-infra101",
-      "uid": "tbd85chgupr9ha6omvqjqg",
+      "uid": "tb9k0f3jkc5cjd97jlad",
       "name": "my03-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -4721,7 +4721,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my03-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85chgupr9ha6omvqjqg"
+        "sys.uid": "tb9k0f3jkc5cjd97jlad"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -4730,9 +4730,9 @@
         {
           "resourceType": "node",
           "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85chgupr9ha6omvqjrg",
-          "cspResourceName": "tbd85chgupr9ha6omvqjrg",
-          "cspResourceId": "tbd85chgupr9ha6omvqjrg",
+          "uid": "tb5aad3lmo0gt6dfk9uj",
+          "cspResourceName": "tb5aad3lmo0gt6dfk9uj",
+          "cspResourceId": "tb5aad3lmo0gt6dfk9uj",
           "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -4746,14 +4746,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:08:17",
+          "createdTime": "2026-06-02 12:05:04",
           "label": {
-            "keypair": "tbd85cf76pr9ha6omvqjgg",
+            "keypair": "tb6kf3c8jjcig0aqofjm",
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-18 08:08:17",
-            "sys.cspResourceId": "tbd85chgupr9ha6omvqjrg",
-            "sys.cspResourceName": "tbd85chgupr9ha6omvqjrg",
+            "sys.createdTime": "2026-06-02 12:05:04",
+            "sys.cspResourceId": "tb5aad3lmo0gt6dfk9uj",
+            "sys.cspResourceName": "tb5aad3lmo0gt6dfk9uj",
             "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my03-infra101",
             "sys.labelType": "node",
@@ -4762,7 +4762,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd85chgupr9ha6omvqjrg",
+            "sys.uid": "tb5aad3lmo0gt6dfk9uj",
             "sys.vNetId": "my03-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -4770,7 +4770,7 @@
             "region": "asia-northeast3",
             "zone": "asia-northeast3-a"
           },
-          "publicIP": "34.47.88.87",
+          "publicIP": "34.158.221.135",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.2",
@@ -4816,32 +4816,32 @@
             "memoryGiB": 1.953125,
             "costPerHour": 0.063531
           },
-          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
           "image": {
             "resourceType": "image",
-            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
           },
           "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd85cevepr9ha6omvqj20",
+          "cspVNetId": "tbf2lc0iranl4gr0qrj1",
           "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+          "cspSubnetId": "tbbbfhl31q35cvclvii0",
           "networkInterface": "nic0",
           "securityGroupIds": [
             "my03-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+          "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBTyrjHSxt6qZWbQxMqqRCjxDmjtrH2Dnopziy9PbQzxGqw76v+iZm/EYFqx+pxvqaTUNBU++J92lq0WuBr7i68=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBvJlaJerWk572CnkFTR7M94expQ/gc1Y521sL4DISJuWcZnTsKXnKMP14jgZ54TuwCwQX3rfhM+cuwwgNMIyGM=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:Epg/2q2Z05YyN084hOeTw4hNiR7NjcMSq43lf/yocK4",
-            "firstUsedAt": "2026-05-18T08:08:32Z"
+            "fingerprint": "SHA256:ERrBquVmt2+syALqxO7DyelFE+vt+aUmNJYSSa2rB4o",
+            "firstUsedAt": "2026-06-02T12:05:16Z"
           },
           "commandStatus": [
             {
@@ -4849,11 +4849,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:08:29Z",
-              "completedTime": "2026-05-18T08:08:33Z",
-              "elapsedTime": 4,
+              "startedTime": "2026-06-02T12:05:14Z",
+              "completedTime": "2026-06-02T12:05:17Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -4868,7 +4868,7 @@
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-05-18T01:07:34.217-07:00"
+              "value": "2026-06-02T05:04:17.129-07:00"
             },
             {
               "key": "DeletionProtection",
@@ -4880,15 +4880,15 @@
             },
             {
               "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjrg,type:PERSISTENT}"
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb5aad3lmo0gt6dfk9uj,type:PERSISTENT}"
             },
             {
               "key": "Fingerprint",
-              "value": "9VP4LLWbIfc="
+              "value": "ZggRLCXPGm4="
             },
             {
               "key": "Id",
-              "value": "485614543392175657"
+              "value": "4544156388102993967"
             },
             {
               "key": "Kind",
@@ -4896,15 +4896,15 @@
             },
             {
               "key": "LabelFingerprint",
-              "value": "K4XUyTdV-uk="
+              "value": "gdrn9ZcdtK4="
             },
             {
               "key": "Labels",
-              "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+              "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
             },
             {
               "key": "LastStartTimestamp",
-              "value": "2026-05-18T01:07:42.548-07:00"
+              "value": "2026-06-02T05:04:37.007-07:00"
             },
             {
               "key": "MachineType",
@@ -4912,15 +4912,15 @@
             },
             {
               "key": "Metadata",
-              "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+              "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
             },
             {
               "key": "Name",
-              "value": "tbd85chgupr9ha6omvqjrg"
+              "value": "tb5aad3lmo0gt6dfk9uj"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.47.88.87,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:ihh_BNv7Hgc=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.221.135,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:78EyTGfFAXw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
             },
             {
               "key": "ResourceStatus",
@@ -4940,7 +4940,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjrg"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb5aad3lmo0gt6dfk9uj"
             },
             {
               "key": "ServiceAccounts",
@@ -4964,7 +4964,7 @@
             },
             {
               "key": "Tags",
-              "value": "{fingerprint:VTjLFnAOyhg=,items:[tbd85cf7epr9ha6omvqjh0]}"
+              "value": "{fingerprint:HLOb1PbD2RI=,items:[tbn194eshutbrfcgotga]}"
             },
             {
               "key": "Zone",
@@ -4975,9 +4975,9 @@
         {
           "resourceType": "node",
           "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85chgupr9ha6omvqjtg",
-          "cspResourceName": "tbd85chgupr9ha6omvqjtg",
-          "cspResourceId": "tbd85chgupr9ha6omvqjtg",
+          "uid": "tb25cler8rpicfonum0j",
+          "cspResourceName": "tb25cler8rpicfonum0j",
+          "cspResourceId": "tb25cler8rpicfonum0j",
           "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -4991,14 +4991,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:08:19",
+          "createdTime": "2026-06-02 12:05:04",
           "label": {
-            "keypair": "tbd85cf76pr9ha6omvqjgg",
+            "keypair": "tb6kf3c8jjcig0aqofjm",
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-18 08:08:19",
-            "sys.cspResourceId": "tbd85chgupr9ha6omvqjtg",
-            "sys.cspResourceName": "tbd85chgupr9ha6omvqjtg",
+            "sys.createdTime": "2026-06-02 12:05:04",
+            "sys.cspResourceId": "tb25cler8rpicfonum0j",
+            "sys.cspResourceName": "tb25cler8rpicfonum0j",
             "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my03-infra101",
             "sys.labelType": "node",
@@ -5007,7 +5007,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd85chgupr9ha6omvqjtg",
+            "sys.uid": "tb25cler8rpicfonum0j",
             "sys.vNetId": "my03-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -5015,10 +5015,10 @@
             "region": "asia-northeast3",
             "zone": "asia-northeast3-a"
           },
-          "publicIP": "34.64.234.91",
+          "publicIP": "34.64.204.98",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.4",
+          "privateIP": "10.0.1.3",
           "privateDNS": "",
           "rootDiskType": "pd-standard",
           "rootDiskSize": 10,
@@ -5061,32 +5061,32 @@
             "memoryGiB": 7.8125,
             "costPerHour": 0.085966
           },
-          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
           "image": {
             "resourceType": "image",
-            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
           },
           "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd85cevepr9ha6omvqj20",
+          "cspVNetId": "tbf2lc0iranl4gr0qrj1",
           "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+          "cspSubnetId": "tbbbfhl31q35cvclvii0",
           "networkInterface": "nic0",
           "securityGroupIds": [
             "my03-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+          "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGvD1KU1+ZJdf79GZ9H34PziLBJYb01WxzgNS5tWz0GeOpGg8L88IGpPqPfqdXKb5bROJbby0KOvfhdVCVUmLQM=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLUgTpq0/v92+Ov2nKeXig6AWK4yF0Gc1ZxosnLKf8lPmjXRFSkHJsCD0YZDOfiGUBlUww8UeS2xVqwC4870/oQ=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:DYAWOOMoPbZPyNgE6XOiqkS7jz5oAKe042rekh/h+a0",
-            "firstUsedAt": "2026-05-18T08:08:29Z"
+            "fingerprint": "SHA256:WFzUU+3UDSttNynTqwpHaMgj53E6aCNppI9EW+XJ0RU",
+            "firstUsedAt": "2026-06-02T12:05:14Z"
           },
           "commandStatus": [
             {
@@ -5094,11 +5094,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:08:29Z",
-              "completedTime": "2026-05-18T08:08:32Z",
-              "elapsedTime": 3,
+              "startedTime": "2026-06-02T12:05:14Z",
+              "completedTime": "2026-06-02T12:05:16Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5113,7 +5113,7 @@
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-05-18T01:07:35.886-07:00"
+              "value": "2026-06-02T05:04:17.589-07:00"
             },
             {
               "key": "DeletionProtection",
@@ -5125,15 +5125,15 @@
             },
             {
               "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjtg,type:PERSISTENT}"
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb25cler8rpicfonum0j,type:PERSISTENT}"
             },
             {
               "key": "Fingerprint",
-              "value": "DWOIQhWVgNc="
+              "value": "69YQphFs3wM="
             },
             {
               "key": "Id",
-              "value": "1272312304157292072"
+              "value": "8018957467993208878"
             },
             {
               "key": "Kind",
@@ -5141,15 +5141,15 @@
             },
             {
               "key": "LabelFingerprint",
-              "value": "K4XUyTdV-uk="
+              "value": "gdrn9ZcdtK4="
             },
             {
               "key": "Labels",
-              "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+              "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
             },
             {
               "key": "LastStartTimestamp",
-              "value": "2026-05-18T01:07:42.684-07:00"
+              "value": "2026-06-02T05:04:29.800-07:00"
             },
             {
               "key": "MachineType",
@@ -5157,15 +5157,15 @@
             },
             {
               "key": "Metadata",
-              "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+              "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
             },
             {
               "key": "Name",
-              "value": "tbd85chgupr9ha6omvqjtg"
+              "value": "tb25cler8rpicfonum0j"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.234.91,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:eL5WeVK8vho=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.204.98,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:1Wsh4ie-ycE=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
             },
             {
               "key": "ResourceStatus",
@@ -5185,7 +5185,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjtg"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb25cler8rpicfonum0j"
             },
             {
               "key": "ServiceAccounts",
@@ -5209,7 +5209,7 @@
             },
             {
               "key": "Tags",
-              "value": "{fingerprint:AiAynOHHwpk=,items:[tbd85cgkmpr9ha6omvqjkg]}"
+              "value": "{fingerprint:MvS1ld5KqfI=,items:[tbol4toon26c949hihp0]}"
             },
             {
               "key": "Zone",
@@ -5220,9 +5220,9 @@
         {
           "resourceType": "node",
           "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85chgupr9ha6omvqjsg",
-          "cspResourceName": "tbd85chgupr9ha6omvqjsg",
-          "cspResourceId": "tbd85chgupr9ha6omvqjsg",
+          "uid": "tbk09te5ihs839lat9rh",
+          "cspResourceName": "tbk09te5ihs839lat9rh",
+          "cspResourceId": "tbk09te5ihs839lat9rh",
           "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5236,14 +5236,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:08:17",
+          "createdTime": "2026-06-02 12:05:04",
           "label": {
-            "keypair": "tbd85cf76pr9ha6omvqjgg",
+            "keypair": "tb6kf3c8jjcig0aqofjm",
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "gcp-asia-northeast3",
-            "sys.createdTime": "2026-05-18 08:08:17",
-            "sys.cspResourceId": "tbd85chgupr9ha6omvqjsg",
-            "sys.cspResourceName": "tbd85chgupr9ha6omvqjsg",
+            "sys.createdTime": "2026-06-02 12:05:04",
+            "sys.cspResourceId": "tbk09te5ihs839lat9rh",
+            "sys.cspResourceName": "tbk09te5ihs839lat9rh",
             "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my03-infra101",
             "sys.labelType": "node",
@@ -5252,7 +5252,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my03-subnet-01",
-            "sys.uid": "tbd85chgupr9ha6omvqjsg",
+            "sys.uid": "tbk09te5ihs839lat9rh",
             "sys.vNetId": "my03-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -5260,10 +5260,10 @@
             "region": "asia-northeast3",
             "zone": "asia-northeast3-a"
           },
-          "publicIP": "34.64.135.175",
+          "publicIP": "8.230.18.51",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.3",
+          "privateIP": "10.0.1.4",
           "privateDNS": "",
           "rootDiskType": "pd-standard",
           "rootDiskSize": 10,
@@ -5306,32 +5306,32 @@
             "memoryGiB": 15.625,
             "costPerHour": 0.171931
           },
-          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
           "image": {
             "resourceType": "image",
-            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
-            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
           },
           "vNetId": "my03-vnet-01",
-          "cspVNetId": "tbd85cevepr9ha6omvqj20",
+          "cspVNetId": "tbf2lc0iranl4gr0qrj1",
           "subnetId": "my03-subnet-01",
-          "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+          "cspSubnetId": "tbbbfhl31q35cvclvii0",
           "networkInterface": "nic0",
           "securityGroupIds": [
             "my03-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my03-sshkey-01",
-          "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+          "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI/QnYwHOlz6TT2SILbnQJKkPJsNlnr8GTuR0+y0rv+tXXMbYs1SIKMw1M8Q1VVNZyJfvqytUW8Pk/1tpGi6xa4=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLyLErlt9S67FpIuIuIgk56BGEfqpZgEudzYRmYFTrRy7e5hTNnW2GA56f4iE0yzvF8jAxTnq+P7z7YvWQO6coU=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:aEf3AqgSAOIliyJaPgDKOhdH5uP8vR/tFTEZIp+gcMw",
-            "firstUsedAt": "2026-05-18T08:08:32Z"
+            "fingerprint": "SHA256:dxmTL8Z4RRRFIztfhrxzp6jxm7GWvtYNV5kDjJtoz1k",
+            "firstUsedAt": "2026-06-02T12:05:16Z"
           },
           "commandStatus": [
             {
@@ -5339,11 +5339,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:08:29Z",
-              "completedTime": "2026-05-18T08:08:33Z",
-              "elapsedTime": 4,
+              "startedTime": "2026-06-02T12:05:14Z",
+              "completedTime": "2026-06-02T12:05:17Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -5358,7 +5358,7 @@
             },
             {
               "key": "CreationTimestamp",
-              "value": "2026-05-18T01:07:35.010-07:00"
+              "value": "2026-06-02T05:04:20.591-07:00"
             },
             {
               "key": "DeletionProtection",
@@ -5370,15 +5370,15 @@
             },
             {
               "key": "Disks",
-              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjsg,type:PERSISTENT}"
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbk09te5ihs839lat9rh,type:PERSISTENT}"
             },
             {
               "key": "Fingerprint",
-              "value": "HMqjE_xTr3c="
+              "value": "5TwSnPdL_r8="
             },
             {
               "key": "Id",
-              "value": "4838453238055794217"
+              "value": "3160271724368590891"
             },
             {
               "key": "Kind",
@@ -5386,15 +5386,15 @@
             },
             {
               "key": "LabelFingerprint",
-              "value": "K4XUyTdV-uk="
+              "value": "gdrn9ZcdtK4="
             },
             {
               "key": "Labels",
-              "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+              "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
             },
             {
               "key": "LastStartTimestamp",
-              "value": "2026-05-18T01:07:43.230-07:00"
+              "value": "2026-06-02T05:04:30.378-07:00"
             },
             {
               "key": "MachineType",
@@ -5402,15 +5402,15 @@
             },
             {
               "key": "Metadata",
-              "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+              "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
             },
             {
               "key": "Name",
-              "value": "tbd85chgupr9ha6omvqjsg"
+              "value": "tbk09te5ihs839lat9rh"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.135.175,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:aInRVIK88Rw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:8.230.18.51,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lOZ6jix2v68=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
             },
             {
               "key": "ResourceStatus",
@@ -5430,7 +5430,7 @@
             },
             {
               "key": "SelfLink",
-              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjsg"
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbk09te5ihs839lat9rh"
             },
             {
               "key": "ServiceAccounts",
@@ -5454,7 +5454,7 @@
             },
             {
               "key": "Tags",
-              "value": "{fingerprint:iDI4EcKiK68=,items:[tbd85cfrepr9ha6omvqjhg]}"
+              "value": "{fingerprint:DSXaZ9BoiC0=,items:[tbd6ae36tqdum3bvi8od]}"
             },
             {
               "key": "Zone",
@@ -5475,27 +5475,12 @@
           {
             "infraId": "my03-infra101",
             "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "34.64.234.91",
+            "nodeIp": "34.64.204.98",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
-            "err": null
-          },
-          {
-            "infraId": "my03-infra101",
-            "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "34.64.135.175",
-            "command": {
-              "0": "uname -a"
-            },
-            "stdout": {
-              "0": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5505,12 +5490,27 @@
           {
             "infraId": "my03-infra101",
             "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "34.47.88.87",
+            "nodeIp": "34.158.221.135",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my03-infra101",
+            "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "8.230.18.51",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5523,7 +5523,7 @@
     {
       "resourceType": "infra",
       "id": "my08-infra101",
-      "uid": "tbd85ch6epr9ha6omvqjlg",
+      "uid": "tb9k4svj3amakfqac867",
       "name": "my08-infra101",
       "status": "Creating:3 (R:0/3)",
       "statusCount": {
@@ -5551,7 +5551,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my08-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjlg"
+        "sys.uid": "tb9k4svj3amakfqac867"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -5560,7 +5560,7 @@
         {
           "resourceType": "node",
           "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85ch6epr9ha6omvqjmg",
+          "uid": "tbca72iou035q8bsubcf",
           "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -5640,7 +5640,7 @@
         {
           "resourceType": "node",
           "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85ch6epr9ha6omvqjog",
+          "uid": "tb62kdji13343nefcgpa",
           "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5697,7 +5697,7 @@
             "regionRepresentative": true,
             "verified": true
           },
-          "specId": "ncp+kr+s2-g3a",
+          "specId": "ncp+kr+s2-g3",
           "cspSpecName": "",
           "spec": {},
           "imageId": "23214590",
@@ -5720,7 +5720,7 @@
         {
           "resourceType": "node",
           "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85ch6epr9ha6omvqjng",
+          "uid": "tb926lt0j2uls25i7d2u",
           "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5863,7 +5863,7 @@
 {
   "resourceType": "infra",
   "id": "my03-infra101",
-  "uid": "tbd85chgupr9ha6omvqjqg",
+  "uid": "tb9k0f3jkc5cjd97jlad",
   "name": "my03-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -5891,7 +5891,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my03-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85chgupr9ha6omvqjqg"
+    "sys.uid": "tb9k0f3jkc5cjd97jlad"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -5900,9 +5900,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85chgupr9ha6omvqjrg",
-      "cspResourceName": "tbd85chgupr9ha6omvqjrg",
-      "cspResourceId": "tbd85chgupr9ha6omvqjrg",
+      "uid": "tb5aad3lmo0gt6dfk9uj",
+      "cspResourceName": "tb5aad3lmo0gt6dfk9uj",
+      "cspResourceId": "tb5aad3lmo0gt6dfk9uj",
       "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -5916,14 +5916,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:08:17",
+      "createdTime": "2026-06-02 12:05:04",
       "label": {
-        "keypair": "tbd85cf76pr9ha6omvqjgg",
+        "keypair": "tb6kf3c8jjcig0aqofjm",
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-18 08:08:17",
-        "sys.cspResourceId": "tbd85chgupr9ha6omvqjrg",
-        "sys.cspResourceName": "tbd85chgupr9ha6omvqjrg",
+        "sys.createdTime": "2026-06-02 12:05:04",
+        "sys.cspResourceId": "tb5aad3lmo0gt6dfk9uj",
+        "sys.cspResourceName": "tb5aad3lmo0gt6dfk9uj",
         "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -5932,7 +5932,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd85chgupr9ha6omvqjrg",
+        "sys.uid": "tb5aad3lmo0gt6dfk9uj",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -5940,7 +5940,7 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.47.88.87",
+      "publicIP": "34.158.221.135",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.2",
@@ -5986,32 +5986,32 @@
         "memoryGiB": 1.953125,
         "costPerHour": 0.063531
       },
-      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
       "image": {
         "resourceType": "image",
-        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd85cevepr9ha6omvqj20",
+      "cspVNetId": "tbf2lc0iranl4gr0qrj1",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+      "cspSubnetId": "tbbbfhl31q35cvclvii0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+      "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBTyrjHSxt6qZWbQxMqqRCjxDmjtrH2Dnopziy9PbQzxGqw76v+iZm/EYFqx+pxvqaTUNBU++J92lq0WuBr7i68=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBvJlaJerWk572CnkFTR7M94expQ/gc1Y521sL4DISJuWcZnTsKXnKMP14jgZ54TuwCwQX3rfhM+cuwwgNMIyGM=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:Epg/2q2Z05YyN084hOeTw4hNiR7NjcMSq43lf/yocK4",
-        "firstUsedAt": "2026-05-18T08:08:32Z"
+        "fingerprint": "SHA256:ERrBquVmt2+syALqxO7DyelFE+vt+aUmNJYSSa2rB4o",
+        "firstUsedAt": "2026-06-02T12:05:16Z"
       },
       "commandStatus": [
         {
@@ -6019,11 +6019,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:08:29Z",
-          "completedTime": "2026-05-18T08:08:33Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-06-02T12:05:14Z",
+          "completedTime": "2026-06-02T12:05:17Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6038,7 +6038,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-18T01:07:34.217-07:00"
+          "value": "2026-06-02T05:04:17.129-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -6050,15 +6050,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjrg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb5aad3lmo0gt6dfk9uj,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "9VP4LLWbIfc="
+          "value": "ZggRLCXPGm4="
         },
         {
           "key": "Id",
-          "value": "485614543392175657"
+          "value": "4544156388102993967"
         },
         {
           "key": "Kind",
@@ -6066,15 +6066,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "K4XUyTdV-uk="
+          "value": "gdrn9ZcdtK4="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+          "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-18T01:07:42.548-07:00"
+          "value": "2026-06-02T05:04:37.007-07:00"
         },
         {
           "key": "MachineType",
@@ -6082,15 +6082,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd85chgupr9ha6omvqjrg"
+          "value": "tb5aad3lmo0gt6dfk9uj"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.47.88.87,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:ihh_BNv7Hgc=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.221.135,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:78EyTGfFAXw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
         },
         {
           "key": "ResourceStatus",
@@ -6110,7 +6110,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjrg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb5aad3lmo0gt6dfk9uj"
         },
         {
           "key": "ServiceAccounts",
@@ -6134,7 +6134,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:VTjLFnAOyhg=,items:[tbd85cf7epr9ha6omvqjh0]}"
+          "value": "{fingerprint:HLOb1PbD2RI=,items:[tbn194eshutbrfcgotga]}"
         },
         {
           "key": "Zone",
@@ -6145,9 +6145,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85chgupr9ha6omvqjtg",
-      "cspResourceName": "tbd85chgupr9ha6omvqjtg",
-      "cspResourceId": "tbd85chgupr9ha6omvqjtg",
+      "uid": "tb25cler8rpicfonum0j",
+      "cspResourceName": "tb25cler8rpicfonum0j",
+      "cspResourceId": "tb25cler8rpicfonum0j",
       "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6161,14 +6161,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:08:19",
+      "createdTime": "2026-06-02 12:05:04",
       "label": {
-        "keypair": "tbd85cf76pr9ha6omvqjgg",
+        "keypair": "tb6kf3c8jjcig0aqofjm",
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-18 08:08:19",
-        "sys.cspResourceId": "tbd85chgupr9ha6omvqjtg",
-        "sys.cspResourceName": "tbd85chgupr9ha6omvqjtg",
+        "sys.createdTime": "2026-06-02 12:05:04",
+        "sys.cspResourceId": "tb25cler8rpicfonum0j",
+        "sys.cspResourceName": "tb25cler8rpicfonum0j",
         "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -6177,7 +6177,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd85chgupr9ha6omvqjtg",
+        "sys.uid": "tb25cler8rpicfonum0j",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -6185,10 +6185,10 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.234.91",
+      "publicIP": "34.64.204.98",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.3",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
       "rootDiskSize": 10,
@@ -6231,32 +6231,32 @@
         "memoryGiB": 7.8125,
         "costPerHour": 0.085966
       },
-      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
       "image": {
         "resourceType": "image",
-        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd85cevepr9ha6omvqj20",
+      "cspVNetId": "tbf2lc0iranl4gr0qrj1",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+      "cspSubnetId": "tbbbfhl31q35cvclvii0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+      "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGvD1KU1+ZJdf79GZ9H34PziLBJYb01WxzgNS5tWz0GeOpGg8L88IGpPqPfqdXKb5bROJbby0KOvfhdVCVUmLQM=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLUgTpq0/v92+Ov2nKeXig6AWK4yF0Gc1ZxosnLKf8lPmjXRFSkHJsCD0YZDOfiGUBlUww8UeS2xVqwC4870/oQ=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:DYAWOOMoPbZPyNgE6XOiqkS7jz5oAKe042rekh/h+a0",
-        "firstUsedAt": "2026-05-18T08:08:29Z"
+        "fingerprint": "SHA256:WFzUU+3UDSttNynTqwpHaMgj53E6aCNppI9EW+XJ0RU",
+        "firstUsedAt": "2026-06-02T12:05:14Z"
       },
       "commandStatus": [
         {
@@ -6264,11 +6264,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:08:29Z",
-          "completedTime": "2026-05-18T08:08:32Z",
-          "elapsedTime": 3,
+          "startedTime": "2026-06-02T12:05:14Z",
+          "completedTime": "2026-06-02T12:05:16Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6283,7 +6283,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-18T01:07:35.886-07:00"
+          "value": "2026-06-02T05:04:17.589-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -6295,15 +6295,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjtg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb25cler8rpicfonum0j,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "DWOIQhWVgNc="
+          "value": "69YQphFs3wM="
         },
         {
           "key": "Id",
-          "value": "1272312304157292072"
+          "value": "8018957467993208878"
         },
         {
           "key": "Kind",
@@ -6311,15 +6311,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "K4XUyTdV-uk="
+          "value": "gdrn9ZcdtK4="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+          "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-18T01:07:42.684-07:00"
+          "value": "2026-06-02T05:04:29.800-07:00"
         },
         {
           "key": "MachineType",
@@ -6327,15 +6327,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd85chgupr9ha6omvqjtg"
+          "value": "tb25cler8rpicfonum0j"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.234.91,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:eL5WeVK8vho=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.204.98,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:1Wsh4ie-ycE=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
         },
         {
           "key": "ResourceStatus",
@@ -6355,7 +6355,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjtg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb25cler8rpicfonum0j"
         },
         {
           "key": "ServiceAccounts",
@@ -6379,7 +6379,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:AiAynOHHwpk=,items:[tbd85cgkmpr9ha6omvqjkg]}"
+          "value": "{fingerprint:MvS1ld5KqfI=,items:[tbol4toon26c949hihp0]}"
         },
         {
           "key": "Zone",
@@ -6390,9 +6390,9 @@
     {
       "resourceType": "node",
       "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85chgupr9ha6omvqjsg",
-      "cspResourceName": "tbd85chgupr9ha6omvqjsg",
-      "cspResourceId": "tbd85chgupr9ha6omvqjsg",
+      "uid": "tbk09te5ihs839lat9rh",
+      "cspResourceName": "tbk09te5ihs839lat9rh",
+      "cspResourceId": "tbk09te5ihs839lat9rh",
       "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -6406,14 +6406,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:08:17",
+      "createdTime": "2026-06-02 12:05:04",
       "label": {
-        "keypair": "tbd85cf76pr9ha6omvqjgg",
+        "keypair": "tb6kf3c8jjcig0aqofjm",
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "gcp-asia-northeast3",
-        "sys.createdTime": "2026-05-18 08:08:17",
-        "sys.cspResourceId": "tbd85chgupr9ha6omvqjsg",
-        "sys.cspResourceName": "tbd85chgupr9ha6omvqjsg",
+        "sys.createdTime": "2026-06-02 12:05:04",
+        "sys.cspResourceId": "tbk09te5ihs839lat9rh",
+        "sys.cspResourceName": "tbk09te5ihs839lat9rh",
         "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my03-infra101",
         "sys.labelType": "node",
@@ -6422,7 +6422,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my03-subnet-01",
-        "sys.uid": "tbd85chgupr9ha6omvqjsg",
+        "sys.uid": "tbk09te5ihs839lat9rh",
         "sys.vNetId": "my03-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
@@ -6430,10 +6430,10 @@
         "region": "asia-northeast3",
         "zone": "asia-northeast3-a"
       },
-      "publicIP": "34.64.135.175",
+      "publicIP": "8.230.18.51",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.3",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "pd-standard",
       "rootDiskSize": 10,
@@ -6476,32 +6476,32 @@
         "memoryGiB": 15.625,
         "costPerHour": 0.171931
       },
-      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
-      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+      "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+      "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
       "image": {
         "resourceType": "image",
-        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421",
+        "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
-        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21"
+        "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
       },
       "vNetId": "my03-vnet-01",
-      "cspVNetId": "tbd85cevepr9ha6omvqj20",
+      "cspVNetId": "tbf2lc0iranl4gr0qrj1",
       "subnetId": "my03-subnet-01",
-      "cspSubnetId": "tbd85cevepr9ha6omvqj2g",
+      "cspSubnetId": "tbbbfhl31q35cvclvii0",
       "networkInterface": "nic0",
       "securityGroupIds": [
         "my03-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my03-sshkey-01",
-      "cspSshKeyId": "tbd85cf76pr9ha6omvqjgg",
+      "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI/QnYwHOlz6TT2SILbnQJKkPJsNlnr8GTuR0+y0rv+tXXMbYs1SIKMw1M8Q1VVNZyJfvqytUW8Pk/1tpGi6xa4=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLyLErlt9S67FpIuIuIgk56BGEfqpZgEudzYRmYFTrRy7e5hTNnW2GA56f4iE0yzvF8jAxTnq+P7z7YvWQO6coU=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:aEf3AqgSAOIliyJaPgDKOhdH5uP8vR/tFTEZIp+gcMw",
-        "firstUsedAt": "2026-05-18T08:08:32Z"
+        "fingerprint": "SHA256:dxmTL8Z4RRRFIztfhrxzp6jxm7GWvtYNV5kDjJtoz1k",
+        "firstUsedAt": "2026-06-02T12:05:16Z"
       },
       "commandStatus": [
         {
@@ -6509,11 +6509,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:08:29Z",
-          "completedTime": "2026-05-18T08:08:33Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-06-02T12:05:14Z",
+          "completedTime": "2026-06-02T12:05:17Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -6528,7 +6528,7 @@
         },
         {
           "key": "CreationTimestamp",
-          "value": "2026-05-18T01:07:35.010-07:00"
+          "value": "2026-06-02T05:04:20.591-07:00"
         },
         {
           "key": "DeletionProtection",
@@ -6540,15 +6540,15 @@
         },
         {
           "key": "Disks",
-          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbd85chgupr9ha6omvqjsg,type:PERSISTENT}"
+          "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbk09te5ihs839lat9rh,type:PERSISTENT}"
         },
         {
           "key": "Fingerprint",
-          "value": "HMqjE_xTr3c="
+          "value": "5TwSnPdL_r8="
         },
         {
           "key": "Id",
-          "value": "4838453238055794217"
+          "value": "3160271724368590891"
         },
         {
           "key": "Kind",
@@ -6556,15 +6556,15 @@
         },
         {
           "key": "LabelFingerprint",
-          "value": "K4XUyTdV-uk="
+          "value": "gdrn9ZcdtK4="
         },
         {
           "key": "Labels",
-          "value": "{keypair:tbd85cf76pr9ha6omvqjgg}"
+          "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
         },
         {
           "key": "LastStartTimestamp",
-          "value": "2026-05-18T01:07:43.230-07:00"
+          "value": "2026-06-02T05:04:30.378-07:00"
         },
         {
           "key": "MachineType",
@@ -6572,15 +6572,15 @@
         },
         {
           "key": "Metadata",
-          "value": "{fingerprint:4mXilFAdhXk=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDRNsz+Kr5uI2gh/HIQLb/A/BNIZzB10hTcxid94rIFHBB7XH/28kAjVEdTYy3qPESRcmuwT/mB4AUmL+GL8rL1EUEQ2wa1VyO8xdX0Tz+XwmgHyazyqz+7YC0xwkX37qCbGTHfookvGA+LXbHNgxbqaSfh/TopiSignv4tN1uIMLyE8cOBHi4DHNXirwnRPQEqKSYAU+3qe8fhDVsfabUCg2a+NCSdSfX3eU9yS0bvtJkP12yA5Pz2GKeuaa+pulWOkaOZyb7tQedNZzWpjzGMQHv5ZxQwpOR5gNyTh/QsLUew+v2boJ5geDjYWNEduF2Wu8AGIqa0GRXMbAGiv09378zMMc9ry+IJsf158/byCj1Z2u2ye//BHMnhBGQ68iXe5F6jBW1LM+qr082r6T0+WjE0isMtiUe7lLaf7YenK0qzDgJdHRVzxQbQHWyxIMNBHVHPEnC0/Ks9v1EzXECYdvKENV8aMPdvJgPSPLva52baL/9/rbTsbJ6Al9MV1wFhpNYfpMjKZ2yb1NUOtrnAlhBePEyXfl9Ssp2RNNXBMNt2AHJ4/1SDOvAHvbcoLGSOyuEQ3tZy6bCj57UcJPp9tej+rTJsk4/wy0dHfhLaqCLe8HYUzKgeD/2o3gB/2AeslWEg+AdBdn+Z9oQhdFj/+8JICYE/zy///Nj0QPjg2Q== cb-user}],kind:compute#metadata}"
+          "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
         },
         {
           "key": "Name",
-          "value": "tbd85chgupr9ha6omvqjsg"
+          "value": "tbk09te5ihs839lat9rh"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.135.175,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:aInRVIK88Rw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbd85cevepr9ha6omvqj20,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbd85cevepr9ha6omvqj2g}"
+          "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:8.230.18.51,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lOZ6jix2v68=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
         },
         {
           "key": "ResourceStatus",
@@ -6600,7 +6600,7 @@
         },
         {
           "key": "SelfLink",
-          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbd85chgupr9ha6omvqjsg"
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbk09te5ihs839lat9rh"
         },
         {
           "key": "ServiceAccounts",
@@ -6624,7 +6624,7 @@
         },
         {
           "key": "Tags",
-          "value": "{fingerprint:iDI4EcKiK68=,items:[tbd85cfrepr9ha6omvqjhg]}"
+          "value": "{fingerprint:DSXaZ9BoiC0=,items:[tbd6ae36tqdum3bvi8od]}"
         },
         {
           "key": "Zone",
@@ -6645,27 +6645,12 @@
       {
         "infraId": "my03-infra101",
         "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "34.64.234.91",
+        "nodeIp": "34.64.204.98",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my03-infra101",
-        "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "34.64.135.175",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6675,12 +6660,27 @@
       {
         "infraId": "my03-infra101",
         "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "34.47.88.87",
+        "nodeIp": "34.158.221.135",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my03-infra101",
+        "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "8.230.18.51",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6738,8 +6738,8 @@
       "command": "uname -a",
       "nodeGroup": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux tbd85chgupr9ha6omvqjrg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "34.47.88.87",
+      "output": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "34.158.221.135",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -6750,8 +6750,8 @@
       "command": "uname -a",
       "nodeGroup": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux tbd85chgupr9ha6omvqjtg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "34.64.234.91",
+      "output": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "34.64.204.98",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -6762,8 +6762,8 @@
       "command": "uname -a",
       "nodeGroup": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux tbd85chgupr9ha6omvqjsg 6.8.0-1053-gcp #56~22.04.1-Ubuntu SMP Mon Mar 23 20:16:54 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "34.64.135.175",
+      "output": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "8.230.18.51",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -6793,7 +6793,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:09:08
+**Generated At:** 2026-06-02 12:05:56
 
 **Namespace:** mig01
 
@@ -6821,23 +6821,23 @@
 
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
-| e2-standard-2 | 2 | 7.8 | - | x86_64 |  | $0.0860 | 1 |
 | e2-standard-4 | 4 | 15.6 | - | x86_64 |  | $0.1719 | 1 |
 | e2-highcpu-2 | 2 | 2.0 | - | x86_64 |  | $0.0635 | 1 |
+| e2-standard-2 | 2 | 7.8 | - | x86_64 |  | $0.0860 | 1 |
 
 ### VM Images
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421 | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 10 GB | 3 |
+| https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520 | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | 10 GB | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tbd85chgupr9ha6omvqjrg | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.47.88.87<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tbd85chgupr9ha6omvqjtg | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.234.91<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
-| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbd85chgupr9ha6omvqjsg | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.135.175<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | tb5aad3lmo0gt6dfk9uj | Running | 2 vCPU, 2.0 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.158.221.135<br>**Private IP:** 10.0.1.2<br>**SGs:** my03-sg-01<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | tb25cler8rpicfonum0j | Running | 2 vCPU, 7.8 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 34.64.204.98<br>**Private IP:** 10.0.1.3<br>**SGs:** my03-sg-03<br>**SSH:** my03-sshkey-01 |
+| my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | tbk09te5ihs839lat9rh | Running | 4 vCPU, 15.6 GiB | Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 (Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20) | **VNet:** my03-vnet-01<br>**Subnet:** my03-subnet-01<br>**Public IP:** 8.230.18.51<br>**Private IP:** 10.0.1.4<br>**SGs:** my03-sg-02<br>**SSH:** my03-sshkey-01 |
 
 
 ## Network Resources
@@ -6849,7 +6849,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-vnet-01 |
-| **CSP VNet ID** | tbd85cevepr9ha6omvqj20 |
+| **CSP VNet ID** | tbf2lc0iranl4gr0qrj1 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | gcp-asia-northeast3 |
 | **Subnet Count** | 1 |
@@ -6858,7 +6858,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my03-subnet-01 | tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 |  |
+| my03-subnet-01 | tbbbfhl31q35cvclvii0 | 10.0.1.0/24 |  |
 
 
 ## Security Resources
@@ -6867,7 +6867,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  |  |
+| my03-sshkey-01 | tb6kf3c8jjcig0aqofjm |  |  |
 
 ### Security Groups
 
@@ -6876,7 +6876,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-01 |
-| **CSP Security Group ID** | tbd85cf7epr9ha6omvqjh0 |
+| **CSP Security Group ID** | tbn194eshutbrfcgotga |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -6904,7 +6904,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-02 |
-| **CSP Security Group ID** | tbd85cfrepr9ha6omvqjhg |
+| **CSP Security Group ID** | tbd6ae36tqdum3bvi8od |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -6937,7 +6937,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my03-sg-03 |
-| **CSP Security Group ID** | tbd85cgkmpr9ha6omvqjkg |
+| **CSP Security Group ID** | tbol4toon26c949hihp0 |
 | **VNet** | my03-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -7012,7 +7012,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:09:10*
+*Report generated: 2026-06-02 12:06:01*
 
 ---
 
@@ -7056,9 +7056,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tbd85chgupr9ha6omvqjrg<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tbd85chgupr9ha6omvqjtg<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbd85chgupr9ha6omvqjsg<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** tb5aad3lmo0gt6dfk9uj<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** tb25cler8rpicfonum0j<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** tbk09te5ihs839lat9rh<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7080,9 +7080,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260421<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-04-21 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -7092,7 +7092,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-01
 
-**CSP ID:** tbd85cf7epr9ha6omvqjh0 | **VNet:** my03-vnet-01 | **Rules:** 14
+**CSP ID:** tbn194eshutbrfcgotga | **VNet:** my03-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7120,7 +7120,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-02
 
-**CSP ID:** tbd85cfrepr9ha6omvqjhg | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbd6ae36tqdum3bvi8od | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7153,7 +7153,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my03-sg-03
 
-**CSP ID:** tbd85cgkmpr9ha6omvqjkg | **VNet:** my03-vnet-01 | **Rules:** 19
+**CSP ID:** tbol4toon26c949hihp0 | **VNet:** my03-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7194,13 +7194,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my03-vnet-01<br>**ID:** tbd85cevepr9ha6omvqj20 | 10.0.0.0/21 |
+| 1 | **Name:** my03-vnet-01<br>**ID:** tbf2lc0iranl4gr0qrj1 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my03-subnet-01<br>**ID:** tbd85cevepr9ha6omvqj2g | 10.0.1.0/24 | my03-vnet-01 |
+| 1 | **Name:** my03-subnet-01<br>**ID:** tbbbfhl31q35cvclvii0 | 10.0.1.0/24 | my03-vnet-01 |
 
 ### Source Network Information
 
@@ -7242,7 +7242,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my03-sshkey-01 | tbd85cf76pr9ha6omvqjgg |  | Used by all 3 VMs |
+| 1 | my03-sshkey-01 | tb6kf3c8jjcig0aqofjm |  | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-ibm.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-ibm.md
@@ -7,19 +7,19 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (d392141)
-- imdl: v0.1.5+ (d392141)
-- CB-Tumblebug: v0.12.10
-- CB-Spider: v0.12.22
-- CB-MapUI: v0.12.31
+- CM-Beetle: imdl/v0.1.5+ (4987539)
+- imdl: v0.1.5+ (4987539)
+- CB-Tumblebug: v0.12.13
+- CB-Spider: v0.12.26
+- CB-MapUI: v0.12.34
 - Target CSP: IBM
 - Target Region: au-syd
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 19, 2026
-- Test Time: 11:01:43 KST
-- Test Execution: 2026-05-19 11:01:43 KST
+- Test Date: June 2, 2026
+- Test Time: 20:57:10 KST
+- Test Execution: 2026-06-02 20:57:10 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 21.961s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 2m55.879s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 16ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 8ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 90ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 15.53s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 2m54.786s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 38ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 7ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 26ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.378s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.361s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m30.323s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.345s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.3s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m22.808s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 6m25.781293149s
+**Total Duration**: 6m8.262026084s
 
-*Test executed on May 19, 2026 at 11:01:43 KST (2026-05-19 11:01:43 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 20:57:10 KST (2026-06-02 20:57:10 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1967,7 +1967,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "ibm-au-syd",
             "specId": "ibm+au-syd+nxf-2x2",
-            "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -1986,7 +1986,7 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "ibm-au-syd",
             "specId": "ibm+au-syd+bxf-4x16",
-            "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2005,7 +2005,7 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "ibm-au-syd",
             "specId": "ibm+au-syd+bxf-2x8",
-            "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2049,7 +2049,7 @@
       "targetSpecList": [
         {
           "id": "ibm+au-syd+nxf-2x2",
-          "uid": "d7k8jbtq1uu3ogmsijag",
+          "uid": "tb7jggfvq658ffi7hanf",
           "cspSpecName": "nxf-2x2",
           "name": "ibm+au-syd+nxf-2x2",
           "namespace": "system",
@@ -2078,6 +2078,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard,spot]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:2000}"
@@ -2109,6 +2113,10 @@
             {
               "key": "NetworkAttachmentCount",
               "value": "{max:1,min:1,type:range}"
+            },
+            {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
             },
             {
               "key": "NetworkInterfaceCount",
@@ -2151,18 +2159,34 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:200}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:2}"
             },
             {
               "key": "VcpuManufacturer",
-              "value": "{type:dependent,value:null}"
+              "value": "{type:dependent}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[10,25,50,100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:pooled,type:enum,values:[weighted,pooled]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         },
         {
           "id": "ibm+au-syd+bxf-4x16",
-          "uid": "d7k8jbtq1uu3ogmsih9g",
+          "uid": "tbtp8i585ail9mh3jnod",
           "cspSpecName": "bxf-4x16",
           "name": "ibm+au-syd+bxf-4x16",
           "namespace": "system",
@@ -2191,6 +2215,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard,spot]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:8000}"
@@ -2222,6 +2250,10 @@
             {
               "key": "NetworkAttachmentCount",
               "value": "{max:1,min:1,type:range}"
+            },
+            {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
             },
             {
               "key": "NetworkInterfaceCount",
@@ -2264,18 +2296,34 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:200}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:4}"
             },
             {
               "key": "VcpuManufacturer",
-              "value": "{type:dependent,value:null}"
+              "value": "{type:dependent}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[50,100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:pooled,type:enum,values:[weighted,pooled]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         },
         {
           "id": "ibm+au-syd+bxf-2x8",
-          "uid": "d7k8jbtq1uu3ogmsih8g",
+          "uid": "tbu5hc2ke8pnt5ssgcbo",
           "cspSpecName": "bxf-2x8",
           "name": "ibm+au-syd+bxf-2x8",
           "namespace": "system",
@@ -2304,6 +2352,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard,spot]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:4000}"
@@ -2335,6 +2387,10 @@
             {
               "key": "NetworkAttachmentCount",
               "value": "{max:1,min:1,type:range}"
+            },
+            {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
             },
             {
               "key": "NetworkInterfaceCount",
@@ -2377,12 +2433,28 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:200}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:2}"
             },
             {
               "key": "VcpuManufacturer",
-              "value": "{type:dependent,value:null}"
+              "value": "{type:dependent}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[50,100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:pooled,type:enum,values:[weighted,pooled]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         }
@@ -2392,18 +2464,18 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "ibm",
-          "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
           "regionList": [
             "au-syd"
           ],
-          "id": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-          "uid": "d7k8jplq1uu3ogmtlqig",
-          "name": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+          "id": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "uid": "tbtrt2lnuipiuftrap37",
+          "name": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "ibm-au-syd",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:14 Wed",
+          "fetchedTime": "2026.05.27 06:32:55 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -2417,16 +2489,20 @@
           "imageStatus": "Available",
           "details": [
             {
+              "key": "AllowedUse",
+              "value": "{api_version:2024-11-28,bare_metal_server:true,instance:true}"
+            },
+            {
               "key": "CatalogOffering",
               "value": "{managed:false}"
             },
             {
               "key": "CreatedAt",
-              "value": "2026-03-18T06:11:00.000Z"
+              "value": "2026-05-19T23:51:58.000Z"
             },
             {
               "key": "CRN",
-              "value": "crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632"
+              "value": "crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d"
             },
             {
               "key": "Encryption",
@@ -2434,31 +2510,31 @@
             },
             {
               "key": "File",
-              "value": "{checksums:{sha256:547886323915c92d71ca8b197142ceb9fa3e81fa75148614221b5cb56f0c7f0e},size:1}"
+              "value": "{checksums:{sha256:05ab42b9bb4881c3944fc5452b46a275bb94a6366831b1a874fa708585c4ecb1},size:1}"
             },
             {
               "key": "Href",
-              "value": "https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632"
+              "value": "https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d"
             },
             {
               "key": "ID",
-              "value": "r026-3e2370e7-648b-4c31-9305-f09265b49632"
+              "value": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d"
             },
             {
               "key": "MinimumProvisionedSize",
-              "value": "100"
+              "value": "10"
             },
             {
               "key": "Name",
-              "value": "ibm-ubuntu-22-04-5-minimal-amd64-13"
+              "value": "ibm-ubuntu-22-04-5-minimal-amd64-15"
             },
             {
               "key": "OperatingSystem",
               "value": "{allow_user_image_creation:true,architecture:amd64,dedicated_host_only:false,display_name:Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64),family:Ubuntu Linux,href:https://au-syd.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-22-04-amd64,name:ubuntu-22-04-amd64,user_data_format:cloud_init,vendor:Canonical,version:22.04 LTS Jammy Jellyfish Minimal Install}"
             },
             {
-              "key": "OwnerType",
-              "value": "provider"
+              "key": "Remote",
+              "value": "{account:{id:811f8abfbd32425597dc7ba40da98fa6,resource_type:account}}"
             },
             {
               "key": "ResourceGroup",
@@ -2833,7 +2909,7 @@
             "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=50.0% Image=100.0%",
             "connectionName": "ibm-au-syd",
             "specId": "ibm+au-syd+nxf-2x1",
-            "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2852,7 +2928,7 @@
             "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "ibm-au-syd",
             "specId": "ibm+au-syd+bx2-4x16",
-            "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2871,7 +2947,7 @@
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
             "connectionName": "ibm-au-syd",
             "specId": "ibm+au-syd+bx2-2x8",
-            "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
             "securityGroupIds": [
@@ -2915,7 +2991,7 @@
       "targetSpecList": [
         {
           "id": "ibm+au-syd+nxf-2x2",
-          "uid": "d7k8jbtq1uu3ogmsijag",
+          "uid": "tb7jggfvq658ffi7hanf",
           "cspSpecName": "nxf-2x2",
           "name": "ibm+au-syd+nxf-2x2",
           "namespace": "system",
@@ -2944,6 +3020,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard,spot]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:2000}"
@@ -2977,6 +3057,10 @@
               "value": "{max:1,min:1,type:range}"
             },
             {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
+            },
+            {
               "key": "NetworkInterfaceCount",
               "value": "{max:1,min:1,type:range}"
             },
@@ -3017,18 +3101,34 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:200}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:2}"
             },
             {
               "key": "VcpuManufacturer",
-              "value": "{type:dependent,value:null}"
+              "value": "{type:dependent}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[10,25,50,100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:pooled,type:enum,values:[weighted,pooled]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         },
         {
           "id": "ibm+au-syd+bxf-4x16",
-          "uid": "d7k8jbtq1uu3ogmsih9g",
+          "uid": "tbtp8i585ail9mh3jnod",
           "cspSpecName": "bxf-4x16",
           "name": "ibm+au-syd+bxf-4x16",
           "namespace": "system",
@@ -3057,6 +3157,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard,spot]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:8000}"
@@ -3090,6 +3194,10 @@
               "value": "{max:1,min:1,type:range}"
             },
             {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
+            },
+            {
               "key": "NetworkInterfaceCount",
               "value": "{max:1,min:1,type:range}"
             },
@@ -3130,18 +3238,34 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:200}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:4}"
             },
             {
               "key": "VcpuManufacturer",
-              "value": "{type:dependent,value:null}"
+              "value": "{type:dependent}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[50,100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:pooled,type:enum,values:[weighted,pooled]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         },
         {
           "id": "ibm+au-syd+bxf-2x8",
-          "uid": "d7k8jbtq1uu3ogmsih8g",
+          "uid": "tbu5hc2ke8pnt5ssgcbo",
           "cspSpecName": "bxf-2x8",
           "name": "ibm+au-syd+bxf-2x8",
           "namespace": "system",
@@ -3170,6 +3294,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard,spot]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:4000}"
@@ -3201,6 +3329,10 @@
             {
               "key": "NetworkAttachmentCount",
               "value": "{max:1,min:1,type:range}"
+            },
+            {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
             },
             {
               "key": "NetworkInterfaceCount",
@@ -3243,18 +3375,34 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:200}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:2}"
             },
             {
               "key": "VcpuManufacturer",
-              "value": "{type:dependent,value:null}"
+              "value": "{type:dependent}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[50,100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:pooled,type:enum,values:[weighted,pooled]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         },
         {
           "id": "ibm+au-syd+nxf-2x1",
-          "uid": "d7k8jbtq1uu3ogmsijb0",
+          "uid": "tbm961b7uek2fdn6h3to",
           "cspSpecName": "nxf-2x1",
           "name": "ibm+au-syd+nxf-2x1",
           "namespace": "system",
@@ -3283,6 +3431,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard,spot]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:2000}"
@@ -3314,6 +3466,10 @@
             {
               "key": "NetworkAttachmentCount",
               "value": "{max:1,min:1,type:range}"
+            },
+            {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
             },
             {
               "key": "NetworkInterfaceCount",
@@ -3356,18 +3512,34 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:200}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:2}"
             },
             {
               "key": "VcpuManufacturer",
-              "value": "{type:dependent,value:null}"
+              "value": "{type:dependent}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[10,25,50,100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:pooled,type:enum,values:[weighted,pooled]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         },
         {
           "id": "ibm+au-syd+bx2-4x16",
-          "uid": "d7k8jbtq1uu3ogmsiha0",
+          "uid": "tbgdlsg7fs0qf1nr53pr",
           "cspSpecName": "bx2-4x16",
           "name": "ibm+au-syd+bx2-4x16",
           "namespace": "system",
@@ -3396,6 +3568,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:8000}"
@@ -3427,6 +3603,10 @@
             {
               "key": "NetworkAttachmentCount",
               "value": "{max:5,min:1,type:range}"
+            },
+            {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
             },
             {
               "key": "NetworkInterfaceCount",
@@ -3469,18 +3649,34 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:100}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:4}"
             },
             {
               "key": "VcpuManufacturer",
               "value": "{type:fixed,value:intel}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:weighted,type:enum,values:[weighted]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         },
         {
           "id": "ibm+au-syd+bx2-2x8",
-          "uid": "d7k8jbtq1uu3ogmsih80",
+          "uid": "tb4036nluqjoeocg0vnh",
           "cspSpecName": "bx2-2x8",
           "name": "ibm+au-syd+bx2-2x8",
           "namespace": "system",
@@ -3509,6 +3705,10 @@
           "rootDiskSize": -1,
           "systemLabel": "auto-gen",
           "details": [
+            {
+              "key": "AvailabilityClass",
+              "value": "{default:standard,type:enum,values:[standard]}"
+            },
             {
               "key": "Bandwidth",
               "value": "{type:fixed,value:4000}"
@@ -3540,6 +3740,10 @@
             {
               "key": "NetworkAttachmentCount",
               "value": "{max:5,min:1,type:range}"
+            },
+            {
+              "key": "NetworkBandwidthMode",
+              "value": "{type:fixed,value:divided}"
             },
             {
               "key": "NetworkInterfaceCount",
@@ -3582,12 +3786,28 @@
               "value": "{type:fixed,value:amd64}"
             },
             {
+              "key": "VcpuBurstLimit",
+              "value": "{type:fixed,value:100}"
+            },
+            {
               "key": "VcpuCount",
               "value": "{type:fixed,value:2}"
             },
             {
               "key": "VcpuManufacturer",
               "value": "{type:fixed,value:intel}"
+            },
+            {
+              "key": "VcpuPercentage",
+              "value": "{default:100,type:enum,values:[100]}"
+            },
+            {
+              "key": "VolumeBandwidthQosModes",
+              "value": "{default:weighted,type:enum,values:[weighted]}"
+            },
+            {
+              "key": "Zones",
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-1,name:au-syd-1}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-2,name:au-syd-2}; {href:https://au-syd.iaas.cloud.ibm.com/v1/regions/au-syd/au-syd-3,name:au-syd-3}"
             }
           ]
         }
@@ -3597,18 +3817,18 @@
           "resourceType": "image",
           "namespace": "system",
           "providerName": "ibm",
-          "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
           "regionList": [
             "au-syd"
           ],
-          "id": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-          "uid": "d7k8jplq1uu3ogmtlqig",
-          "name": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+          "id": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "uid": "tbtrt2lnuipiuftrap37",
+          "name": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "ibm-au-syd",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:14 Wed",
+          "fetchedTime": "2026.05.27 06:32:55 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -3622,16 +3842,20 @@
           "imageStatus": "Available",
           "details": [
             {
+              "key": "AllowedUse",
+              "value": "{api_version:2024-11-28,bare_metal_server:true,instance:true}"
+            },
+            {
               "key": "CatalogOffering",
               "value": "{managed:false}"
             },
             {
               "key": "CreatedAt",
-              "value": "2026-03-18T06:11:00.000Z"
+              "value": "2026-05-19T23:51:58.000Z"
             },
             {
               "key": "CRN",
-              "value": "crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632"
+              "value": "crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d"
             },
             {
               "key": "Encryption",
@@ -3639,31 +3863,31 @@
             },
             {
               "key": "File",
-              "value": "{checksums:{sha256:547886323915c92d71ca8b197142ceb9fa3e81fa75148614221b5cb56f0c7f0e},size:1}"
+              "value": "{checksums:{sha256:05ab42b9bb4881c3944fc5452b46a275bb94a6366831b1a874fa708585c4ecb1},size:1}"
             },
             {
               "key": "Href",
-              "value": "https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632"
+              "value": "https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d"
             },
             {
               "key": "ID",
-              "value": "r026-3e2370e7-648b-4c31-9305-f09265b49632"
+              "value": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d"
             },
             {
               "key": "MinimumProvisionedSize",
-              "value": "100"
+              "value": "10"
             },
             {
               "key": "Name",
-              "value": "ibm-ubuntu-22-04-5-minimal-amd64-13"
+              "value": "ibm-ubuntu-22-04-5-minimal-amd64-15"
             },
             {
               "key": "OperatingSystem",
               "value": "{allow_user_image_creation:true,architecture:amd64,dedicated_host_only:false,display_name:Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64),family:Ubuntu Linux,href:https://au-syd.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-22-04-amd64,name:ubuntu-22-04-amd64,user_data_format:cloud_init,vendor:Canonical,version:22.04 LTS Jammy Jellyfish Minimal Install}"
             },
             {
-              "key": "OwnerType",
-              "value": "provider"
+              "key": "Remote",
+              "value": "{account:{id:811f8abfbd32425597dc7ba40da98fa6,resource_type:account}}"
             },
             {
               "key": "ResourceGroup",
@@ -4044,7 +4268,7 @@
 {
   "resourceType": "infra",
   "id": "my06-infra101",
-  "uid": "tb77vdum8fsgk0k3mmmq",
+  "uid": "tbb155e34rt94il69ph3",
   "name": "my06-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -4072,7 +4296,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my06-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tb77vdum8fsgk0k3mmmq"
+    "sys.uid": "tbb155e34rt94il69ph3"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -4081,9 +4305,9 @@
     {
       "resourceType": "node",
       "id": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbgohfsamsafahcqbms3",
-      "cspResourceName": "tbgohfsamsafahcqbms3",
-      "cspResourceId": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f",
+      "uid": "tbt7k7116g5o02ekkgfm",
+      "cspResourceName": "tbt7k7116g5o02ekkgfm",
+      "cspResourceId": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457",
       "name": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -4097,13 +4321,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 02:04:33",
+      "createdTime": "2026-06-02 11:59:56",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "ibm-au-syd",
-        "sys.createdTime": "2026-05-19 02:04:33",
-        "sys.cspResourceId": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f",
-        "sys.cspResourceName": "tbgohfsamsafahcqbms3",
+        "sys.createdTime": "2026-06-02 11:59:56",
+        "sys.cspResourceId": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457",
+        "sys.cspResourceName": "tbt7k7116g5o02ekkgfm",
         "sys.id": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my06-infra101",
         "sys.labelType": "node",
@@ -4112,7 +4336,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my06-subnet-01",
-        "sys.uid": "tbgohfsamsafahcqbms3",
+        "sys.uid": "tbt7k7116g5o02ekkgfm",
         "sys.vNetId": "my06-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4120,7 +4344,7 @@
         "region": "au-syd",
         "zone": "au-syd-1"
       },
-      "publicIP": "159.23.91.41",
+      "publicIP": "159.23.102.221",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.5",
@@ -4166,38 +4390,45 @@
         "memoryGiB": 2,
         "costPerHour": 0.094
       },
-      "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-      "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+      "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+      "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
       "image": {
         "resourceType": "image",
-        "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+        "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
       },
       "vNetId": "my06-vnet-01",
-      "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+      "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
       "subnetId": "my06-subnet-01",
-      "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-      "networkInterface": "fifth-prattler-scant-wands",
+      "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+      "networkInterface": "flask-hardship-unfitting-uncapped",
       "securityGroupIds": [
         "my06-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my06-sshkey-01",
-      "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+      "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
       "nodeUserName": "cb-user",
+      "sshHostKeyInfo": {
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAC8wdkeZ9gSMvTRBE8uUz6TGh+0YMlgOLO+Rh0C626WTd32ms8sDNvgMbaGZpFyUQtaomZR53J9kPjY7csXJAk=",
+        "keyType": "ecdsa-sha2-nistp256",
+        "fingerprint": "SHA256:rhFh2QMNhzSTwiu1H3k4UCkoFE4F6j+Xp8OeEDSWowM",
+        "firstUsedAt": "2026-06-02T12:00:09Z"
+      },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Failed",
-          "startedTime": "2026-05-19T02:04:43Z",
-          "completedTime": "2026-05-19T02:04:53Z",
-          "elapsedTime": 10,
-          "resultSummary": "Command execution failed",
-          "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+          "status": "Completed",
+          "startedTime": "2026-06-02T12:00:09Z",
+          "completedTime": "2026-06-02T12:00:13Z",
+          "elapsedTime": 4,
+          "resultSummary": "Command executed successfully",
+          "stdout": "Linux tbt7k7116g5o02ekkgfm 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stderr": "\n"
         }
       ],
       "addtionalDetails": [
@@ -4215,7 +4446,7 @@
         },
         {
           "key": "BootVolumeAttachment",
-          "value": "{device:{id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320-84cvs},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/volume_attachments/02h7-1f1d0450-123c-491a-abbd-aa74315c9320,id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320,name:knoll-virtuous-overflow-overcook,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,id:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,name:filterable-petri-carmaker-hardware,resource_type:volume}}"
+          "value": "{device:{id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662-jwbn8},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/volume_attachments/02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,name:garnet-magically-wifi-feisty,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,id:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,name:fondue-saturate-kettle-utility,resource_type:volume}}"
         },
         {
           "key": "ConfidentialComputeMode",
@@ -4223,11 +4454,11 @@
         },
         {
           "key": "CreatedAt",
-          "value": "2026-05-19T02:03:58.000Z"
+          "value": "2026-06-02T11:59:23.000Z"
         },
         {
           "key": "CRN",
-          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
         },
         {
           "key": "EnableSecureBoot",
@@ -4239,15 +4470,15 @@
         },
         {
           "key": "Href",
-          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
         },
         {
           "key": "ID",
-          "value": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+          "value": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
         },
         {
           "key": "Image",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
         },
         {
           "key": "LifecycleState",
@@ -4263,11 +4494,11 @@
         },
         {
           "key": "Name",
-          "value": "tbgohfsamsafahcqbms3"
+          "value": "tbt7k7116g5o02ekkgfm"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/network_interfaces/02h7-5df82744-9eb7-49a3-9313-7780cedd36db,id:02h7-5df82744-9eb7-49a3-9313-7780cedd36db,name:fifth-prattler-scant-wands,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,id:02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,name:snagged-cattishly-hypnotism-immersion,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/network_interfaces/02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,id:02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,name:flask-hardship-unfitting-uncapped,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,id:02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,name:dig-backlight-sincerity-roulette,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "NumaCount",
@@ -4275,7 +4506,7 @@
         },
         {
           "key": "PrimaryNetworkInterface",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/network_interfaces/02h7-5df82744-9eb7-49a3-9313-7780cedd36db,id:02h7-5df82744-9eb7-49a3-9313-7780cedd36db,name:fifth-prattler-scant-wands,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,id:02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,name:snagged-cattishly-hypnotism-immersion,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/network_interfaces/02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,id:02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,name:flask-hardship-unfitting-uncapped,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,id:02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,name:dig-backlight-sincerity-roulette,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "Profile",
@@ -4315,7 +4546,7 @@
         },
         {
           "key": "VolumeAttachments",
-          "value": "{device:{id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320-84cvs},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/volume_attachments/02h7-1f1d0450-123c-491a-abbd-aa74315c9320,id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320,name:knoll-virtuous-overflow-overcook,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,id:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,name:filterable-petri-carmaker-hardware,resource_type:volume}}"
+          "value": "{device:{id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662-jwbn8},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/volume_attachments/02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,name:garnet-magically-wifi-feisty,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,id:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,name:fondue-saturate-kettle-utility,resource_type:volume}}"
         },
         {
           "key": "VolumeBandwidthQosMode",
@@ -4323,7 +4554,7 @@
         },
         {
           "key": "VPC",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
         },
         {
           "key": "Zone",
@@ -4334,9 +4565,9 @@
     {
       "resourceType": "node",
       "id": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbvrc1olv3qvn1eq963r",
-      "cspResourceName": "tbvrc1olv3qvn1eq963r",
-      "cspResourceId": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a",
+      "uid": "tb1h7ijtv4sdjjt74cq4",
+      "cspResourceName": "tb1h7ijtv4sdjjt74cq4",
+      "cspResourceId": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4",
       "name": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -4350,13 +4581,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 02:04:38",
+      "createdTime": "2026-06-02 12:00:04",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "ibm-au-syd",
-        "sys.createdTime": "2026-05-19 02:04:38",
-        "sys.cspResourceId": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a",
-        "sys.cspResourceName": "tbvrc1olv3qvn1eq963r",
+        "sys.createdTime": "2026-06-02 12:00:04",
+        "sys.cspResourceId": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4",
+        "sys.cspResourceName": "tb1h7ijtv4sdjjt74cq4",
         "sys.id": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my06-infra101",
         "sys.labelType": "node",
@@ -4365,7 +4596,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my06-subnet-01",
-        "sys.uid": "tbvrc1olv3qvn1eq963r",
+        "sys.uid": "tb1h7ijtv4sdjjt74cq4",
         "sys.vNetId": "my06-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4373,10 +4604,10 @@
         "region": "au-syd",
         "zone": "au-syd-1"
       },
-      "publicIP": "159.23.91.42",
+      "publicIP": "159.23.98.218",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.6",
       "privateDNS": "",
       "rootDiskType": "general-purpose",
       "rootDiskSize": 100,
@@ -4419,38 +4650,44 @@
         "memoryGiB": 8,
         "costPerHour": 0.117
       },
-      "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-      "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+      "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+      "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
       "image": {
         "resourceType": "image",
-        "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+        "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
       },
       "vNetId": "my06-vnet-01",
-      "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+      "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
       "subnetId": "my06-subnet-01",
-      "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-      "networkInterface": "pregame-slab-pebbly-stuffed",
+      "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+      "networkInterface": "underling-headband-jawline-dandy",
       "securityGroupIds": [
         "my06-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my06-sshkey-01",
-      "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+      "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
       "nodeUserName": "cb-user",
+      "sshHostKeyInfo": {
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGPaje4p0cHi3xSR/tidAHCnzFneiJIw0aQiK/EwDvTEXEZR+qsC0LF+tFSFLRUT1u8A6v80/OKlulbvQMXzI6E=",
+        "keyType": "ecdsa-sha2-nistp256",
+        "fingerprint": "SHA256:UUfEs/wSunSjtxc257xEkGRgYJVZi09b3FC0zZFK+oU",
+        "firstUsedAt": "2026-06-02T12:00:12Z"
+      },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Failed",
-          "startedTime": "2026-05-19T02:04:43Z",
-          "completedTime": "2026-05-19T02:04:53Z",
-          "elapsedTime": 10,
+          "startedTime": "2026-06-02T12:00:09Z",
+          "completedTime": "2026-06-02T12:00:30Z",
+          "elapsedTime": 21,
           "resultSummary": "Command execution failed",
-          "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -4468,7 +4705,7 @@
         },
         {
           "key": "BootVolumeAttachment",
-          "value": "{device:{id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3-v8c5g},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/volume_attachments/02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,name:dynastic-caterpillar-booting-upstroke,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,id:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,name:kept-ribbon-dropdown-bunkhouse,resource_type:volume}}"
+          "value": "{device:{id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69-lc6sz},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/volume_attachments/02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,name:mocker-steersman-mushroom-stock,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-1d869fd7-f427-491a-a998-230be98d0f8f,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-1d869fd7-f427-491a-a998-230be98d0f8f,id:r026-1d869fd7-f427-491a-a998-230be98d0f8f,name:secluded-hatbox-payphone-lecturer,resource_type:volume}}"
         },
         {
           "key": "ConfidentialComputeMode",
@@ -4476,11 +4713,11 @@
         },
         {
           "key": "CreatedAt",
-          "value": "2026-05-19T02:03:58.000Z"
+          "value": "2026-06-02T11:59:25.000Z"
         },
         {
           "key": "CRN",
-          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
         },
         {
           "key": "EnableSecureBoot",
@@ -4492,15 +4729,15 @@
         },
         {
           "key": "Href",
-          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
         },
         {
           "key": "ID",
-          "value": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+          "value": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
         },
         {
           "key": "Image",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
         },
         {
           "key": "LifecycleState",
@@ -4516,11 +4753,11 @@
         },
         {
           "key": "Name",
-          "value": "tbvrc1olv3qvn1eq963r"
+          "value": "tb1h7ijtv4sdjjt74cq4"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/network_interfaces/02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,id:02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,name:pregame-slab-pebbly-stuffed,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,id:02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,name:deftly-hastily-twelve-shelf,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/network_interfaces/02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,id:02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,name:underling-headband-jawline-dandy,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-29641c82-c582-42aa-8330-7dd5b55583c2,id:02h7-29641c82-c582-42aa-8330-7dd5b55583c2,name:cleat-overstate-dislike-settling,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "NumaCount",
@@ -4528,7 +4765,7 @@
         },
         {
           "key": "PrimaryNetworkInterface",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/network_interfaces/02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,id:02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,name:pregame-slab-pebbly-stuffed,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,id:02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,name:deftly-hastily-twelve-shelf,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/network_interfaces/02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,id:02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,name:underling-headband-jawline-dandy,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-29641c82-c582-42aa-8330-7dd5b55583c2,id:02h7-29641c82-c582-42aa-8330-7dd5b55583c2,name:cleat-overstate-dislike-settling,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "Profile",
@@ -4568,7 +4805,7 @@
         },
         {
           "key": "VolumeAttachments",
-          "value": "{device:{id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3-v8c5g},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/volume_attachments/02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,name:dynastic-caterpillar-booting-upstroke,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,id:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,name:kept-ribbon-dropdown-bunkhouse,resource_type:volume}}"
+          "value": "{device:{id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69-lc6sz},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/volume_attachments/02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,name:mocker-steersman-mushroom-stock,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-1d869fd7-f427-491a-a998-230be98d0f8f,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-1d869fd7-f427-491a-a998-230be98d0f8f,id:r026-1d869fd7-f427-491a-a998-230be98d0f8f,name:secluded-hatbox-payphone-lecturer,resource_type:volume}}"
         },
         {
           "key": "VolumeBandwidthQosMode",
@@ -4576,7 +4813,7 @@
         },
         {
           "key": "VPC",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
         },
         {
           "key": "Zone",
@@ -4587,9 +4824,9 @@
     {
       "resourceType": "node",
       "id": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbcsjiapgrtftvnunu8g",
-      "cspResourceName": "tbcsjiapgrtftvnunu8g",
-      "cspResourceId": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9",
+      "uid": "tbfb0c8hrtma9tjabtm6",
+      "cspResourceName": "tbfb0c8hrtma9tjabtm6",
+      "cspResourceId": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6",
       "name": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4603,13 +4840,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 02:04:34",
+      "createdTime": "2026-06-02 12:00:00",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "ibm-au-syd",
-        "sys.createdTime": "2026-05-19 02:04:34",
-        "sys.cspResourceId": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9",
-        "sys.cspResourceName": "tbcsjiapgrtftvnunu8g",
+        "sys.createdTime": "2026-06-02 12:00:00",
+        "sys.cspResourceId": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6",
+        "sys.cspResourceName": "tbfb0c8hrtma9tjabtm6",
         "sys.id": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my06-infra101",
         "sys.labelType": "node",
@@ -4618,7 +4855,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my06-subnet-01",
-        "sys.uid": "tbcsjiapgrtftvnunu8g",
+        "sys.uid": "tbfb0c8hrtma9tjabtm6",
         "sys.vNetId": "my06-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4626,10 +4863,10 @@
         "region": "au-syd",
         "zone": "au-syd-1"
       },
-      "publicIP": "159.23.98.92",
+      "publicIP": "159.23.94.110",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.6",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "general-purpose",
       "rootDiskSize": 100,
@@ -4672,32 +4909,32 @@
         "memoryGiB": 16,
         "costPerHour": 0.235
       },
-      "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-      "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+      "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+      "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
       "image": {
         "resourceType": "image",
-        "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+        "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
       },
       "vNetId": "my06-vnet-01",
-      "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+      "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
       "subnetId": "my06-subnet-01",
-      "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-      "networkInterface": "charcoal-groggily-tube-thinner",
+      "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+      "networkInterface": "cast-handcraft-hulk-scalded",
       "securityGroupIds": [
         "my06-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my06-sshkey-01",
-      "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+      "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD19aNuDPdYwRJ0C7cqJjtYB1B4cwXNpSpwjJpSgOeQTkLprtVKo35BNAmDANMDObhESvSFhUirKrHuD5G8hb2I=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMZia3tsPEXHAdMl3XqD20BJ7FgY29w9Zh5t4KDDweL4FDYix1xEB8GeagoakJ/0EqA0Pot7pz6z0SxH5pXZxFw=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:aAXzAs0R5JeQmb78jUcnjIMu7gCsfKJLjRi8ixUyMYc",
-        "firstUsedAt": "2026-05-19T02:04:44Z"
+        "fingerprint": "SHA256:AxjNblckKR1i97qPsF9JhDs5lyqT3XRq+W7bi6GEgpc",
+        "firstUsedAt": "2026-06-02T12:00:12Z"
       },
       "commandStatus": [
         {
@@ -4705,11 +4942,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Failed",
-          "startedTime": "2026-05-19T02:04:43Z",
-          "completedTime": "2026-05-19T02:04:53Z",
-          "elapsedTime": 10,
+          "startedTime": "2026-06-02T12:00:09Z",
+          "completedTime": "2026-06-02T12:00:30Z",
+          "elapsedTime": 21,
           "resultSummary": "Command execution failed",
-          "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -4727,7 +4964,7 @@
         },
         {
           "key": "BootVolumeAttachment",
-          "value": "{device:{id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42-kcj8l},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/volume_attachments/02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,name:oxymoron-rely-aspire-commotion,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-0b03e033-0b5a-4c2a-ab10-4177171712be,id:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,name:creme-reshape-super-wake,resource_type:volume}}"
+          "value": "{device:{id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199-dpdgt},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/volume_attachments/02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,name:riverside-fang-shampoo-affirm,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,id:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,name:runway-preshow-deed-truce,resource_type:volume}}"
         },
         {
           "key": "ConfidentialComputeMode",
@@ -4735,11 +4972,11 @@
         },
         {
           "key": "CreatedAt",
-          "value": "2026-05-19T02:03:59.000Z"
+          "value": "2026-06-02T11:59:22.000Z"
         },
         {
           "key": "CRN",
-          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
         },
         {
           "key": "EnableSecureBoot",
@@ -4751,15 +4988,15 @@
         },
         {
           "key": "Href",
-          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
         },
         {
           "key": "ID",
-          "value": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+          "value": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
         },
         {
           "key": "Image",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
         },
         {
           "key": "LifecycleState",
@@ -4775,11 +5012,11 @@
         },
         {
           "key": "Name",
-          "value": "tbcsjiapgrtftvnunu8g"
+          "value": "tbfb0c8hrtma9tjabtm6"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/network_interfaces/02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,id:02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,name:charcoal-groggily-tube-thinner,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,id:02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,name:cylinder-hastiness-rigged-foster,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/network_interfaces/02h7-2d45942c-5b73-4894-9f98-736c8d83526f,id:02h7-2d45942c-5b73-4894-9f98-736c8d83526f,name:cast-handcraft-hulk-scalded,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,id:02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,name:festoonery-cardigan-magically-obstinate,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "NumaCount",
@@ -4787,7 +5024,7 @@
         },
         {
           "key": "PrimaryNetworkInterface",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/network_interfaces/02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,id:02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,name:charcoal-groggily-tube-thinner,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,id:02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,name:cylinder-hastiness-rigged-foster,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/network_interfaces/02h7-2d45942c-5b73-4894-9f98-736c8d83526f,id:02h7-2d45942c-5b73-4894-9f98-736c8d83526f,name:cast-handcraft-hulk-scalded,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,id:02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,name:festoonery-cardigan-magically-obstinate,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "Profile",
@@ -4827,7 +5064,7 @@
         },
         {
           "key": "VolumeAttachments",
-          "value": "{device:{id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42-kcj8l},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/volume_attachments/02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,name:oxymoron-rely-aspire-commotion,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-0b03e033-0b5a-4c2a-ab10-4177171712be,id:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,name:creme-reshape-super-wake,resource_type:volume}}"
+          "value": "{device:{id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199-dpdgt},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/volume_attachments/02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,name:riverside-fang-shampoo-affirm,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,id:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,name:runway-preshow-deed-truce,resource_type:volume}}"
         },
         {
           "key": "VolumeBandwidthQosMode",
@@ -4835,7 +5072,7 @@
         },
         {
           "key": "VPC",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
         },
         {
           "key": "Zone",
@@ -4856,18 +5093,22 @@
       {
         "infraId": "my06-infra101",
         "nodeId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "159.23.91.41",
+        "nodeIp": "159.23.102.221",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {},
-        "stderr": {},
+        "stdout": {
+          "0": "Linux tbt7k7116g5o02ekkgfm 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
         "err": null
       },
       {
         "infraId": "my06-infra101",
         "nodeId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "159.23.91.42",
+        "nodeIp": "159.23.98.218",
         "command": {
           "0": "uname -a"
         },
@@ -4878,7 +5119,7 @@
       {
         "infraId": "my06-infra101",
         "nodeId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "159.23.98.92",
+        "nodeIp": "159.23.94.110",
         "command": {
           "0": "uname -a"
         },
@@ -4914,8 +5155,577 @@
   "infra": [
     {
       "resourceType": "infra",
+      "id": "my02-infra101",
+      "uid": "tbv4r5dg0r6ctsgj7tfe",
+      "name": "my02-infra101",
+      "status": "Terminated:3 (R:0/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 0,
+        "countRunning": 0,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 3,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 0,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "Terminated",
+      "targetAction": "Terminate",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my02-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my02-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tbv4r5dg0r6ctsgj7tfe"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tb81h514blbmih6th0ra",
+          "cspResourceName": "tb81h514blbmih6th0ra",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
+          "name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Terminated",
+          "targetStatus": "Terminated",
+          "targetAction": "Terminate",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "terminated VM. No action is acceptable except deletion",
+          "createdTime": "2026-06-02 11:58:51",
+          "label": {
+            "createdBy": "tb81h514blbmih6th0ra",
+            "keypair": "tbmeu2jlibrbjhpqt6ks",
+            "publicip": "tb81h514blbmih6th0ra-51215-PublicIP",
+            "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.connectionName": "azure-koreasouth",
+            "sys.createdTime": "2026-06-02 11:58:51",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra",
+            "sys.cspResourceName": "tb81h514blbmih6th0ra",
+            "sys.id": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.infraId": "my02-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.subnetId": "my02-subnet-01",
+            "sys.uid": "tb81h514blbmih6th0ra",
+            "sys.vNetId": "my02-vnet-01"
+          },
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
+          "region": {
+            "region": "koreasouth"
+          },
+          "publicIP": "40.89.209.210",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.4",
+          "privateDNS": "",
+          "rootDiskType": "PremiumSSD",
+          "rootDiskSize": 30,
+          "RootDeviceName": "Not visible in Azure",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2als_v2",
+          "cspSpecName": "Standard_B2als_v2",
+          "spec": {
+            "cspSpecName": "Standard_B2als_v2",
+            "vCPU": 2,
+            "memoryGiB": 3.90625,
+            "costPerHour": 0.0432
+          },
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+          "networkInterface": "tb81h514blbmih6th0ra-74785-VNic",
+          "securityGroupIds": [
+            "my02-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFW7tvj2HzsClA8X1H26zUY4x8P6NQYpxpab+6eweSK3WB1Z7hjR9loeEmmH+DcvmhMv+MY0Rswn2avB6fUySUc=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:iARQFNvURLH907WgwzHgMJPVSWgoyBhMXtYvYWM/db0",
+            "firstUsedAt": "2026-06-02T11:58:58Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-06-02T11:58:57Z",
+              "completedTime": "2026-06-02T11:59:01Z",
+              "elapsedTime": 4,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "Location",
+              "value": "koreasouth"
+            },
+            {
+              "key": "Properties",
+              "value": "{hardwareProfile:{vmSize:Standard_B2als_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tb81h514blbmih6th0ra-74785-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tb81h514blbmih6th0ra,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,storageAccountType:Premium_LRS},name:tb81h514blbmih6th0ra_OsDisk_1_f68013d858ac4524824a70a9db72638e,osType:Linux}},timeCreated:2026-06-02T11:58:00.0230074Z,vmId:a194131f-a308-4f9e-bd5f-1954226d1a73}"
+            },
+            {
+              "key": "Tags",
+              "value": "{createdBy:tb81h514blbmih6th0ra,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tb81h514blbmih6th0ra-51215-PublicIP}"
+            },
+            {
+              "key": "Etag",
+              "value": "\\1\\"
+            },
+            {
+              "key": "ID",
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tb81h514blbmih6th0ra"
+            },
+            {
+              "key": "Name",
+              "value": "tb81h514blbmih6th0ra"
+            },
+            {
+              "key": "Type",
+              "value": "Microsoft.Compute/virtualMachines"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tbj3l6ut11ch7mvkq2p2",
+          "cspResourceName": "tbj3l6ut11ch7mvkq2p2",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
+          "name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Terminated",
+          "targetStatus": "Terminated",
+          "targetAction": "Terminate",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "terminated VM. No action is acceptable except deletion",
+          "createdTime": "2026-06-02 11:58:51",
+          "label": {
+            "createdBy": "tbj3l6ut11ch7mvkq2p2",
+            "keypair": "tbmeu2jlibrbjhpqt6ks",
+            "publicip": "tbj3l6ut11ch7mvkq2p2-63146-PublicIP",
+            "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.connectionName": "azure-koreasouth",
+            "sys.createdTime": "2026-06-02 11:58:51",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2",
+            "sys.cspResourceName": "tbj3l6ut11ch7mvkq2p2",
+            "sys.id": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.infraId": "my02-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.subnetId": "my02-subnet-01",
+            "sys.uid": "tbj3l6ut11ch7mvkq2p2",
+            "sys.vNetId": "my02-vnet-01"
+          },
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": "koreasouth"
+          },
+          "publicIP": "52.231.195.8",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.6",
+          "privateDNS": "",
+          "rootDiskType": "PremiumSSD",
+          "rootDiskSize": 30,
+          "RootDeviceName": "Not visible in Azure",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b2as_v2",
+          "cspSpecName": "Standard_B2as_v2",
+          "spec": {
+            "cspSpecName": "Standard_B2as_v2",
+            "vCPU": 2,
+            "memoryGiB": 7.8125,
+            "costPerHour": 0.0865
+          },
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605280",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202605260"
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+          "networkInterface": "tbj3l6ut11ch7mvkq2p2-3298-VNic",
+          "securityGroupIds": [
+            "my02-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJtUMh1cIUNrdvxDyS/sX2gg1UlgprQImyTmtt571zIcfmNpvML9//EZjbJhwyEPPk1DSV9P+GsLYIsancoLI2Q=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:vHAecS7HpoCmHLAn96798w3BOcO14c/PF8E2f32n6W4",
+            "firstUsedAt": "2026-06-02T11:59:00Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-06-02T11:58:57Z",
+              "completedTime": "2026-06-02T11:59:03Z",
+              "elapsedTime": 6,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "Location",
+              "value": "koreasouth"
+            },
+            {
+              "key": "Properties",
+              "value": "{hardwareProfile:{vmSize:Standard_B2as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tbj3l6ut11ch7mvkq2p2-3298-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tbj3l6ut11ch7mvkq2p2,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],diskControllerType:SCSI,imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts-gen2,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,storageAccountType:Premium_LRS},name:tbj3l6ut11ch7mvkq2p2_OsDisk_1_5e8befb085954c5198c00c1288c77c74,osType:Linux}},timeCreated:2026-06-02T11:58:02.5923143Z,vmId:26a400ec-766d-4066-a986-31dee1af0a49}"
+            },
+            {
+              "key": "Tags",
+              "value": "{createdBy:tbj3l6ut11ch7mvkq2p2,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tbj3l6ut11ch7mvkq2p2-63146-PublicIP}"
+            },
+            {
+              "key": "Etag",
+              "value": "\\1\\"
+            },
+            {
+              "key": "ID",
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tbj3l6ut11ch7mvkq2p2"
+            },
+            {
+              "key": "Name",
+              "value": "tbj3l6ut11ch7mvkq2p2"
+            },
+            {
+              "key": "Type",
+              "value": "Microsoft.Compute/virtualMachines"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tblumcks3qbld4l0rqdu",
+          "cspResourceName": "tblumcks3qbld4l0rqdu",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
+          "name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "Korea South",
+            "latitude": 35.1796,
+            "longitude": 129.0756
+          },
+          "status": "Terminated",
+          "targetStatus": "Terminated",
+          "targetAction": "Terminate",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "terminated VM. No action is acceptable except deletion",
+          "createdTime": "2026-06-02 11:58:51",
+          "label": {
+            "createdBy": "tblumcks3qbld4l0rqdu",
+            "keypair": "tbmeu2jlibrbjhpqt6ks",
+            "publicip": "tblumcks3qbld4l0rqdu-15505-PublicIP",
+            "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.connectionName": "azure-koreasouth",
+            "sys.createdTime": "2026-06-02 11:58:51",
+            "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu",
+            "sys.cspResourceName": "tblumcks3qbld4l0rqdu",
+            "sys.id": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.infraId": "my02-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.subnetId": "my02-subnet-01",
+            "sys.uid": "tblumcks3qbld4l0rqdu",
+            "sys.vNetId": "my02-vnet-01"
+          },
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": "koreasouth"
+          },
+          "publicIP": "20.214.40.12",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.5",
+          "privateDNS": "",
+          "rootDiskType": "PremiumSSD",
+          "rootDiskSize": 30,
+          "RootDeviceName": "Not visible in Azure",
+          "connectionName": "azure-koreasouth",
+          "connectionConfig": {
+            "configName": "azure-koreasouth",
+            "providerName": "azure",
+            "driverName": "azure-driver-v1.0.so",
+            "credentialName": "azure",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "azure-koreasouth",
+            "regionZoneInfo": {
+              "assignedRegion": "koreasouth",
+              "assignedZone": ""
+            },
+            "regionDetail": {
+              "regionId": "koreasouth",
+              "regionName": "koreasouth",
+              "description": "Korea South",
+              "location": {
+                "display": "Korea South",
+                "latitude": 35.1796,
+                "longitude": 129.0756
+              },
+              "zones": []
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "azure+koreasouth+standard_b4as_v2",
+          "cspSpecName": "Standard_B4as_v2",
+          "spec": {
+            "cspSpecName": "Standard_B4as_v2",
+            "vCPU": 4,
+            "memoryGiB": 15.625,
+            "costPerHour": 0.173
+          },
+          "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605280",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:22.04.202605260"
+          },
+          "vNetId": "my02-vnet-01",
+          "cspVNetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta",
+          "subnetId": "my02-subnet-01",
+          "cspSubnetId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbaa7lm1qpjpqcm1blta/subnets/tbdk04p2j6rjaddfeilr",
+          "networkInterface": "tblumcks3qbld4l0rqdu-93021-VNic",
+          "securityGroupIds": [
+            "my02-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my02-sshkey-01",
+          "cspSshKeyId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbmeu2jlibrbjhpqt6ks",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPTL9uzNQSU1yXWyoHY8FKtgjUxNkaKpGjhn6dtQjVMVJC3cpROCI06y1MwW8elX7OtijS4pmgWxkK29xA0kJ80=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:lVsWJmS92R46BkqahsTpl8eAW8rA6D39KJOZaJA3sj8",
+            "firstUsedAt": "2026-06-02T11:59:00Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-06-02T11:58:57Z",
+              "completedTime": "2026-06-02T11:59:02Z",
+              "elapsedTime": 5,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "Location",
+              "value": "koreasouth"
+            },
+            {
+              "key": "Properties",
+              "value": "{hardwareProfile:{vmSize:Standard_B4as_v2},networkProfile:{networkInterfaces:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/networkInterfaces/tblumcks3qbld4l0rqdu-93021-VNic,properties:{primary:true}}]},osProfile:{adminUsername:cb-user,allowExtensionOperations:true,computerName:tblumcks3qbld4l0rqdu,linuxConfiguration:{disablePasswordAuthentication:true,patchSettings:{assessmentMode:ImageDefault,patchMode:ImageDefault},provisionVMAgent:true,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpktoKLh1JaY7GzYG/FsvMS7Gxwj0F8FZzI9Q5KMffkjE6BTyUFuxHPgtyWbGKkZfk48XNdc0Yfiy11Oaol4Z/zUtnZkql9x1p8ktqwvK6RPaZjlxWjG2n4dvidBMsHCdpQjsmj3Zao8xsYG2fovFDgx2CUOeUEpCNp9uY2J54UumH6YLfVXrV2kQfeJkRXRQBlUUw6MObttcVhhNsVlaLxzeqb/sLaHEb5Pa6tO2Fok+VE++/OPAf5nubPirQp+Uo9ld7OhLolUnAfocho0frZSwaGv0VcU1iwpBWl66Kza8lKofk73hQrC3Ppr0eNb4VauY5Rh1sWuHC28C+Ikduc0JzfQ5WOczPDsMvFpylLvxHlMcxYSeEHtnO4/ykKs4duNp5SBIByiJsImpWaDNO44GJP3QdacdghiiLrb++6j7vAA2d/yRJpRrDjQyrMqJLTCYR9PLVmu/jNGx3mBdSareS2TIA0NG70tEvIzuCgNsAhGHOXstLqVbwsf8N6BP0bXx7l+lOTAGLu6/0V25cmutW0ZDkGwty+dUBKx7ocv6IVGZT+G6EUvnpcbGqtcfgG8o+ECZcuEnJGNKrQONYdEDC/WkfcekgpuqD58aS3pxWxb8bdrtQJYT2NQHSfLbtnNqCatVg11nSYvusxPZw13BXmo/5XKRFUCtnxN15qQ==\\n,path:/home/cb-user/.ssh/authorized_keys}]}},requireGuestProvisionSignal:true,secrets:[]},provisioningState:Succeeded,securityProfile:{securityType:Standard},storageProfile:{dataDisks:[],imageReference:{exactVersion:22.04.202605280,offer:0001-com-ubuntu-server-jammy-daily,publisher:Canonical,sku:22_04-daily-lts,version:22.04.202605280},osDisk:{caching:ReadWrite,createOption:FromImage,deleteOption:Delete,diskSizeGB:30,managedDisk:{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/disks/tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,storageAccountType:Premium_LRS},name:tblumcks3qbld4l0rqdu_OsDisk_1_9a7cccbd80604b8199a546a33c83bb41,osType:Linux}},timeCreated:2026-06-02T11:58:00.3944037Z,vmId:bb9a97ea-bbc0-4b18-b394-cb1accf01389}"
+            },
+            {
+              "key": "Tags",
+              "value": "{createdBy:tblumcks3qbld4l0rqdu,keypair:tbmeu2jlibrbjhpqt6ks,publicip:tblumcks3qbld4l0rqdu-15505-PublicIP}"
+            },
+            {
+              "key": "Etag",
+              "value": "\\1\\"
+            },
+            {
+              "key": "ID",
+              "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/virtualMachines/tblumcks3qbld4l0rqdu"
+            },
+            {
+              "key": "Name",
+              "value": "tblumcks3qbld4l0rqdu"
+            },
+            {
+              "key": "Type",
+              "value": "Microsoft.Compute/virtualMachines"
+            }
+          ]
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": [
+          {
+            "infraId": "my02-infra101",
+            "nodeId": "my02-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "40.89.209.210",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tb81h514blbmih6th0ra 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my02-infra101",
+            "nodeId": "my02-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "20.214.40.12",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tblumcks3qbld4l0rqdu 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my02-infra101",
+            "nodeId": "my02-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "52.231.195.8",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tbj3l6ut11ch7mvkq2p2 6.8.0-1052-azure #58~22.04.1-Ubuntu SMP Thu Mar 26 05:02:21 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": "infra",
       "id": "my06-infra101",
-      "uid": "tb77vdum8fsgk0k3mmmq",
+      "uid": "tbb155e34rt94il69ph3",
       "name": "my06-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -4943,7 +5753,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my06-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tb77vdum8fsgk0k3mmmq"
+        "sys.uid": "tbb155e34rt94il69ph3"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -4952,9 +5762,9 @@
         {
           "resourceType": "node",
           "id": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbgohfsamsafahcqbms3",
-          "cspResourceName": "tbgohfsamsafahcqbms3",
-          "cspResourceId": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f",
+          "uid": "tbt7k7116g5o02ekkgfm",
+          "cspResourceName": "tbt7k7116g5o02ekkgfm",
+          "cspResourceId": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457",
           "name": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -4968,13 +5778,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-19 02:04:33",
+          "createdTime": "2026-06-02 11:59:56",
           "label": {
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "ibm-au-syd",
-            "sys.createdTime": "2026-05-19 02:04:33",
-            "sys.cspResourceId": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f",
-            "sys.cspResourceName": "tbgohfsamsafahcqbms3",
+            "sys.createdTime": "2026-06-02 11:59:56",
+            "sys.cspResourceId": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457",
+            "sys.cspResourceName": "tbt7k7116g5o02ekkgfm",
             "sys.id": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my06-infra101",
             "sys.labelType": "node",
@@ -4983,7 +5793,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my06-subnet-01",
-            "sys.uid": "tbgohfsamsafahcqbms3",
+            "sys.uid": "tbt7k7116g5o02ekkgfm",
             "sys.vNetId": "my06-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4991,7 +5801,7 @@
             "region": "au-syd",
             "zone": "au-syd-1"
           },
-          "publicIP": "159.23.91.41",
+          "publicIP": "159.23.102.221",
           "sshPort": 22,
           "publicDNS": "",
           "privateIP": "10.0.1.5",
@@ -5037,38 +5847,45 @@
             "memoryGiB": 2,
             "costPerHour": 0.094
           },
-          "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-          "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+          "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
           "image": {
             "resourceType": "image",
-            "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
           },
           "vNetId": "my06-vnet-01",
-          "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+          "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
           "subnetId": "my06-subnet-01",
-          "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-          "networkInterface": "fifth-prattler-scant-wands",
+          "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+          "networkInterface": "flask-hardship-unfitting-uncapped",
           "securityGroupIds": [
             "my06-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my06-sshkey-01",
-          "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+          "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
           "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAC8wdkeZ9gSMvTRBE8uUz6TGh+0YMlgOLO+Rh0C626WTd32ms8sDNvgMbaGZpFyUQtaomZR53J9kPjY7csXJAk=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:rhFh2QMNhzSTwiu1H3k4UCkoFE4F6j+Xp8OeEDSWowM",
+            "firstUsedAt": "2026-06-02T12:00:09Z"
+          },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
-              "status": "Failed",
-              "startedTime": "2026-05-19T02:04:43Z",
-              "completedTime": "2026-05-19T02:04:53Z",
-              "elapsedTime": 10,
-              "resultSummary": "Command execution failed",
-              "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+              "status": "Completed",
+              "startedTime": "2026-06-02T12:00:09Z",
+              "completedTime": "2026-06-02T12:00:13Z",
+              "elapsedTime": 4,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux tbt7k7116g5o02ekkgfm 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
             }
           ],
           "addtionalDetails": [
@@ -5086,7 +5903,7 @@
             },
             {
               "key": "BootVolumeAttachment",
-              "value": "{device:{id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320-84cvs},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/volume_attachments/02h7-1f1d0450-123c-491a-abbd-aa74315c9320,id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320,name:knoll-virtuous-overflow-overcook,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,id:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,name:filterable-petri-carmaker-hardware,resource_type:volume}}"
+              "value": "{device:{id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662-jwbn8},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/volume_attachments/02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,name:garnet-magically-wifi-feisty,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,id:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,name:fondue-saturate-kettle-utility,resource_type:volume}}"
             },
             {
               "key": "ConfidentialComputeMode",
@@ -5094,11 +5911,11 @@
             },
             {
               "key": "CreatedAt",
-              "value": "2026-05-19T02:03:58.000Z"
+              "value": "2026-06-02T11:59:23.000Z"
             },
             {
               "key": "CRN",
-              "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+              "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
             },
             {
               "key": "EnableSecureBoot",
@@ -5110,15 +5927,15 @@
             },
             {
               "key": "Href",
-              "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+              "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
             },
             {
               "key": "ID",
-              "value": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+              "value": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
             },
             {
               "key": "Image",
-              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
             },
             {
               "key": "LifecycleState",
@@ -5134,11 +5951,11 @@
             },
             {
               "key": "Name",
-              "value": "tbgohfsamsafahcqbms3"
+              "value": "tbt7k7116g5o02ekkgfm"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/network_interfaces/02h7-5df82744-9eb7-49a3-9313-7780cedd36db,id:02h7-5df82744-9eb7-49a3-9313-7780cedd36db,name:fifth-prattler-scant-wands,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,id:02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,name:snagged-cattishly-hypnotism-immersion,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/network_interfaces/02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,id:02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,name:flask-hardship-unfitting-uncapped,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,id:02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,name:dig-backlight-sincerity-roulette,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
             },
             {
               "key": "NumaCount",
@@ -5146,7 +5963,7 @@
             },
             {
               "key": "PrimaryNetworkInterface",
-              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/network_interfaces/02h7-5df82744-9eb7-49a3-9313-7780cedd36db,id:02h7-5df82744-9eb7-49a3-9313-7780cedd36db,name:fifth-prattler-scant-wands,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,id:02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,name:snagged-cattishly-hypnotism-immersion,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/network_interfaces/02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,id:02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,name:flask-hardship-unfitting-uncapped,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,id:02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,name:dig-backlight-sincerity-roulette,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
             },
             {
               "key": "Profile",
@@ -5186,7 +6003,7 @@
             },
             {
               "key": "VolumeAttachments",
-              "value": "{device:{id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320-84cvs},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/volume_attachments/02h7-1f1d0450-123c-491a-abbd-aa74315c9320,id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320,name:knoll-virtuous-overflow-overcook,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,id:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,name:filterable-petri-carmaker-hardware,resource_type:volume}}"
+              "value": "{device:{id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662-jwbn8},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/volume_attachments/02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,name:garnet-magically-wifi-feisty,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,id:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,name:fondue-saturate-kettle-utility,resource_type:volume}}"
             },
             {
               "key": "VolumeBandwidthQosMode",
@@ -5194,7 +6011,7 @@
             },
             {
               "key": "VPC",
-              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
             },
             {
               "key": "Zone",
@@ -5205,9 +6022,9 @@
         {
           "resourceType": "node",
           "id": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbvrc1olv3qvn1eq963r",
-          "cspResourceName": "tbvrc1olv3qvn1eq963r",
-          "cspResourceId": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a",
+          "uid": "tb1h7ijtv4sdjjt74cq4",
+          "cspResourceName": "tb1h7ijtv4sdjjt74cq4",
+          "cspResourceId": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4",
           "name": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -5221,13 +6038,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-19 02:04:38",
+          "createdTime": "2026-06-02 12:00:04",
           "label": {
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "ibm-au-syd",
-            "sys.createdTime": "2026-05-19 02:04:38",
-            "sys.cspResourceId": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a",
-            "sys.cspResourceName": "tbvrc1olv3qvn1eq963r",
+            "sys.createdTime": "2026-06-02 12:00:04",
+            "sys.cspResourceId": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4",
+            "sys.cspResourceName": "tb1h7ijtv4sdjjt74cq4",
             "sys.id": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my06-infra101",
             "sys.labelType": "node",
@@ -5236,7 +6053,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my06-subnet-01",
-            "sys.uid": "tbvrc1olv3qvn1eq963r",
+            "sys.uid": "tb1h7ijtv4sdjjt74cq4",
             "sys.vNetId": "my06-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5244,10 +6061,10 @@
             "region": "au-syd",
             "zone": "au-syd-1"
           },
-          "publicIP": "159.23.91.42",
+          "publicIP": "159.23.98.218",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.4",
+          "privateIP": "10.0.1.6",
           "privateDNS": "",
           "rootDiskType": "general-purpose",
           "rootDiskSize": 100,
@@ -5290,38 +6107,44 @@
             "memoryGiB": 8,
             "costPerHour": 0.117
           },
-          "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-          "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+          "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
           "image": {
             "resourceType": "image",
-            "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
           },
           "vNetId": "my06-vnet-01",
-          "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+          "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
           "subnetId": "my06-subnet-01",
-          "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-          "networkInterface": "pregame-slab-pebbly-stuffed",
+          "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+          "networkInterface": "underling-headband-jawline-dandy",
           "securityGroupIds": [
             "my06-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my06-sshkey-01",
-          "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+          "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
           "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGPaje4p0cHi3xSR/tidAHCnzFneiJIw0aQiK/EwDvTEXEZR+qsC0LF+tFSFLRUT1u8A6v80/OKlulbvQMXzI6E=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:UUfEs/wSunSjtxc257xEkGRgYJVZi09b3FC0zZFK+oU",
+            "firstUsedAt": "2026-06-02T12:00:12Z"
+          },
           "commandStatus": [
             {
               "index": 1,
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Failed",
-              "startedTime": "2026-05-19T02:04:43Z",
-              "completedTime": "2026-05-19T02:04:53Z",
-              "elapsedTime": 10,
+              "startedTime": "2026-06-02T12:00:09Z",
+              "completedTime": "2026-06-02T12:00:30Z",
+              "elapsedTime": 21,
               "resultSummary": "Command execution failed",
-              "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -5339,7 +6162,7 @@
             },
             {
               "key": "BootVolumeAttachment",
-              "value": "{device:{id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3-v8c5g},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/volume_attachments/02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,name:dynastic-caterpillar-booting-upstroke,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,id:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,name:kept-ribbon-dropdown-bunkhouse,resource_type:volume}}"
+              "value": "{device:{id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69-lc6sz},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/volume_attachments/02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,name:mocker-steersman-mushroom-stock,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-1d869fd7-f427-491a-a998-230be98d0f8f,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-1d869fd7-f427-491a-a998-230be98d0f8f,id:r026-1d869fd7-f427-491a-a998-230be98d0f8f,name:secluded-hatbox-payphone-lecturer,resource_type:volume}}"
             },
             {
               "key": "ConfidentialComputeMode",
@@ -5347,11 +6170,11 @@
             },
             {
               "key": "CreatedAt",
-              "value": "2026-05-19T02:03:58.000Z"
+              "value": "2026-06-02T11:59:25.000Z"
             },
             {
               "key": "CRN",
-              "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+              "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
             },
             {
               "key": "EnableSecureBoot",
@@ -5363,15 +6186,15 @@
             },
             {
               "key": "Href",
-              "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+              "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
             },
             {
               "key": "ID",
-              "value": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+              "value": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
             },
             {
               "key": "Image",
-              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
             },
             {
               "key": "LifecycleState",
@@ -5387,11 +6210,11 @@
             },
             {
               "key": "Name",
-              "value": "tbvrc1olv3qvn1eq963r"
+              "value": "tb1h7ijtv4sdjjt74cq4"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/network_interfaces/02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,id:02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,name:pregame-slab-pebbly-stuffed,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,id:02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,name:deftly-hastily-twelve-shelf,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/network_interfaces/02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,id:02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,name:underling-headband-jawline-dandy,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-29641c82-c582-42aa-8330-7dd5b55583c2,id:02h7-29641c82-c582-42aa-8330-7dd5b55583c2,name:cleat-overstate-dislike-settling,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
             },
             {
               "key": "NumaCount",
@@ -5399,7 +6222,7 @@
             },
             {
               "key": "PrimaryNetworkInterface",
-              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/network_interfaces/02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,id:02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,name:pregame-slab-pebbly-stuffed,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,id:02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,name:deftly-hastily-twelve-shelf,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/network_interfaces/02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,id:02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,name:underling-headband-jawline-dandy,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-29641c82-c582-42aa-8330-7dd5b55583c2,id:02h7-29641c82-c582-42aa-8330-7dd5b55583c2,name:cleat-overstate-dislike-settling,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
             },
             {
               "key": "Profile",
@@ -5439,7 +6262,7 @@
             },
             {
               "key": "VolumeAttachments",
-              "value": "{device:{id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3-v8c5g},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/volume_attachments/02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,name:dynastic-caterpillar-booting-upstroke,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,id:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,name:kept-ribbon-dropdown-bunkhouse,resource_type:volume}}"
+              "value": "{device:{id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69-lc6sz},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/volume_attachments/02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,name:mocker-steersman-mushroom-stock,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-1d869fd7-f427-491a-a998-230be98d0f8f,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-1d869fd7-f427-491a-a998-230be98d0f8f,id:r026-1d869fd7-f427-491a-a998-230be98d0f8f,name:secluded-hatbox-payphone-lecturer,resource_type:volume}}"
             },
             {
               "key": "VolumeBandwidthQosMode",
@@ -5447,7 +6270,7 @@
             },
             {
               "key": "VPC",
-              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
             },
             {
               "key": "Zone",
@@ -5458,9 +6281,9 @@
         {
           "resourceType": "node",
           "id": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbcsjiapgrtftvnunu8g",
-          "cspResourceName": "tbcsjiapgrtftvnunu8g",
-          "cspResourceId": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9",
+          "uid": "tbfb0c8hrtma9tjabtm6",
+          "cspResourceName": "tbfb0c8hrtma9tjabtm6",
+          "cspResourceId": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6",
           "name": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5474,13 +6297,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-19 02:04:34",
+          "createdTime": "2026-06-02 12:00:00",
           "label": {
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "ibm-au-syd",
-            "sys.createdTime": "2026-05-19 02:04:34",
-            "sys.cspResourceId": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9",
-            "sys.cspResourceName": "tbcsjiapgrtftvnunu8g",
+            "sys.createdTime": "2026-06-02 12:00:00",
+            "sys.cspResourceId": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6",
+            "sys.cspResourceName": "tbfb0c8hrtma9tjabtm6",
             "sys.id": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my06-infra101",
             "sys.labelType": "node",
@@ -5489,7 +6312,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my06-subnet-01",
-            "sys.uid": "tbcsjiapgrtftvnunu8g",
+            "sys.uid": "tbfb0c8hrtma9tjabtm6",
             "sys.vNetId": "my06-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5497,10 +6320,10 @@
             "region": "au-syd",
             "zone": "au-syd-1"
           },
-          "publicIP": "159.23.98.92",
+          "publicIP": "159.23.94.110",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.6",
+          "privateIP": "10.0.1.4",
           "privateDNS": "",
           "rootDiskType": "general-purpose",
           "rootDiskSize": 100,
@@ -5543,32 +6366,32 @@
             "memoryGiB": 16,
             "costPerHour": 0.235
           },
-          "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-          "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+          "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+          "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
           "image": {
             "resourceType": "image",
-            "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+            "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
             "osType": "Ubuntu 22.04",
             "osArchitecture": "x86_64",
             "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
           },
           "vNetId": "my06-vnet-01",
-          "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+          "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
           "subnetId": "my06-subnet-01",
-          "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-          "networkInterface": "charcoal-groggily-tube-thinner",
+          "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+          "networkInterface": "cast-handcraft-hulk-scalded",
           "securityGroupIds": [
             "my06-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my06-sshkey-01",
-          "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+          "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD19aNuDPdYwRJ0C7cqJjtYB1B4cwXNpSpwjJpSgOeQTkLprtVKo35BNAmDANMDObhESvSFhUirKrHuD5G8hb2I=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMZia3tsPEXHAdMl3XqD20BJ7FgY29w9Zh5t4KDDweL4FDYix1xEB8GeagoakJ/0EqA0Pot7pz6z0SxH5pXZxFw=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:aAXzAs0R5JeQmb78jUcnjIMu7gCsfKJLjRi8ixUyMYc",
-            "firstUsedAt": "2026-05-19T02:04:44Z"
+            "fingerprint": "SHA256:AxjNblckKR1i97qPsF9JhDs5lyqT3XRq+W7bi6GEgpc",
+            "firstUsedAt": "2026-06-02T12:00:12Z"
           },
           "commandStatus": [
             {
@@ -5576,11 +6399,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Failed",
-              "startedTime": "2026-05-19T02:04:43Z",
-              "completedTime": "2026-05-19T02:04:53Z",
-              "elapsedTime": 10,
+              "startedTime": "2026-06-02T12:00:09Z",
+              "completedTime": "2026-06-02T12:00:30Z",
+              "elapsedTime": 21,
               "resultSummary": "Command execution failed",
-              "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+              "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
             }
           ],
           "addtionalDetails": [
@@ -5598,7 +6421,7 @@
             },
             {
               "key": "BootVolumeAttachment",
-              "value": "{device:{id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42-kcj8l},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/volume_attachments/02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,name:oxymoron-rely-aspire-commotion,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-0b03e033-0b5a-4c2a-ab10-4177171712be,id:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,name:creme-reshape-super-wake,resource_type:volume}}"
+              "value": "{device:{id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199-dpdgt},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/volume_attachments/02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,name:riverside-fang-shampoo-affirm,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,id:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,name:runway-preshow-deed-truce,resource_type:volume}}"
             },
             {
               "key": "ConfidentialComputeMode",
@@ -5606,11 +6429,11 @@
             },
             {
               "key": "CreatedAt",
-              "value": "2026-05-19T02:03:59.000Z"
+              "value": "2026-06-02T11:59:22.000Z"
             },
             {
               "key": "CRN",
-              "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+              "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
             },
             {
               "key": "EnableSecureBoot",
@@ -5622,15 +6445,15 @@
             },
             {
               "key": "Href",
-              "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+              "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
             },
             {
               "key": "ID",
-              "value": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+              "value": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
             },
             {
               "key": "Image",
-              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
             },
             {
               "key": "LifecycleState",
@@ -5646,11 +6469,11 @@
             },
             {
               "key": "Name",
-              "value": "tbcsjiapgrtftvnunu8g"
+              "value": "tbfb0c8hrtma9tjabtm6"
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/network_interfaces/02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,id:02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,name:charcoal-groggily-tube-thinner,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,id:02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,name:cylinder-hastiness-rigged-foster,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/network_interfaces/02h7-2d45942c-5b73-4894-9f98-736c8d83526f,id:02h7-2d45942c-5b73-4894-9f98-736c8d83526f,name:cast-handcraft-hulk-scalded,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,id:02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,name:festoonery-cardigan-magically-obstinate,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
             },
             {
               "key": "NumaCount",
@@ -5658,7 +6481,7 @@
             },
             {
               "key": "PrimaryNetworkInterface",
-              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/network_interfaces/02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,id:02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,name:charcoal-groggily-tube-thinner,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,id:02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,name:cylinder-hastiness-rigged-foster,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+              "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/network_interfaces/02h7-2d45942c-5b73-4894-9f98-736c8d83526f,id:02h7-2d45942c-5b73-4894-9f98-736c8d83526f,name:cast-handcraft-hulk-scalded,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,id:02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,name:festoonery-cardigan-magically-obstinate,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
             },
             {
               "key": "Profile",
@@ -5698,7 +6521,7 @@
             },
             {
               "key": "VolumeAttachments",
-              "value": "{device:{id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42-kcj8l},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/volume_attachments/02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,name:oxymoron-rely-aspire-commotion,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-0b03e033-0b5a-4c2a-ab10-4177171712be,id:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,name:creme-reshape-super-wake,resource_type:volume}}"
+              "value": "{device:{id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199-dpdgt},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/volume_attachments/02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,name:riverside-fang-shampoo-affirm,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,id:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,name:runway-preshow-deed-truce,resource_type:volume}}"
             },
             {
               "key": "VolumeBandwidthQosMode",
@@ -5706,7 +6529,7 @@
             },
             {
               "key": "VPC",
-              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+              "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
             },
             {
               "key": "Zone",
@@ -5727,18 +6550,22 @@
           {
             "infraId": "my06-infra101",
             "nodeId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "159.23.91.41",
+            "nodeIp": "159.23.102.221",
             "command": {
               "0": "uname -a"
             },
-            "stdout": {},
-            "stderr": {},
+            "stdout": {
+              "0": "Linux tbt7k7116g5o02ekkgfm 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
             "err": null
           },
           {
             "infraId": "my06-infra101",
             "nodeId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "159.23.91.42",
+            "nodeIp": "159.23.98.218",
             "command": {
               "0": "uname -a"
             },
@@ -5749,7 +6576,7 @@
           {
             "infraId": "my06-infra101",
             "nodeId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "159.23.98.92",
+            "nodeIp": "159.23.94.110",
             "command": {
               "0": "uname -a"
             },
@@ -5784,6 +6611,7 @@
 ```json
 {
   "idList": [
+    "my02-infra101",
     "my06-infra101"
   ]
 }
@@ -5813,7 +6641,7 @@
 {
   "resourceType": "infra",
   "id": "my06-infra101",
-  "uid": "tb77vdum8fsgk0k3mmmq",
+  "uid": "tbb155e34rt94il69ph3",
   "name": "my06-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -5841,7 +6669,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my06-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tb77vdum8fsgk0k3mmmq"
+    "sys.uid": "tbb155e34rt94il69ph3"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -5850,9 +6678,9 @@
     {
       "resourceType": "node",
       "id": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbgohfsamsafahcqbms3",
-      "cspResourceName": "tbgohfsamsafahcqbms3",
-      "cspResourceId": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f",
+      "uid": "tbt7k7116g5o02ekkgfm",
+      "cspResourceName": "tbt7k7116g5o02ekkgfm",
+      "cspResourceId": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457",
       "name": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -5866,13 +6694,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 02:04:33",
+      "createdTime": "2026-06-02 11:59:56",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "ibm-au-syd",
-        "sys.createdTime": "2026-05-19 02:04:33",
-        "sys.cspResourceId": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f",
-        "sys.cspResourceName": "tbgohfsamsafahcqbms3",
+        "sys.createdTime": "2026-06-02 11:59:56",
+        "sys.cspResourceId": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457",
+        "sys.cspResourceName": "tbt7k7116g5o02ekkgfm",
         "sys.id": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my06-infra101",
         "sys.labelType": "node",
@@ -5881,7 +6709,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my06-subnet-01",
-        "sys.uid": "tbgohfsamsafahcqbms3",
+        "sys.uid": "tbt7k7116g5o02ekkgfm",
         "sys.vNetId": "my06-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -5889,7 +6717,7 @@
         "region": "au-syd",
         "zone": "au-syd-1"
       },
-      "publicIP": "159.23.91.41",
+      "publicIP": "159.23.102.221",
       "sshPort": 22,
       "publicDNS": "",
       "privateIP": "10.0.1.5",
@@ -5935,38 +6763,45 @@
         "memoryGiB": 2,
         "costPerHour": 0.094
       },
-      "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-      "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+      "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+      "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
       "image": {
         "resourceType": "image",
-        "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+        "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
       },
       "vNetId": "my06-vnet-01",
-      "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+      "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
       "subnetId": "my06-subnet-01",
-      "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-      "networkInterface": "fifth-prattler-scant-wands",
+      "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+      "networkInterface": "flask-hardship-unfitting-uncapped",
       "securityGroupIds": [
         "my06-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my06-sshkey-01",
-      "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+      "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
       "nodeUserName": "cb-user",
+      "sshHostKeyInfo": {
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAC8wdkeZ9gSMvTRBE8uUz6TGh+0YMlgOLO+Rh0C626WTd32ms8sDNvgMbaGZpFyUQtaomZR53J9kPjY7csXJAk=",
+        "keyType": "ecdsa-sha2-nistp256",
+        "fingerprint": "SHA256:rhFh2QMNhzSTwiu1H3k4UCkoFE4F6j+Xp8OeEDSWowM",
+        "firstUsedAt": "2026-06-02T12:00:09Z"
+      },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
-          "status": "Failed",
-          "startedTime": "2026-05-19T02:04:43Z",
-          "completedTime": "2026-05-19T02:04:53Z",
-          "elapsedTime": 10,
-          "resultSummary": "Command execution failed",
-          "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+          "status": "Completed",
+          "startedTime": "2026-06-02T12:00:09Z",
+          "completedTime": "2026-06-02T12:00:13Z",
+          "elapsedTime": 4,
+          "resultSummary": "Command executed successfully",
+          "stdout": "Linux tbt7k7116g5o02ekkgfm 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stderr": "\n"
         }
       ],
       "addtionalDetails": [
@@ -5984,7 +6819,7 @@
         },
         {
           "key": "BootVolumeAttachment",
-          "value": "{device:{id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320-84cvs},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/volume_attachments/02h7-1f1d0450-123c-491a-abbd-aa74315c9320,id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320,name:knoll-virtuous-overflow-overcook,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,id:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,name:filterable-petri-carmaker-hardware,resource_type:volume}}"
+          "value": "{device:{id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662-jwbn8},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/volume_attachments/02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,name:garnet-magically-wifi-feisty,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,id:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,name:fondue-saturate-kettle-utility,resource_type:volume}}"
         },
         {
           "key": "ConfidentialComputeMode",
@@ -5992,11 +6827,11 @@
         },
         {
           "key": "CreatedAt",
-          "value": "2026-05-19T02:03:58.000Z"
+          "value": "2026-06-02T11:59:23.000Z"
         },
         {
           "key": "CRN",
-          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
         },
         {
           "key": "EnableSecureBoot",
@@ -6008,15 +6843,15 @@
         },
         {
           "key": "Href",
-          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
         },
         {
           "key": "ID",
-          "value": "02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f"
+          "value": "02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457"
         },
         {
           "key": "Image",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
         },
         {
           "key": "LifecycleState",
@@ -6032,11 +6867,11 @@
         },
         {
           "key": "Name",
-          "value": "tbgohfsamsafahcqbms3"
+          "value": "tbt7k7116g5o02ekkgfm"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/network_interfaces/02h7-5df82744-9eb7-49a3-9313-7780cedd36db,id:02h7-5df82744-9eb7-49a3-9313-7780cedd36db,name:fifth-prattler-scant-wands,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,id:02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,name:snagged-cattishly-hypnotism-immersion,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/network_interfaces/02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,id:02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,name:flask-hardship-unfitting-uncapped,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,id:02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,name:dig-backlight-sincerity-roulette,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "NumaCount",
@@ -6044,7 +6879,7 @@
         },
         {
           "key": "PrimaryNetworkInterface",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/network_interfaces/02h7-5df82744-9eb7-49a3-9313-7780cedd36db,id:02h7-5df82744-9eb7-49a3-9313-7780cedd36db,name:fifth-prattler-scant-wands,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,id:02h7-e70fbc9b-bfa1-4804-baf4-97b261579d69,name:snagged-cattishly-hypnotism-immersion,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/network_interfaces/02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,id:02h7-6b3534ae-f81a-45db-9555-7e3a76415ba3,name:flask-hardship-unfitting-uncapped,primary_ip:{address:10.0.1.5,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,id:02h7-2d482142-2179-4b13-baa5-44bc5c76b85d,name:dig-backlight-sincerity-roulette,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "Profile",
@@ -6084,7 +6919,7 @@
         },
         {
           "key": "VolumeAttachments",
-          "value": "{device:{id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320-84cvs},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f/volume_attachments/02h7-1f1d0450-123c-491a-abbd-aa74315c9320,id:02h7-1f1d0450-123c-491a-abbd-aa74315c9320,name:knoll-virtuous-overflow-overcook,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,id:r026-8f4b37ce-3bf7-43bb-83dc-db2440238cb5,name:filterable-petri-carmaker-hardware,resource_type:volume}}"
+          "value": "{device:{id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662-jwbn8},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457/volume_attachments/02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,id:02h7-fb51cdd2-60f4-4e13-92ae-ceeb810b6662,name:garnet-magically-wifi-feisty,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,id:r026-34a55d8f-c6ca-4737-abb3-f7fca0efdcb5,name:fondue-saturate-kettle-utility,resource_type:volume}}"
         },
         {
           "key": "VolumeBandwidthQosMode",
@@ -6092,7 +6927,7 @@
         },
         {
           "key": "VPC",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
         },
         {
           "key": "Zone",
@@ -6103,9 +6938,9 @@
     {
       "resourceType": "node",
       "id": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbvrc1olv3qvn1eq963r",
-      "cspResourceName": "tbvrc1olv3qvn1eq963r",
-      "cspResourceId": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a",
+      "uid": "tb1h7ijtv4sdjjt74cq4",
+      "cspResourceName": "tb1h7ijtv4sdjjt74cq4",
+      "cspResourceId": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4",
       "name": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -6119,13 +6954,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 02:04:38",
+      "createdTime": "2026-06-02 12:00:04",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "ibm-au-syd",
-        "sys.createdTime": "2026-05-19 02:04:38",
-        "sys.cspResourceId": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a",
-        "sys.cspResourceName": "tbvrc1olv3qvn1eq963r",
+        "sys.createdTime": "2026-06-02 12:00:04",
+        "sys.cspResourceId": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4",
+        "sys.cspResourceName": "tb1h7ijtv4sdjjt74cq4",
         "sys.id": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my06-infra101",
         "sys.labelType": "node",
@@ -6134,7 +6969,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my06-subnet-01",
-        "sys.uid": "tbvrc1olv3qvn1eq963r",
+        "sys.uid": "tb1h7ijtv4sdjjt74cq4",
         "sys.vNetId": "my06-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6142,10 +6977,10 @@
         "region": "au-syd",
         "zone": "au-syd-1"
       },
-      "publicIP": "159.23.91.42",
+      "publicIP": "159.23.98.218",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.4",
+      "privateIP": "10.0.1.6",
       "privateDNS": "",
       "rootDiskType": "general-purpose",
       "rootDiskSize": 100,
@@ -6188,38 +7023,44 @@
         "memoryGiB": 8,
         "costPerHour": 0.117
       },
-      "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-      "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+      "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+      "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
       "image": {
         "resourceType": "image",
-        "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+        "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
       },
       "vNetId": "my06-vnet-01",
-      "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+      "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
       "subnetId": "my06-subnet-01",
-      "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-      "networkInterface": "pregame-slab-pebbly-stuffed",
+      "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+      "networkInterface": "underling-headband-jawline-dandy",
       "securityGroupIds": [
         "my06-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my06-sshkey-01",
-      "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+      "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
       "nodeUserName": "cb-user",
+      "sshHostKeyInfo": {
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGPaje4p0cHi3xSR/tidAHCnzFneiJIw0aQiK/EwDvTEXEZR+qsC0LF+tFSFLRUT1u8A6v80/OKlulbvQMXzI6E=",
+        "keyType": "ecdsa-sha2-nistp256",
+        "fingerprint": "SHA256:UUfEs/wSunSjtxc257xEkGRgYJVZi09b3FC0zZFK+oU",
+        "firstUsedAt": "2026-06-02T12:00:12Z"
+      },
       "commandStatus": [
         {
           "index": 1,
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Failed",
-          "startedTime": "2026-05-19T02:04:43Z",
-          "completedTime": "2026-05-19T02:04:53Z",
-          "elapsedTime": 10,
+          "startedTime": "2026-06-02T12:00:09Z",
+          "completedTime": "2026-06-02T12:00:30Z",
+          "elapsedTime": 21,
           "resultSummary": "Command execution failed",
-          "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -6237,7 +7078,7 @@
         },
         {
           "key": "BootVolumeAttachment",
-          "value": "{device:{id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3-v8c5g},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/volume_attachments/02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,name:dynastic-caterpillar-booting-upstroke,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,id:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,name:kept-ribbon-dropdown-bunkhouse,resource_type:volume}}"
+          "value": "{device:{id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69-lc6sz},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/volume_attachments/02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,name:mocker-steersman-mushroom-stock,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-1d869fd7-f427-491a-a998-230be98d0f8f,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-1d869fd7-f427-491a-a998-230be98d0f8f,id:r026-1d869fd7-f427-491a-a998-230be98d0f8f,name:secluded-hatbox-payphone-lecturer,resource_type:volume}}"
         },
         {
           "key": "ConfidentialComputeMode",
@@ -6245,11 +7086,11 @@
         },
         {
           "key": "CreatedAt",
-          "value": "2026-05-19T02:03:58.000Z"
+          "value": "2026-06-02T11:59:25.000Z"
         },
         {
           "key": "CRN",
-          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
         },
         {
           "key": "EnableSecureBoot",
@@ -6261,15 +7102,15 @@
         },
         {
           "key": "Href",
-          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
         },
         {
           "key": "ID",
-          "value": "02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a"
+          "value": "02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4"
         },
         {
           "key": "Image",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
         },
         {
           "key": "LifecycleState",
@@ -6285,11 +7126,11 @@
         },
         {
           "key": "Name",
-          "value": "tbvrc1olv3qvn1eq963r"
+          "value": "tb1h7ijtv4sdjjt74cq4"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/network_interfaces/02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,id:02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,name:pregame-slab-pebbly-stuffed,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,id:02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,name:deftly-hastily-twelve-shelf,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/network_interfaces/02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,id:02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,name:underling-headband-jawline-dandy,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-29641c82-c582-42aa-8330-7dd5b55583c2,id:02h7-29641c82-c582-42aa-8330-7dd5b55583c2,name:cleat-overstate-dislike-settling,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "NumaCount",
@@ -6297,7 +7138,7 @@
         },
         {
           "key": "PrimaryNetworkInterface",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/network_interfaces/02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,id:02h7-2be17642-ef44-4ad0-8d4a-0d44cecec6e2,name:pregame-slab-pebbly-stuffed,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,id:02h7-e64d785e-71d2-49b2-824a-8ca8330802f7,name:deftly-hastily-twelve-shelf,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/network_interfaces/02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,id:02h7-f67cddfa-e676-4345-9ddb-f30c4ffa67af,name:underling-headband-jawline-dandy,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-29641c82-c582-42aa-8330-7dd5b55583c2,id:02h7-29641c82-c582-42aa-8330-7dd5b55583c2,name:cleat-overstate-dislike-settling,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "Profile",
@@ -6337,7 +7178,7 @@
         },
         {
           "key": "VolumeAttachments",
-          "value": "{device:{id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3-v8c5g},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a/volume_attachments/02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,id:02h7-85ef0d73-5933-40f5-8c0f-43b8354c67c3,name:dynastic-caterpillar-booting-upstroke,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,id:r026-7f897e01-22ae-415e-8793-0ab4fc7c1c06,name:kept-ribbon-dropdown-bunkhouse,resource_type:volume}}"
+          "value": "{device:{id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69-lc6sz},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4/volume_attachments/02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,id:02h7-18c2d556-6054-4a2c-aa66-cd5c81867f69,name:mocker-steersman-mushroom-stock,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-1d869fd7-f427-491a-a998-230be98d0f8f,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-1d869fd7-f427-491a-a998-230be98d0f8f,id:r026-1d869fd7-f427-491a-a998-230be98d0f8f,name:secluded-hatbox-payphone-lecturer,resource_type:volume}}"
         },
         {
           "key": "VolumeBandwidthQosMode",
@@ -6345,7 +7186,7 @@
         },
         {
           "key": "VPC",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
         },
         {
           "key": "Zone",
@@ -6356,9 +7197,9 @@
     {
       "resourceType": "node",
       "id": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbcsjiapgrtftvnunu8g",
-      "cspResourceName": "tbcsjiapgrtftvnunu8g",
-      "cspResourceId": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9",
+      "uid": "tbfb0c8hrtma9tjabtm6",
+      "cspResourceName": "tbfb0c8hrtma9tjabtm6",
+      "cspResourceId": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6",
       "name": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -6372,13 +7213,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-19 02:04:34",
+      "createdTime": "2026-06-02 12:00:00",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "ibm-au-syd",
-        "sys.createdTime": "2026-05-19 02:04:34",
-        "sys.cspResourceId": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9",
-        "sys.cspResourceName": "tbcsjiapgrtftvnunu8g",
+        "sys.createdTime": "2026-06-02 12:00:00",
+        "sys.cspResourceId": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6",
+        "sys.cspResourceName": "tbfb0c8hrtma9tjabtm6",
         "sys.id": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my06-infra101",
         "sys.labelType": "node",
@@ -6387,7 +7228,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my06-subnet-01",
-        "sys.uid": "tbcsjiapgrtftvnunu8g",
+        "sys.uid": "tbfb0c8hrtma9tjabtm6",
         "sys.vNetId": "my06-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -6395,10 +7236,10 @@
         "region": "au-syd",
         "zone": "au-syd-1"
       },
-      "publicIP": "159.23.98.92",
+      "publicIP": "159.23.94.110",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.6",
+      "privateIP": "10.0.1.4",
       "privateDNS": "",
       "rootDiskType": "general-purpose",
       "rootDiskSize": 100,
@@ -6441,32 +7282,32 @@
         "memoryGiB": 16,
         "costPerHour": 0.235
       },
-      "imageId": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
-      "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+      "imageId": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
+      "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
       "image": {
         "resourceType": "image",
-        "cspImageName": "r026-3e2370e7-648b-4c31-9305-f09265b49632",
+        "cspImageName": "r026-c8e249d4-f148-4416-a3c6-555b7a02f67d",
         "osType": "Ubuntu 22.04",
         "osArchitecture": "x86_64",
         "osDistribution": "Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)"
       },
       "vNetId": "my06-vnet-01",
-      "cspVNetId": "r026-a7ef8b86-1f9b-4b44-8720-86429cea400f",
+      "cspVNetId": "r026-5b6a8f03-385e-44ef-b1bc-825c662ed931",
       "subnetId": "my06-subnet-01",
-      "cspSubnetId": "02h7-a0b66e6e-dbca-4527-980a-20e9e6237218",
-      "networkInterface": "charcoal-groggily-tube-thinner",
+      "cspSubnetId": "02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d",
+      "networkInterface": "cast-handcraft-hulk-scalded",
       "securityGroupIds": [
         "my06-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my06-sshkey-01",
-      "cspSshKeyId": "r026-8eebf157-a783-44b5-928d-0483871a4148",
+      "cspSshKeyId": "r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD19aNuDPdYwRJ0C7cqJjtYB1B4cwXNpSpwjJpSgOeQTkLprtVKo35BNAmDANMDObhESvSFhUirKrHuD5G8hb2I=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMZia3tsPEXHAdMl3XqD20BJ7FgY29w9Zh5t4KDDweL4FDYix1xEB8GeagoakJ/0EqA0Pot7pz6z0SxH5pXZxFw=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:aAXzAs0R5JeQmb78jUcnjIMu7gCsfKJLjRi8ixUyMYc",
-        "firstUsedAt": "2026-05-19T02:04:44Z"
+        "fingerprint": "SHA256:AxjNblckKR1i97qPsF9JhDs5lyqT3XRq+W7bi6GEgpc",
+        "firstUsedAt": "2026-06-02T12:00:12Z"
       },
       "commandStatus": [
         {
@@ -6474,11 +7315,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Failed",
-          "startedTime": "2026-05-19T02:04:43Z",
-          "completedTime": "2026-05-19T02:04:53Z",
-          "elapsedTime": 10,
+          "startedTime": "2026-06-02T12:00:09Z",
+          "completedTime": "2026-06-02T12:00:30Z",
+          "elapsedTime": 21,
           "resultSummary": "Command execution failed",
-          "errorMessage": "failed to connect to target host via bastion after 3 attempts: failed to establish SSH connection to bastion host: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"
+          "errorMessage": "failed to establish SSH connection to target host: ssh: handshake failed: EOF"
         }
       ],
       "addtionalDetails": [
@@ -6496,7 +7337,7 @@
         },
         {
           "key": "BootVolumeAttachment",
-          "value": "{device:{id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42-kcj8l},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/volume_attachments/02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,name:oxymoron-rely-aspire-commotion,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-0b03e033-0b5a-4c2a-ab10-4177171712be,id:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,name:creme-reshape-super-wake,resource_type:volume}}"
+          "value": "{device:{id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199-dpdgt},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/volume_attachments/02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,name:riverside-fang-shampoo-affirm,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,id:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,name:runway-preshow-deed-truce,resource_type:volume}}"
         },
         {
           "key": "ConfidentialComputeMode",
@@ -6504,11 +7345,11 @@
         },
         {
           "key": "CreatedAt",
-          "value": "2026-05-19T02:03:59.000Z"
+          "value": "2026-06-02T11:59:22.000Z"
         },
         {
           "key": "CRN",
-          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+          "value": "crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::instance:02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
         },
         {
           "key": "EnableSecureBoot",
@@ -6520,15 +7361,15 @@
         },
         {
           "key": "Href",
-          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+          "value": "https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
         },
         {
           "key": "ID",
-          "value": "02h7_f3d4a783-9b7a-457f-9787-84add44186f9"
+          "value": "02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6"
         },
         {
           "key": "Image",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-3e2370e7-648b-4c31-9305-f09265b49632,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-3e2370e7-648b-4c31-9305-f09265b49632,id:r026-3e2370e7-648b-4c31-9305-f09265b49632,name:ibm-ubuntu-22-04-5-minimal-amd64-13,resource_type:image}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/811f8abfbd32425597dc7ba40da98fa6::image:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,href:https://au-syd.iaas.cloud.ibm.com/v1/images/r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,id:r026-c8e249d4-f148-4416-a3c6-555b7a02f67d,name:ibm-ubuntu-22-04-5-minimal-amd64-15,resource_type:image}"
         },
         {
           "key": "LifecycleState",
@@ -6544,11 +7385,11 @@
         },
         {
           "key": "Name",
-          "value": "tbcsjiapgrtftvnunu8g"
+          "value": "tbfb0c8hrtma9tjabtm6"
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/network_interfaces/02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,id:02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,name:charcoal-groggily-tube-thinner,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,id:02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,name:cylinder-hastiness-rigged-foster,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/network_interfaces/02h7-2d45942c-5b73-4894-9f98-736c8d83526f,id:02h7-2d45942c-5b73-4894-9f98-736c8d83526f,name:cast-handcraft-hulk-scalded,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,id:02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,name:festoonery-cardigan-magically-obstinate,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "NumaCount",
@@ -6556,7 +7397,7 @@
         },
         {
           "key": "PrimaryNetworkInterface",
-          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/network_interfaces/02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,id:02h7-ab2b71b6-986e-4c74-8db3-1209839ea8ce,name:charcoal-groggily-tube-thinner,primary_ip:{address:10.0.1.6,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218/reserved_ips/02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,id:02h7-6cb7e9e2-941f-4f28-9da1-6724a578e613,name:cylinder-hastiness-rigged-foster,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,id:02h7-a0b66e6e-dbca-4527-980a-20e9e6237218,name:tbg6dsf041aagmr0ojtg,resource_type:subnet}}"
+          "value": "{href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/network_interfaces/02h7-2d45942c-5b73-4894-9f98-736c8d83526f,id:02h7-2d45942c-5b73-4894-9f98-736c8d83526f,name:cast-handcraft-hulk-scalded,primary_ip:{address:10.0.1.4,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d/reserved_ips/02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,id:02h7-eb5f7396-9c2b-42b7-9fb6-cc21304b10bf,name:festoonery-cardigan-magically-obstinate,resource_type:subnet_reserved_ip},resource_type:network_interface,subnet:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::subnet:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,href:https://au-syd.iaas.cloud.ibm.com/v1/subnets/02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,id:02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d,name:tbif7mdf8fhjkp0ck6ut,resource_type:subnet}}"
         },
         {
           "key": "Profile",
@@ -6596,7 +7437,7 @@
         },
         {
           "key": "VolumeAttachments",
-          "value": "{device:{id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42-kcj8l},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_f3d4a783-9b7a-457f-9787-84add44186f9/volume_attachments/02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,id:02h7-9e0b26ac-e163-452e-a4b6-5ee6e9dd7c42,name:oxymoron-rely-aspire-commotion,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-0b03e033-0b5a-4c2a-ab10-4177171712be,id:r026-0b03e033-0b5a-4c2a-ab10-4177171712be,name:creme-reshape-super-wake,resource_type:volume}}"
+          "value": "{device:{id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199-dpdgt},href:https://au-syd.iaas.cloud.ibm.com/v1/instances/02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6/volume_attachments/02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,id:02h7-fc17086e-3af1-45a6-af02-459cc2b8b199,name:riverside-fang-shampoo-affirm,volume:{crn:crn:v1:bluemix:public:is:au-syd-1:a/ab205347a7c3b57f09dabb32df178bcf::volume:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,href:https://au-syd.iaas.cloud.ibm.com/v1/volumes/r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,id:r026-01f48f90-c0ec-4014-9ac9-cb4b2db80737,name:runway-preshow-deed-truce,resource_type:volume}}"
         },
         {
           "key": "VolumeBandwidthQosMode",
@@ -6604,7 +7445,7 @@
         },
         {
           "key": "VPC",
-          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,id:r026-a7ef8b86-1f9b-4b44-8720-86429cea400f,name:tbqruv517cf8m1599d8a,resource_type:vpc}"
+          "value": "{crn:crn:v1:bluemix:public:is:au-syd:a/ab205347a7c3b57f09dabb32df178bcf::vpc:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,href:https://au-syd.iaas.cloud.ibm.com/v1/vpcs/r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,id:r026-5b6a8f03-385e-44ef-b1bc-825c662ed931,name:tbans8fa21l4pkrjo0a0,resource_type:vpc}"
         },
         {
           "key": "Zone",
@@ -6625,18 +7466,22 @@
       {
         "infraId": "my06-infra101",
         "nodeId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "159.23.91.41",
+        "nodeIp": "159.23.102.221",
         "command": {
           "0": "uname -a"
         },
-        "stdout": {},
-        "stderr": {},
+        "stdout": {
+          "0": "Linux tbt7k7116g5o02ekkgfm 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
         "err": null
       },
       {
         "infraId": "my06-infra101",
         "nodeId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "159.23.91.42",
+        "nodeIp": "159.23.98.218",
         "command": {
           "0": "uname -a"
         },
@@ -6647,7 +7492,7 @@
       {
         "infraId": "my06-infra101",
         "nodeId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "159.23.98.92",
+        "nodeIp": "159.23.94.110",
         "command": {
           "0": "uname -a"
         },
@@ -6706,8 +7551,8 @@
       "command": "uname -a",
       "nodeGroup": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux tbgohfsamsafahcqbms3 5.15.0-1095-ibm #98-Ubuntu SMP Wed Feb 11 00:14:35 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "159.23.91.41",
+      "output": "Linux tbt7k7116g5o02ekkgfm 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "159.23.102.221",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -6718,8 +7563,8 @@
       "command": "uname -a",
       "nodeGroup": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux tbvrc1olv3qvn1eq963r 5.15.0-1095-ibm #98-Ubuntu SMP Wed Feb 11 00:14:35 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "159.23.91.42",
+      "output": "Linux tb1h7ijtv4sdjjt74cq4 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "159.23.98.218",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -6730,8 +7575,8 @@
       "command": "uname -a",
       "nodeGroup": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux tbcsjiapgrtftvnunu8g 5.15.0-1095-ibm #98-Ubuntu SMP Wed Feb 11 00:14:35 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "159.23.98.92",
+      "output": "Linux tbfb0c8hrtma9tjabtm6 5.15.0-1100-ibm #103-Ubuntu SMP Mon Apr 20 14:53:14 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "159.23.94.110",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -6761,7 +7606,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-19 02:05:43
+**Generated At:** 2026-06-02 12:01:20
 
 **Namespace:** mig01
 
@@ -6797,15 +7642,15 @@
 
 | Name | Distribution | OS Type | OS Platform | Architecture | Root Disk Type | Root Disk Size | VMs Using This Image |
 |------|--------------|---------|-------------|--------------|----------------|----------------|----------------------|
-| r026-3e2370e7-648b-4c31-9305-f09265b49632 | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | - | 3 |
+| r026-c8e249d4-f148-4416-a3c6-555b7a02f67d | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | Ubuntu 22.04 | Linux/UNIX | x86_64 | NA | - | 3 |
 
 ### Virtual Machines
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f | Running | 2 vCPU, 2.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.91.41<br>**Private IP:** 10.0.1.5<br>**SGs:** my06-sg-01<br>**SSH:** my06-sshkey-01 |
-| my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a | Running | 2 vCPU, 8.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.91.42<br>**Private IP:** 10.0.1.4<br>**SGs:** my06-sg-03<br>**SSH:** my06-sshkey-01 |
-| my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 02h7_f3d4a783-9b7a-457f-9787-84add44186f9 | Running | 4 vCPU, 16.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.98.92<br>**Private IP:** 10.0.1.6<br>**SGs:** my06-sg-02<br>**SSH:** my06-sshkey-01 |
+| my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457 | Running | 2 vCPU, 2.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.102.221<br>**Private IP:** 10.0.1.5<br>**SGs:** my06-sg-01<br>**SSH:** my06-sshkey-01 |
+| my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4 | Running | 2 vCPU, 8.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.98.218<br>**Private IP:** 10.0.1.6<br>**SGs:** my06-sg-03<br>**SSH:** my06-sshkey-01 |
+| my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6 | Running | 4 vCPU, 16.0 GiB | Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) (Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64)) | **VNet:** my06-vnet-01<br>**Subnet:** my06-subnet-01<br>**Public IP:** 159.23.94.110<br>**Private IP:** 10.0.1.4<br>**SGs:** my06-sg-02<br>**SSH:** my06-sshkey-01 |
 
 
 ## Network Resources
@@ -6817,7 +7662,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-vnet-01 |
-| **CSP VNet ID** | r026-a7ef8b86-1f9b-4b44-8720-86429cea400f |
+| **CSP VNet ID** | r026-5b6a8f03-385e-44ef-b1bc-825c662ed931 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | ibm-au-syd |
 | **Subnet Count** | 1 |
@@ -6826,7 +7671,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my06-subnet-01 | 02h7-a0b66e6e-dbca-4527-980a-20e9e6237218 | 10.0.1.0/24 | au-syd-1 |
+| my06-subnet-01 | 02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d | 10.0.1.0/24 | au-syd-1 |
 
 
 ## Security Resources
@@ -6835,7 +7680,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my06-sshkey-01 | r026-8eebf157-a783-44b5-928d-0483871a4148 |  | SHA256:sYz80Z4IeGL3THfON6dTQifM2Lera2g8BaoVL37ccOo |
+| my06-sshkey-01 | r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb |  | SHA256:TvBOM01LhEtmxXCF8izGk3MZUyQr9cHun/EEuzIgBLY |
 
 ### Security Groups
 
@@ -6844,7 +7689,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-sg-01 |
-| **CSP Security Group ID** | r026-46eea056-e6af-4b54-89af-d772afbe34a4 |
+| **CSP Security Group ID** | r026-cc7a1860-d3e6-4d83-a31f-753910673746 |
 | **VNet** | my06-vnet-01 |
 | **Rule Count** | 14 rules |
 
@@ -6872,7 +7717,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-sg-02 |
-| **CSP Security Group ID** | r026-c9a5b2c1-7c4c-4667-9dc0-a9dfe3019693 |
+| **CSP Security Group ID** | r026-09e47208-047d-4485-8bd2-19d7a50feb71 |
 | **VNet** | my06-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -6905,7 +7750,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my06-sg-03 |
-| **CSP Security Group ID** | r026-7090750f-4896-4245-a120-a41155025729 |
+| **CSP Security Group ID** | r026-6e6f8825-c77d-4255-af1a-3eeeaad54cbc |
 | **VNet** | my06-vnet-01 |
 | **Rule Count** | 19 rules |
 
@@ -6980,7 +7825,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-19 02:05:49*
+*Report generated: 2026-06-02 12:01:25*
 
 ---
 
@@ -7009,7 +7854,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | nxf-2x2, bxf-2x8, bxf-4x16 |
+| 2 | **VM Spec** | 3 | ✅ Selected | bxf-2x8, bxf-4x16, nxf-2x2 |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my06-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my06-vnet-01) |
@@ -7024,9 +7869,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 02h7_20b28aa2-9b92-44f4-b118-bfb41cde9f8f<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 02h7_17da4537-eef8-454d-a76f-d1dd5df99a6a<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 02h7_f3d4a783-9b7a-457f-9787-84add44186f9<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 02h7_19d7fc00-e7df-4a3c-b2cc-fa3322e13457<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 02h7_95a5c89f-123a-4b3a-844f-7df4b78274c4<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 02h7_9472bbc0-6de5-4bbe-af5f-cb0b60ba15c6<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -7048,9 +7893,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** r026-3e2370e7-648b-4c31-9305-f09265b49632<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** r026-3e2370e7-648b-4c31-9305-f09265b49632<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** r026-3e2370e7-648b-4c31-9305-f09265b49632<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my06-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** r026-c8e249d4-f148-4416-a3c6-555b7a02f67d<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 2 | my06-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Image ID:** r026-c8e249d4-f148-4416-a3c6-555b7a02f67d<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 3 | my06-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Image ID:** r026-c8e249d4-f148-4416-a3c6-555b7a02f67d<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64) | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
 
 ---
 
@@ -7060,7 +7905,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my06-sg-01
 
-**CSP ID:** r026-46eea056-e6af-4b54-89af-d772afbe34a4 | **VNet:** my06-vnet-01 | **Rules:** 14
+**CSP ID:** r026-cc7a1860-d3e6-4d83-a31f-753910673746 | **VNet:** my06-vnet-01 | **Rules:** 14
 
 **Assigned VMs:**
 
@@ -7088,7 +7933,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my06-sg-02
 
-**CSP ID:** r026-c9a5b2c1-7c4c-4667-9dc0-a9dfe3019693 | **VNet:** my06-vnet-01 | **Rules:** 19
+**CSP ID:** r026-09e47208-047d-4485-8bd2-19d7a50feb71 | **VNet:** my06-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7121,7 +7966,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my06-sg-03
 
-**CSP ID:** r026-7090750f-4896-4245-a120-a41155025729 | **VNet:** my06-vnet-01 | **Rules:** 19
+**CSP ID:** r026-6e6f8825-c77d-4255-af1a-3eeeaad54cbc | **VNet:** my06-vnet-01 | **Rules:** 19
 
 **Assigned VMs:**
 
@@ -7162,13 +8007,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my06-vnet-01<br>**ID:** r026-a7ef8b86-1f9b-4b44-8720-86429cea400f | 10.0.0.0/21 |
+| 1 | **Name:** my06-vnet-01<br>**ID:** r026-5b6a8f03-385e-44ef-b1bc-825c662ed931 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my06-subnet-01<br>**ID:** 02h7-a0b66e6e-dbca-4527-980a-20e9e6237218 | 10.0.1.0/24 | my06-vnet-01 |
+| 1 | **Name:** my06-subnet-01<br>**ID:** 02h7-3a33398e-c6ca-4655-863a-99dbdad0a91d | 10.0.1.0/24 | my06-vnet-01 |
 
 ### Source Network Information
 
@@ -7210,7 +8055,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my06-sshkey-01 | r026-8eebf157-a783-44b5-928d-0483871a4148 | SHA256:sYz80Z4IeGL3THfON6dTQifM2Lera2g8BaoVL37ccOo | Used by all 3 VMs |
+| 1 | my06-sshkey-01 | r026-19980fa4-1edc-4a64-9b7d-4a3d029ed2cb | SHA256:TvBOM01LhEtmxXCF8izGk3MZUyQr9cHun/EEuzIgBLY | Used by all 3 VMs |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-results-ncp.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-results-ncp.md
@@ -7,19 +7,19 @@
 
 ### Environment
 
-- CM-Beetle: imdl/v0.1.5+ (c574040)
-- cm-model: unknown
-- CB-Tumblebug: vunknown
-- CB-Spider: vunknown
-- CB-MapUI: vunknown
+- CM-Beetle: imdl/v0.1.5+ (4987539)
+- imdl: v0.1.5+ (4987539)
+- CB-Tumblebug: v0.12.13
+- CB-Spider: v0.12.26
+- CB-MapUI: v0.12.34
 - Target CSP: NCP
 - Target Region: kr
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: May 18, 2026
-- Test Time: 17:01:42 KST
-- Test Execution: 2026-05-18 17:01:42 KST
+- Test Date: June 2, 2026
+- Test Time: 20:57:11 KST
+- Test Execution: 2026-06-02 20:57:11 KST
 
 ### Scenario
 
@@ -42,21 +42,21 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 2m24.067s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 7m33.995s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 18ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 3ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 12ms | Pass |
+| 1 | `POST /beetle/recommendation/infra` | ✅ **PASS** | 2m15.919s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 7m24.368s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1.069s | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 7ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 26ms | Pass |
 | 6 | Remote Command Accessibility Check | ✅ **PASS** | 0s | Pass |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.252s | Pass |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.253s | Pass |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 2m12.229s | Pass |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.954s | Pass |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.433s | Pass |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 2m14.464s | Pass |
 
 **Overall Result**: 9/9 tests passed ✅
 
-**Total Duration**: 13m34.78116931s
+**Total Duration**: 13m20.277151806s
 
-*Test executed on May 18, 2026 at 17:01:42 KST (2026-05-18 17:01:42 KST) using CM-Beetle automated test CLI*
+*Test executed on June 2, 2026 at 20:57:11 KST (2026-06-02 20:57:11 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -2004,7 +2004,7 @@
             },
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "ncp-kr",
-            "specId": "ncp+kr+s2-g3a",
+            "specId": "ncp+kr+s2-g3",
             "imageId": "23214590",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
@@ -2049,7 +2049,7 @@
       "targetSpecList": [
         {
           "id": "ncp+kr+ci2-g3",
-          "uid": "d7k8jh5q1uu3ogmsvp00",
+          "uid": "tb1hjl118fhlft06gqiv",
           "cspSpecName": "ci2-g3",
           "name": "ncp+kr+ci2-g3",
           "namespace": "system",
@@ -2138,7 +2138,7 @@
         },
         {
           "id": "ncp+kr+s4-g3a",
-          "uid": "d7k8jh5q1uu3ogmsvptg",
+          "uid": "tbnv61o0jd4es54audav",
           "cspSpecName": "s4-g3a",
           "name": "ncp+kr+s4-g3a",
           "namespace": "system",
@@ -2226,10 +2226,10 @@
           ]
         },
         {
-          "id": "ncp+kr+s2-g3a",
-          "uid": "d7k8jh5q1uu3ogmsvp90",
-          "cspSpecName": "s2-g3a",
-          "name": "ncp+kr+s2-g3a",
+          "id": "ncp+kr+s2-g3",
+          "uid": "tbp0q60obnqfd757cnbg",
+          "cspSpecName": "s2-g3",
+          "name": "ncp+kr+s2-g3",
           "namespace": "system",
           "connectionName": "ncp-kr",
           "providerName": "ncp",
@@ -2258,7 +2258,7 @@
           "details": [
             {
               "key": "ServerSpecCode",
-              "value": "s2-g3a"
+              "value": "s2-g3"
             },
             {
               "key": "GenerationCode",
@@ -2302,7 +2302,7 @@
             },
             {
               "key": "ServerProductCode",
-              "value": "SVR.VSVR.AMD.STAND.C002.M008.G003"
+              "value": "SVR.VSVR.STAND.C002.M008.G003"
             },
             {
               "key": "ServerSpecDescription",
@@ -2310,7 +2310,7 @@
             },
             {
               "key": "CorrespondingImageIds",
-              "value": "109093105,107029409,104630229,100524418,25495367,23221307,23221289,23214590,19463675,17552318"
+              "value": "109093105,107029409,104630229,100524418,25495367,23221307,23221289,23214590,19463675,17552318,16946033"
             }
           ]
         }
@@ -2325,13 +2325,13 @@
             "kr"
           ],
           "id": "23214590",
-          "uid": "d7k8jndq1uu3ogmt0uo0",
+          "uid": "tbr0fa5o2bknrgbf32kg",
           "name": "23214590",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "ncp-kr",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:05 Wed",
+          "fetchedTime": "2026.05.27 06:32:45 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -2794,7 +2794,7 @@
             },
             "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
             "connectionName": "ncp-kr",
-            "specId": "ncp+kr+s2-g3",
+            "specId": "ncp+kr+s2-g3a",
             "imageId": "23214590",
             "vNetId": "vnet-01",
             "subnetId": "subnet-01",
@@ -2839,7 +2839,7 @@
       "targetSpecList": [
         {
           "id": "ncp+kr+ci2-g3",
-          "uid": "d7k8jh5q1uu3ogmsvp00",
+          "uid": "tb1hjl118fhlft06gqiv",
           "cspSpecName": "ci2-g3",
           "name": "ncp+kr+ci2-g3",
           "namespace": "system",
@@ -2928,7 +2928,7 @@
         },
         {
           "id": "ncp+kr+s4-g3a",
-          "uid": "d7k8jh5q1uu3ogmsvptg",
+          "uid": "tbnv61o0jd4es54audav",
           "cspSpecName": "s4-g3a",
           "name": "ncp+kr+s4-g3a",
           "namespace": "system",
@@ -3016,8 +3016,97 @@
           ]
         },
         {
+          "id": "ncp+kr+s2-g3",
+          "uid": "tbp0q60obnqfd757cnbg",
+          "cspSpecName": "s2-g3",
+          "name": "ncp+kr+s2-g3",
+          "namespace": "system",
+          "connectionName": "ncp-kr",
+          "providerName": "ncp",
+          "regionName": "kr",
+          "regionLatitude": 37.4754,
+          "regionLongitude": 126.8831,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 2,
+          "memoryGiB": 8,
+          "diskSizeGB": -1,
+          "costPerHour": 0.0848,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "default",
+          "rootDiskSize": 0,
+          "systemLabel": "from-assets",
+          "details": [
+            {
+              "key": "ServerSpecCode",
+              "value": "s2-g3"
+            },
+            {
+              "key": "GenerationCode",
+              "value": "G3"
+            },
+            {
+              "key": "CpuCount",
+              "value": "2"
+            },
+            {
+              "key": "MemorySize",
+              "value": "8589934592"
+            },
+            {
+              "key": "HypervisorType",
+              "value": "{code:KVM,codeName:KVM}"
+            },
+            {
+              "key": "CpuArchitectureType",
+              "value": "{code:X86_64,codeName:x86 64bit}"
+            },
+            {
+              "key": "BlockStorageMaxCount",
+              "value": "20"
+            },
+            {
+              "key": "BlockStorageMaxIops",
+              "value": "4725"
+            },
+            {
+              "key": "BlockStorageMaxThroughput",
+              "value": "84934656"
+            },
+            {
+              "key": "NetworkPerformance",
+              "value": "1000000000"
+            },
+            {
+              "key": "NetworkInterfaceMaxCount",
+              "value": "3"
+            },
+            {
+              "key": "ServerProductCode",
+              "value": "SVR.VSVR.STAND.C002.M008.G003"
+            },
+            {
+              "key": "ServerSpecDescription",
+              "value": "vCPU 2EA, Memory 8GB"
+            },
+            {
+              "key": "CorrespondingImageIds",
+              "value": "109093105,107029409,104630229,100524418,25495367,23221307,23221289,23214590,19463675,17552318,16946033"
+            }
+          ]
+        },
+        {
           "id": "ncp+kr+s2-g3a",
-          "uid": "d7k8jh5q1uu3ogmsvp90",
+          "uid": "tbbch4tlg6bd8vgk56u2",
           "cspSpecName": "s2-g3a",
           "name": "ncp+kr+s2-g3a",
           "namespace": "system",
@@ -3106,7 +3195,7 @@
         },
         {
           "id": "ncp+kr+s4-g3",
-          "uid": "d7k8jh5q1uu3ogmsvpbg",
+          "uid": "tb733sv5thhtqt761ubr",
           "cspSpecName": "s4-g3",
           "name": "ncp+kr+s4-g3",
           "namespace": "system",
@@ -3192,95 +3281,6 @@
               "value": "109093105,107029409,104630229,100524418,25495367,23221307,23221289,23214590,19463675,17552318,16946033"
             }
           ]
-        },
-        {
-          "id": "ncp+kr+s2-g3",
-          "uid": "d7k8jh5q1uu3ogmsvovg",
-          "cspSpecName": "s2-g3",
-          "name": "ncp+kr+s2-g3",
-          "namespace": "system",
-          "connectionName": "ncp-kr",
-          "providerName": "ncp",
-          "regionName": "kr",
-          "regionLatitude": 37.4754,
-          "regionLongitude": 126.8831,
-          "infraType": "node",
-          "architecture": "x86_64",
-          "vCPU": 2,
-          "memoryGiB": 8,
-          "diskSizeGB": -1,
-          "costPerHour": 0.0848,
-          "evaluationScore01": -1,
-          "evaluationScore02": -1,
-          "evaluationScore03": -1,
-          "evaluationScore04": -1,
-          "evaluationScore05": -1,
-          "evaluationScore06": -1,
-          "evaluationScore07": -1,
-          "evaluationScore08": -1,
-          "evaluationScore09": -1,
-          "evaluationScore10": -1,
-          "rootDiskType": "default",
-          "rootDiskSize": 0,
-          "systemLabel": "from-assets",
-          "details": [
-            {
-              "key": "ServerSpecCode",
-              "value": "s2-g3"
-            },
-            {
-              "key": "GenerationCode",
-              "value": "G3"
-            },
-            {
-              "key": "CpuCount",
-              "value": "2"
-            },
-            {
-              "key": "MemorySize",
-              "value": "8589934592"
-            },
-            {
-              "key": "HypervisorType",
-              "value": "{code:KVM,codeName:KVM}"
-            },
-            {
-              "key": "CpuArchitectureType",
-              "value": "{code:X86_64,codeName:x86 64bit}"
-            },
-            {
-              "key": "BlockStorageMaxCount",
-              "value": "20"
-            },
-            {
-              "key": "BlockStorageMaxIops",
-              "value": "4725"
-            },
-            {
-              "key": "BlockStorageMaxThroughput",
-              "value": "84934656"
-            },
-            {
-              "key": "NetworkPerformance",
-              "value": "1000000000"
-            },
-            {
-              "key": "NetworkInterfaceMaxCount",
-              "value": "3"
-            },
-            {
-              "key": "ServerProductCode",
-              "value": "SVR.VSVR.STAND.C002.M008.G003"
-            },
-            {
-              "key": "ServerSpecDescription",
-              "value": "vCPU 2EA, Memory 8GB"
-            },
-            {
-              "key": "CorrespondingImageIds",
-              "value": "109093105,107029409,104630229,100524418,25495367,23221307,23221289,23214590,19463675,17552318,16946033"
-            }
-          ]
         }
       ],
       "targetOsImageList": [
@@ -3293,13 +3293,13 @@
             "kr"
           ],
           "id": "23214590",
-          "uid": "d7k8jndq1uu3ogmt0uo0",
+          "uid": "tbr0fa5o2bknrgbf32kg",
           "name": "23214590",
           "sourceNodeUid": "",
           "sourceCspImageName": "",
           "connectionName": "ncp-kr",
           "infraType": "",
-          "fetchedTime": "2026.04.22 08:42:05 Wed",
+          "fetchedTime": "2026.05.27 06:32:45 Wed",
           "creationDate": "",
           "isGPUImage": false,
           "isKubernetesImage": false,
@@ -3731,7 +3731,7 @@
 {
   "resourceType": "infra",
   "id": "my08-infra101",
-  "uid": "tbd85ch6epr9ha6omvqjlg",
+  "uid": "tb9k4svj3amakfqac867",
   "name": "my08-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -3759,7 +3759,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my08-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85ch6epr9ha6omvqjlg"
+    "sys.uid": "tb9k4svj3amakfqac867"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -3768,9 +3768,9 @@
     {
       "resourceType": "node",
       "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85ch6epr9ha6omvqjmg",
-      "cspResourceName": "tbd85ch6epr9ha6omvqjmg",
-      "cspResourceId": "138993641",
+      "uid": "tbca72iou035q8bsubcf",
+      "cspResourceName": "tbca72iou035q8bsubcf",
+      "cspResourceId": "140607082",
       "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -3784,13 +3784,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:10:58",
+      "createdTime": "2026-06-02 12:06:31",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-18 08:10:58",
-        "sys.cspResourceId": "138993641",
-        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+        "sys.createdTime": "2026-06-02 12:06:31",
+        "sys.cspResourceId": "140607082",
+        "sys.cspResourceName": "tbca72iou035q8bsubcf",
         "sys.id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
@@ -3799,7 +3799,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my08-subnet-01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjmg",
+        "sys.uid": "tbca72iou035q8bsubcf",
         "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=50.0% Image=75.0%",
@@ -3807,10 +3807,10 @@
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "223.130.156.82",
+      "publicIP": "101.79.10.57",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.7",
+      "privateIP": "10.0.1.6",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -3862,22 +3862,22 @@
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
       "vNetId": "my08-vnet-01",
-      "cspVNetId": "139135",
+      "cspVNetId": "139881",
       "subnetId": "my08-subnet-01",
-      "cspSubnetId": "300855",
+      "cspSubnetId": "302650",
       "networkInterface": "eth0",
       "securityGroupIds": [
         "my08-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my08-sshkey-01",
-      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+      "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-18T08:11:04Z"
+        "firstUsedAt": "2026-06-02T12:06:59Z"
       },
       "commandStatus": [
         {
@@ -3885,22 +3885,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:11:03Z",
-          "completedTime": "2026-05-18T08:11:05Z",
-          "elapsedTime": 2,
+          "startedTime": "2026-06-02T12:06:59Z",
+          "completedTime": "2026-06-02T12:07:00Z",
+          "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbca72iou035q8bsubcf 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138993641"
+          "value": "140607082"
         },
         {
           "key": "ServerName",
-          "value": "tbd85ch6epr9ha6omvqjmg"
+          "value": "tbca72iou035q8bsubcf"
         },
         {
           "key": "CpuCount",
@@ -3916,7 +3916,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd85cg56pr9ha6omvqjj0"
+          "value": "tbbaetbunj5ueuro7mrm"
         },
         {
           "key": "ServerInstanceStatus",
@@ -3932,11 +3932,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-18T17:06:55+0900"
+          "value": "2026-06-02T21:02:39+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-18T17:09:13+0900"
+          "value": "2026-06-02T21:04:51+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -3960,19 +3960,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "139135"
+          "value": "139881"
         },
         {
           "key": "SubnetNo",
-          "value": "300855"
+          "value": "302650"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5694779"
+          "value": "5722303"
         },
         {
           "key": "InitScriptNo",
-          "value": "171473"
+          "value": "173391"
         },
         {
           "key": "ServerInstanceType",
@@ -4003,9 +4003,9 @@
     {
       "resourceType": "node",
       "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85ch6epr9ha6omvqjog",
-      "cspResourceName": "tbd85ch6epr9ha6omvqjog",
-      "cspResourceId": "138993649",
+      "uid": "tb62kdji13343nefcgpa",
+      "cspResourceName": "tb62kdji13343nefcgpa",
+      "cspResourceId": "140607087",
       "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -4019,13 +4019,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:10:58",
+      "createdTime": "2026-06-02 12:06:54",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-18 08:10:58",
-        "sys.cspResourceId": "138993649",
-        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjog",
+        "sys.createdTime": "2026-06-02 12:06:54",
+        "sys.cspResourceId": "140607087",
+        "sys.cspResourceName": "tb62kdji13343nefcgpa",
         "sys.id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
@@ -4034,7 +4034,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my08-subnet-01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjog",
+        "sys.uid": "tb62kdji13343nefcgpa",
         "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -4042,10 +4042,10 @@
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.20.97",
+      "publicIP": "223.130.162.232",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.8",
+      "privateIP": "10.0.1.7",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -4079,10 +4079,10 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "ncp+kr+s2-g3a",
-      "cspSpecName": "s2-g3a",
+      "specId": "ncp+kr+s2-g3",
+      "cspSpecName": "s2-g3",
       "spec": {
-        "cspSpecName": "s2-g3a",
+        "cspSpecName": "s2-g3",
         "vCPU": 2,
         "memoryGiB": 8,
         "costPerHour": 0.0848
@@ -4097,22 +4097,22 @@
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
       "vNetId": "my08-vnet-01",
-      "cspVNetId": "139135",
+      "cspVNetId": "139881",
       "subnetId": "my08-subnet-01",
-      "cspSubnetId": "300855",
+      "cspSubnetId": "302650",
       "networkInterface": "eth0",
       "securityGroupIds": [
         "my08-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my08-sshkey-01",
-      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+      "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-18T08:11:04Z"
+        "firstUsedAt": "2026-06-02T12:07:00Z"
       },
       "commandStatus": [
         {
@@ -4120,22 +4120,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:11:03Z",
-          "completedTime": "2026-05-18T08:11:05Z",
+          "startedTime": "2026-06-02T12:06:59Z",
+          "completedTime": "2026-06-02T12:07:01Z",
           "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb62kdji13343nefcgpa 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138993649"
+          "value": "140607087"
         },
         {
           "key": "ServerName",
-          "value": "tbd85ch6epr9ha6omvqjog"
+          "value": "tb62kdji13343nefcgpa"
         },
         {
           "key": "CpuCount",
@@ -4151,7 +4151,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd85cg56pr9ha6omvqjj0"
+          "value": "tbbaetbunj5ueuro7mrm"
         },
         {
           "key": "ServerInstanceStatus",
@@ -4167,11 +4167,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-18T17:06:58+0900"
+          "value": "2026-06-02T21:02:40+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-18T17:09:11+0900"
+          "value": "2026-06-02T21:05:00+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -4179,7 +4179,7 @@
         },
         {
           "key": "ServerProductCode",
-          "value": "SVR.VSVR.AMD.STAND.C002.M008.G003"
+          "value": "SVR.VSVR.STAND.C002.M008.G003"
         },
         {
           "key": "IsProtectServerTermination",
@@ -4195,19 +4195,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "139135"
+          "value": "139881"
         },
         {
           "key": "SubnetNo",
-          "value": "300855"
+          "value": "302650"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5694780"
+          "value": "5722304"
         },
         {
           "key": "InitScriptNo",
-          "value": "171474"
+          "value": "173392"
         },
         {
           "key": "ServerInstanceType",
@@ -4231,16 +4231,16 @@
         },
         {
           "key": "ServerSpecCode",
-          "value": "s2-g3a"
+          "value": "s2-g3"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85ch6epr9ha6omvqjng",
-      "cspResourceName": "tbd85ch6epr9ha6omvqjng",
-      "cspResourceId": "138993635",
+      "uid": "tb926lt0j2uls25i7d2u",
+      "cspResourceName": "tb926lt0j2uls25i7d2u",
+      "cspResourceId": "140607099",
       "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -4254,13 +4254,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:10:47",
+      "createdTime": "2026-06-02 12:06:31",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-18 08:10:47",
-        "sys.cspResourceId": "138993635",
-        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjng",
+        "sys.createdTime": "2026-06-02 12:06:31",
+        "sys.cspResourceId": "140607099",
+        "sys.cspResourceName": "tb926lt0j2uls25i7d2u",
         "sys.id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
@@ -4269,7 +4269,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my08-subnet-01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjng",
+        "sys.uid": "tb926lt0j2uls25i7d2u",
         "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -4277,10 +4277,10 @@
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.16.239",
+      "publicIP": "101.79.20.104",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.6",
+      "privateIP": "10.0.1.8",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -4332,22 +4332,22 @@
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
       "vNetId": "my08-vnet-01",
-      "cspVNetId": "139135",
+      "cspVNetId": "139881",
       "subnetId": "my08-subnet-01",
-      "cspSubnetId": "300855",
+      "cspSubnetId": "302650",
       "networkInterface": "eth0",
       "securityGroupIds": [
         "my08-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my08-sshkey-01",
-      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+      "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-18T08:11:03Z"
+        "firstUsedAt": "2026-06-02T12:07:00Z"
       },
       "commandStatus": [
         {
@@ -4355,22 +4355,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:11:03Z",
-          "completedTime": "2026-05-18T08:11:04Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-06-02T12:06:59Z",
+          "completedTime": "2026-06-02T12:07:01Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb926lt0j2uls25i7d2u 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138993635"
+          "value": "140607099"
         },
         {
           "key": "ServerName",
-          "value": "tbd85ch6epr9ha6omvqjng"
+          "value": "tb926lt0j2uls25i7d2u"
         },
         {
           "key": "CpuCount",
@@ -4386,7 +4386,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd85cg56pr9ha6omvqjj0"
+          "value": "tbbaetbunj5ueuro7mrm"
         },
         {
           "key": "ServerInstanceStatus",
@@ -4402,11 +4402,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-18T17:06:54+0900"
+          "value": "2026-06-02T21:02:42+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-18T17:09:08+0900"
+          "value": "2026-06-02T21:04:42+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -4430,19 +4430,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "139135"
+          "value": "139881"
         },
         {
           "key": "SubnetNo",
-          "value": "300855"
+          "value": "302650"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5694778"
+          "value": "5722305"
         },
         {
           "key": "InitScriptNo",
-          "value": "171472"
+          "value": "173393"
         },
         {
           "key": "ServerInstanceType",
@@ -4482,13 +4482,28 @@
     "results": [
       {
         "infraId": "my08-infra101",
-        "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "101.79.16.239",
+        "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "101.79.10.57",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbca72iou035q8bsubcf 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "101.79.20.104",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux tb926lt0j2uls25i7d2u 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4498,27 +4513,12 @@
       {
         "infraId": "my08-infra101",
         "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "101.79.20.97",
+        "nodeIp": "223.130.162.232",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my08-infra101",
-        "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "223.130.156.82",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb62kdji13343nefcgpa 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4553,8 +4553,838 @@
   "infra": [
     {
       "resourceType": "infra",
+      "id": "my03-infra101",
+      "uid": "tb9k0f3jkc5cjd97jlad",
+      "name": "my03-infra101",
+      "status": "Terminating:3 (R:0/3)",
+      "statusCount": {
+        "countTotal": 3,
+        "countCreating": 0,
+        "countRunning": 0,
+        "countFailed": 0,
+        "countSuspended": 0,
+        "countRebooting": 0,
+        "countTerminated": 0,
+        "countSuspending": 0,
+        "countResuming": 0,
+        "countTerminating": 3,
+        "countRegistering": 0,
+        "countUndefined": 0
+      },
+      "targetStatus": "Terminated",
+      "targetAction": "Terminate",
+      "installMonAgent": "",
+      "configureCloudAdaptiveNetwork": "",
+      "label": {
+        "sys.description": "Recommended VMs comprising multi-cloud infrastructure",
+        "sys.id": "my03-infra101",
+        "sys.labelType": "infra",
+        "sys.manager": "cb-tumblebug",
+        "sys.name": "my03-infra101",
+        "sys.namespace": "mig01",
+        "sys.uid": "tb9k0f3jkc5cjd97jlad"
+      },
+      "systemLabel": "",
+      "systemMessage": null,
+      "description": "Recommended VMs comprising multi-cloud infrastructure",
+      "node": [
+        {
+          "resourceType": "node",
+          "id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "uid": "tb5aad3lmo0gt6dfk9uj",
+          "cspResourceName": "tb5aad3lmo0gt6dfk9uj",
+          "cspResourceId": "tb5aad3lmo0gt6dfk9uj",
+          "name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+          "nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.2,
+            "longitude": 127
+          },
+          "status": "Terminating",
+          "targetStatus": "Terminated",
+          "targetAction": "Terminate",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-06-02 12:05:04",
+          "label": {
+            "keypair": "tb6kf3c8jjcig0aqofjm",
+            "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.connectionName": "gcp-asia-northeast3",
+            "sys.createdTime": "2026-06-02 12:05:04",
+            "sys.cspResourceId": "tb5aad3lmo0gt6dfk9uj",
+            "sys.cspResourceName": "tb5aad3lmo0gt6dfk9uj",
+            "sys.id": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.infraId": "my03-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "sys.subnetId": "my03-subnet-01",
+            "sys.uid": "tb5aad3lmo0gt6dfk9uj",
+            "sys.vNetId": "my03-vnet-01"
+          },
+          "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": "asia-northeast3",
+            "zone": "asia-northeast3-a"
+          },
+          "publicIP": "34.158.221.135",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.2",
+          "privateDNS": "",
+          "rootDiskType": "pd-standard",
+          "rootDiskSize": 10,
+          "RootDeviceName": "persistent-disk-0",
+          "connectionName": "gcp-asia-northeast3",
+          "connectionConfig": {
+            "configName": "gcp-asia-northeast3",
+            "providerName": "gcp",
+            "driverName": "gcp-driver-v1.0.so",
+            "credentialName": "gcp",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "gcp-asia-northeast3",
+            "regionZoneInfo": {
+              "assignedRegion": "asia-northeast3",
+              "assignedZone": "asia-northeast3-a"
+            },
+            "regionDetail": {
+              "regionId": "asia-northeast3",
+              "regionName": "asia-northeast3",
+              "description": "Seoul South Korea",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.2,
+                "longitude": 127
+              },
+              "zones": [
+                "asia-northeast3-a",
+                "asia-northeast3-b",
+                "asia-northeast3-c"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "gcp+asia-northeast3+e2-highcpu-2",
+          "cspSpecName": "e2-highcpu-2",
+          "spec": {
+            "cspSpecName": "e2-highcpu-2",
+            "vCPU": 2,
+            "memoryGiB": 1.953125,
+            "costPerHour": 0.063531
+          },
+          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
+          },
+          "vNetId": "my03-vnet-01",
+          "cspVNetId": "tbf2lc0iranl4gr0qrj1",
+          "subnetId": "my03-subnet-01",
+          "cspSubnetId": "tbbbfhl31q35cvclvii0",
+          "networkInterface": "nic0",
+          "securityGroupIds": [
+            "my03-sg-01"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my03-sshkey-01",
+          "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBvJlaJerWk572CnkFTR7M94expQ/gc1Y521sL4DISJuWcZnTsKXnKMP14jgZ54TuwCwQX3rfhM+cuwwgNMIyGM=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:ERrBquVmt2+syALqxO7DyelFE+vt+aUmNJYSSa2rB4o",
+            "firstUsedAt": "2026-06-02T12:05:16Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-06-02T12:05:14Z",
+              "completedTime": "2026-06-02T12:05:17Z",
+              "elapsedTime": 3,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "CanIpForward",
+              "value": "false"
+            },
+            {
+              "key": "CpuPlatform",
+              "value": "Intel Broadwell"
+            },
+            {
+              "key": "CreationTimestamp",
+              "value": "2026-06-02T05:04:17.129-07:00"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "Description",
+              "value": "compute sample instance"
+            },
+            {
+              "key": "Disks",
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb5aad3lmo0gt6dfk9uj,type:PERSISTENT}"
+            },
+            {
+              "key": "Fingerprint",
+              "value": "ZggRLCXPGm4="
+            },
+            {
+              "key": "Id",
+              "value": "4544156388102993967"
+            },
+            {
+              "key": "Kind",
+              "value": "compute#instance"
+            },
+            {
+              "key": "LabelFingerprint",
+              "value": "gdrn9ZcdtK4="
+            },
+            {
+              "key": "Labels",
+              "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
+            },
+            {
+              "key": "LastStartTimestamp",
+              "value": "2026-06-02T05:04:37.007-07:00"
+            },
+            {
+              "key": "MachineType",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/machineTypes/e2-highcpu-2"
+            },
+            {
+              "key": "Metadata",
+              "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
+            },
+            {
+              "key": "Name",
+              "value": "tb5aad3lmo0gt6dfk9uj"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.158.221.135,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:78EyTGfFAXw=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.2,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
+            },
+            {
+              "key": "ResourceStatus",
+              "value": "{effectiveInstanceMetadata:{vmDnsSettingMetadataValue:ZonalOnly}}"
+            },
+            {
+              "key": "SatisfiesPzi",
+              "value": "true"
+            },
+            {
+              "key": "SatisfiesPzs",
+              "value": "false"
+            },
+            {
+              "key": "Scheduling",
+              "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
+            },
+            {
+              "key": "SelfLink",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb5aad3lmo0gt6dfk9uj"
+            },
+            {
+              "key": "ServiceAccounts",
+              "value": "{email:MASKED_EMAIL,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
+            },
+            {
+              "key": "ShieldedInstanceConfig",
+              "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
+            },
+            {
+              "key": "ShieldedInstanceIntegrityPolicy",
+              "value": "{updateAutoLearnPolicy:true}"
+            },
+            {
+              "key": "StartRestricted",
+              "value": "false"
+            },
+            {
+              "key": "Status",
+              "value": "RUNNING"
+            },
+            {
+              "key": "Tags",
+              "value": "{fingerprint:HLOb1PbD2RI=,items:[tbn194eshutbrfcgotga]}"
+            },
+            {
+              "key": "Zone",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "uid": "tb25cler8rpicfonum0j",
+          "cspResourceName": "tb25cler8rpicfonum0j",
+          "cspResourceId": "tb25cler8rpicfonum0j",
+          "name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+          "nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.2,
+            "longitude": 127
+          },
+          "status": "Terminating",
+          "targetStatus": "Terminated",
+          "targetAction": "Terminate",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-06-02 12:05:04",
+          "label": {
+            "keypair": "tb6kf3c8jjcig0aqofjm",
+            "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.connectionName": "gcp-asia-northeast3",
+            "sys.createdTime": "2026-06-02 12:05:04",
+            "sys.cspResourceId": "tb25cler8rpicfonum0j",
+            "sys.cspResourceName": "tb25cler8rpicfonum0j",
+            "sys.id": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.infraId": "my03-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "sys.subnetId": "my03-subnet-01",
+            "sys.uid": "tb25cler8rpicfonum0j",
+            "sys.vNetId": "my03-vnet-01"
+          },
+          "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": "asia-northeast3",
+            "zone": "asia-northeast3-a"
+          },
+          "publicIP": "34.64.204.98",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.3",
+          "privateDNS": "",
+          "rootDiskType": "pd-standard",
+          "rootDiskSize": 10,
+          "RootDeviceName": "persistent-disk-0",
+          "connectionName": "gcp-asia-northeast3",
+          "connectionConfig": {
+            "configName": "gcp-asia-northeast3",
+            "providerName": "gcp",
+            "driverName": "gcp-driver-v1.0.so",
+            "credentialName": "gcp",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "gcp-asia-northeast3",
+            "regionZoneInfo": {
+              "assignedRegion": "asia-northeast3",
+              "assignedZone": "asia-northeast3-a"
+            },
+            "regionDetail": {
+              "regionId": "asia-northeast3",
+              "regionName": "asia-northeast3",
+              "description": "Seoul South Korea",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.2,
+                "longitude": 127
+              },
+              "zones": [
+                "asia-northeast3-a",
+                "asia-northeast3-b",
+                "asia-northeast3-c"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "gcp+asia-northeast3+e2-standard-2",
+          "cspSpecName": "e2-standard-2",
+          "spec": {
+            "cspSpecName": "e2-standard-2",
+            "vCPU": 2,
+            "memoryGiB": 7.8125,
+            "costPerHour": 0.085966
+          },
+          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
+          },
+          "vNetId": "my03-vnet-01",
+          "cspVNetId": "tbf2lc0iranl4gr0qrj1",
+          "subnetId": "my03-subnet-01",
+          "cspSubnetId": "tbbbfhl31q35cvclvii0",
+          "networkInterface": "nic0",
+          "securityGroupIds": [
+            "my03-sg-03"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my03-sshkey-01",
+          "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLUgTpq0/v92+Ov2nKeXig6AWK4yF0Gc1ZxosnLKf8lPmjXRFSkHJsCD0YZDOfiGUBlUww8UeS2xVqwC4870/oQ=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:WFzUU+3UDSttNynTqwpHaMgj53E6aCNppI9EW+XJ0RU",
+            "firstUsedAt": "2026-06-02T12:05:14Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-06-02T12:05:14Z",
+              "completedTime": "2026-06-02T12:05:16Z",
+              "elapsedTime": 2,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "CanIpForward",
+              "value": "false"
+            },
+            {
+              "key": "CpuPlatform",
+              "value": "Intel Broadwell"
+            },
+            {
+              "key": "CreationTimestamp",
+              "value": "2026-06-02T05:04:17.589-07:00"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "Description",
+              "value": "compute sample instance"
+            },
+            {
+              "key": "Disks",
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tb25cler8rpicfonum0j,type:PERSISTENT}"
+            },
+            {
+              "key": "Fingerprint",
+              "value": "69YQphFs3wM="
+            },
+            {
+              "key": "Id",
+              "value": "8018957467993208878"
+            },
+            {
+              "key": "Kind",
+              "value": "compute#instance"
+            },
+            {
+              "key": "LabelFingerprint",
+              "value": "gdrn9ZcdtK4="
+            },
+            {
+              "key": "Labels",
+              "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
+            },
+            {
+              "key": "LastStartTimestamp",
+              "value": "2026-06-02T05:04:29.800-07:00"
+            },
+            {
+              "key": "MachineType",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/machineTypes/e2-standard-2"
+            },
+            {
+              "key": "Metadata",
+              "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
+            },
+            {
+              "key": "Name",
+              "value": "tb25cler8rpicfonum0j"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:34.64.204.98,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:1Wsh4ie-ycE=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.3,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
+            },
+            {
+              "key": "ResourceStatus",
+              "value": "{effectiveInstanceMetadata:{vmDnsSettingMetadataValue:ZonalOnly}}"
+            },
+            {
+              "key": "SatisfiesPzi",
+              "value": "true"
+            },
+            {
+              "key": "SatisfiesPzs",
+              "value": "false"
+            },
+            {
+              "key": "Scheduling",
+              "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
+            },
+            {
+              "key": "SelfLink",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tb25cler8rpicfonum0j"
+            },
+            {
+              "key": "ServiceAccounts",
+              "value": "{email:MASKED_EMAIL,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
+            },
+            {
+              "key": "ShieldedInstanceConfig",
+              "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
+            },
+            {
+              "key": "ShieldedInstanceIntegrityPolicy",
+              "value": "{updateAutoLearnPolicy:true}"
+            },
+            {
+              "key": "StartRestricted",
+              "value": "false"
+            },
+            {
+              "key": "Status",
+              "value": "RUNNING"
+            },
+            {
+              "key": "Tags",
+              "value": "{fingerprint:MvS1ld5KqfI=,items:[tbol4toon26c949hihp0]}"
+            },
+            {
+              "key": "Zone",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a"
+            }
+          ]
+        },
+        {
+          "resourceType": "node",
+          "id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "uid": "tbk09te5ihs839lat9rh",
+          "cspResourceName": "tbk09te5ihs839lat9rh",
+          "cspResourceId": "tbk09te5ihs839lat9rh",
+          "name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+          "nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "location": {
+            "display": "South Korea (Seoul)",
+            "latitude": 37.2,
+            "longitude": 127
+          },
+          "status": "Terminating",
+          "targetStatus": "Terminated",
+          "targetAction": "Terminate",
+          "monAgentStatus": "notInstalled",
+          "networkAgentStatus": "notInstalled",
+          "systemMessage": "",
+          "createdTime": "2026-06-02 12:05:04",
+          "label": {
+            "keypair": "tb6kf3c8jjcig0aqofjm",
+            "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.connectionName": "gcp-asia-northeast3",
+            "sys.createdTime": "2026-06-02 12:05:04",
+            "sys.cspResourceId": "tbk09te5ihs839lat9rh",
+            "sys.cspResourceName": "tbk09te5ihs839lat9rh",
+            "sys.id": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.infraId": "my03-infra101",
+            "sys.labelType": "node",
+            "sys.manager": "cb-tumblebug",
+            "sys.name": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "sys.namespace": "mig01",
+            "sys.nodeGroupId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "sys.subnetId": "my03-subnet-01",
+            "sys.uid": "tbk09te5ihs839lat9rh",
+            "sys.vNetId": "my03-vnet-01"
+          },
+          "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+          "region": {
+            "region": "asia-northeast3",
+            "zone": "asia-northeast3-a"
+          },
+          "publicIP": "8.230.18.51",
+          "sshPort": 22,
+          "publicDNS": "",
+          "privateIP": "10.0.1.4",
+          "privateDNS": "",
+          "rootDiskType": "pd-standard",
+          "rootDiskSize": 10,
+          "RootDeviceName": "persistent-disk-0",
+          "connectionName": "gcp-asia-northeast3",
+          "connectionConfig": {
+            "configName": "gcp-asia-northeast3",
+            "providerName": "gcp",
+            "driverName": "gcp-driver-v1.0.so",
+            "credentialName": "gcp",
+            "credentialHolder": "admin",
+            "regionZoneInfoName": "gcp-asia-northeast3",
+            "regionZoneInfo": {
+              "assignedRegion": "asia-northeast3",
+              "assignedZone": "asia-northeast3-a"
+            },
+            "regionDetail": {
+              "regionId": "asia-northeast3",
+              "regionName": "asia-northeast3",
+              "description": "Seoul South Korea",
+              "location": {
+                "display": "South Korea (Seoul)",
+                "latitude": 37.2,
+                "longitude": 127
+              },
+              "zones": [
+                "asia-northeast3-a",
+                "asia-northeast3-b",
+                "asia-northeast3-c"
+              ]
+            },
+            "regionRepresentative": true,
+            "verified": true
+          },
+          "specId": "gcp+asia-northeast3+e2-standard-4",
+          "cspSpecName": "e2-standard-4",
+          "spec": {
+            "cspSpecName": "e2-standard-4",
+            "vCPU": 4,
+            "memoryGiB": 15.625,
+            "costPerHour": 0.171931
+          },
+          "imageId": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+          "image": {
+            "resourceType": "image",
+            "cspImageName": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/images/ubuntu-2204-jammy-v20260520",
+            "osType": "Ubuntu 22.04",
+            "osArchitecture": "x86_64",
+            "osDistribution": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image built on 2026-05-20"
+          },
+          "vNetId": "my03-vnet-01",
+          "cspVNetId": "tbf2lc0iranl4gr0qrj1",
+          "subnetId": "my03-subnet-01",
+          "cspSubnetId": "tbbbfhl31q35cvclvii0",
+          "networkInterface": "nic0",
+          "securityGroupIds": [
+            "my03-sg-02"
+          ],
+          "dataDiskIds": null,
+          "sshKeyId": "my03-sshkey-01",
+          "cspSshKeyId": "tb6kf3c8jjcig0aqofjm",
+          "nodeUserName": "cb-user",
+          "sshHostKeyInfo": {
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLyLErlt9S67FpIuIuIgk56BGEfqpZgEudzYRmYFTrRy7e5hTNnW2GA56f4iE0yzvF8jAxTnq+P7z7YvWQO6coU=",
+            "keyType": "ecdsa-sha2-nistp256",
+            "fingerprint": "SHA256:dxmTL8Z4RRRFIztfhrxzp6jxm7GWvtYNV5kDjJtoz1k",
+            "firstUsedAt": "2026-06-02T12:05:16Z"
+          },
+          "commandStatus": [
+            {
+              "index": 1,
+              "commandRequested": "uname -a",
+              "commandExecuted": "uname -a",
+              "status": "Completed",
+              "startedTime": "2026-06-02T12:05:14Z",
+              "completedTime": "2026-06-02T12:05:17Z",
+              "elapsedTime": 3,
+              "resultSummary": "Command executed successfully",
+              "stdout": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stderr": "\n"
+            }
+          ],
+          "addtionalDetails": [
+            {
+              "key": "CanIpForward",
+              "value": "false"
+            },
+            {
+              "key": "CpuPlatform",
+              "value": "Intel Broadwell"
+            },
+            {
+              "key": "CreationTimestamp",
+              "value": "2026-06-02T05:04:20.591-07:00"
+            },
+            {
+              "key": "DeletionProtection",
+              "value": "false"
+            },
+            {
+              "key": "Description",
+              "value": "compute sample instance"
+            },
+            {
+              "key": "Disks",
+              "value": "{architecture:X86_64,autoDelete:true,boot:true,deviceName:persistent-disk-0,diskSizeGb:10,guestOsFeatures:[{type:VIRTIO_SCSI_MULTIQUEUE},{type:SEV_CAPABLE},{type:SEV_SNP_CAPABLE},{type:SEV_LIVE_MIGRATABLE},{type:SEV_LIVE_MIGRATABLE_V2},{type:IDPF},{type:TDX_CAPABLE},{type:UEFI_COMPATIBLE},{type:GVNIC}],interface:SCSI,kind:compute#attachedDisk,licenses:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/licenses/ubuntu-2204-lts],mode:READ_WRITE,shieldedInstanceInitialState:{dbxs:[{content:2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=,fileType:BIN}]},source:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/disks/tbk09te5ihs839lat9rh,type:PERSISTENT}"
+            },
+            {
+              "key": "Fingerprint",
+              "value": "5TwSnPdL_r8="
+            },
+            {
+              "key": "Id",
+              "value": "3160271724368590891"
+            },
+            {
+              "key": "Kind",
+              "value": "compute#instance"
+            },
+            {
+              "key": "LabelFingerprint",
+              "value": "gdrn9ZcdtK4="
+            },
+            {
+              "key": "Labels",
+              "value": "{keypair:tb6kf3c8jjcig0aqofjm}"
+            },
+            {
+              "key": "LastStartTimestamp",
+              "value": "2026-06-02T05:04:30.378-07:00"
+            },
+            {
+              "key": "MachineType",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/machineTypes/e2-standard-4"
+            },
+            {
+              "key": "Metadata",
+              "value": "{fingerprint:RuPwmP9IHBg=,items:[{key:ssh-keys,value:cb-user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDByLF7mMIMU1rH4zk81E8bCyJSFXhesMJYd6R+EoB26O0BAhd8v7ZGMkbE9wGq02EOFXWKjPHYO7i5Jy7AdWoCRA+4mJxhjDpilDrzOlf80mpa73/OnJ19B9mwQuoHp9N8jmDhhP3hRmjc/HXyWcZJwDY78M/1bXB4mBaaIectUP5KBJdYvOjGpxv7ypXxQ6W/HRNiEcmH0P1IRfdBGxh+60JW3zPyC2aX/FNhQ8lKsP0MqlDMJqURgqCz3VAIuOcSwXE/UOO1oKeYbXBlFlzDBtLbgm3LKC4igipkPfYylrjS1svm3jzZegQWgu24LOJxiexbJuBP522KvtPWF+0YmKOTx/OJd7wshjnxAXWVx3Qf40wpaJn/3GcWRDj83Cq3HXMQel+eQeosOkmm/JP6ZO5YzVDh2rEmlJL0E5Rowo0OoJFaxTlvaPMjpDejShaI1MBfe4cHzdpPqfDu/lUcvoqJsjv+EohVKQJXM3KdL0LVN7FI5HHhj7VpDnGQ30EiuKMndhQV6Ck56u4TeBvvFI0LolsIStgzAph4Vopn1W0elIui1GTANkdG1WNwd4hIGH7W81DovnKbsl3M0G8uBE5+VFPun6WOPPJYuXF5cJEwC1kxaH2fbSlDIhs9ZisHlIxpH1MTVwTwioJtJJAF0yBUVPmAeFK72y4jJDxOvQ== cb-user}],kind:compute#metadata}"
+            },
+            {
+              "key": "Name",
+              "value": "tbk09te5ihs839lat9rh"
+            },
+            {
+              "key": "NetworkInterfaces",
+              "value": "{accessConfigs:[{kind:compute#accessConfig,name:External NAT,natIP:8.230.18.51,networkTier:PREMIUM,type:ONE_TO_ONE_NAT}],fingerprint:lOZ6jix2v68=,kind:compute#networkInterface,name:nic0,network:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/global/networks/tbf2lc0iranl4gr0qrj1,networkIP:10.0.1.4,stackType:IPV4_ONLY,subnetwork:https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbbbfhl31q35cvclvii0}"
+            },
+            {
+              "key": "ResourceStatus",
+              "value": "{effectiveInstanceMetadata:{vmDnsSettingMetadataValue:ZonalOnly}}"
+            },
+            {
+              "key": "SatisfiesPzi",
+              "value": "true"
+            },
+            {
+              "key": "SatisfiesPzs",
+              "value": "false"
+            },
+            {
+              "key": "Scheduling",
+              "value": "{automaticRestart:true,onHostMaintenance:MIGRATE,provisioningModel:STANDARD}"
+            },
+            {
+              "key": "SelfLink",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instances/tbk09te5ihs839lat9rh"
+            },
+            {
+              "key": "ServiceAccounts",
+              "value": "{email:MASKED_EMAIL,scopes:[https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/compute]}"
+            },
+            {
+              "key": "ShieldedInstanceConfig",
+              "value": "{enableIntegrityMonitoring:true,enableVtpm:true}"
+            },
+            {
+              "key": "ShieldedInstanceIntegrityPolicy",
+              "value": "{updateAutoLearnPolicy:true}"
+            },
+            {
+              "key": "StartRestricted",
+              "value": "false"
+            },
+            {
+              "key": "Status",
+              "value": "RUNNING"
+            },
+            {
+              "key": "Tags",
+              "value": "{fingerprint:DSXaZ9BoiC0=,items:[tbd6ae36tqdum3bvi8od]}"
+            },
+            {
+              "key": "Zone",
+              "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a"
+            }
+          ]
+        }
+      ],
+      "newNodeList": null,
+      "postCommand": {
+        "userName": "cb-user",
+        "command": [
+          "uname -a"
+        ]
+      },
+      "postCommandResult": {
+        "results": [
+          {
+            "infraId": "my03-infra101",
+            "nodeId": "my03-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
+            "nodeIp": "34.64.204.98",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tb25cler8rpicfonum0j 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my03-infra101",
+            "nodeId": "my03-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "34.158.221.135",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tb5aad3lmo0gt6dfk9uj 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my03-infra101",
+            "nodeId": "my03-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "8.230.18.51",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tbk09te5ihs839lat9rh 6.8.0-1058-gcp #61~22.04.1-Ubuntu SMP Thu May  7 15:03:19 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": "infra",
       "id": "my08-infra101",
-      "uid": "tbd85ch6epr9ha6omvqjlg",
+      "uid": "tb9k4svj3amakfqac867",
       "name": "my08-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -4582,7 +5412,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my08-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjlg"
+        "sys.uid": "tb9k4svj3amakfqac867"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -4591,9 +5421,9 @@
         {
           "resourceType": "node",
           "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbd85ch6epr9ha6omvqjmg",
-          "cspResourceName": "tbd85ch6epr9ha6omvqjmg",
-          "cspResourceId": "138993641",
+          "uid": "tbca72iou035q8bsubcf",
+          "cspResourceName": "tbca72iou035q8bsubcf",
+          "cspResourceId": "140607082",
           "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -4607,13 +5437,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:10:58",
+          "createdTime": "2026-06-02 12:06:31",
           "label": {
             "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "ncp-kr",
-            "sys.createdTime": "2026-05-18 08:10:58",
-            "sys.cspResourceId": "138993641",
-            "sys.cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+            "sys.createdTime": "2026-06-02 12:06:31",
+            "sys.cspResourceId": "140607082",
+            "sys.cspResourceName": "tbca72iou035q8bsubcf",
             "sys.id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my08-infra101",
             "sys.labelType": "node",
@@ -4622,7 +5452,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my08-subnet-01",
-            "sys.uid": "tbd85ch6epr9ha6omvqjmg",
+            "sys.uid": "tbca72iou035q8bsubcf",
             "sys.vNetId": "my08-vnet-01"
           },
           "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=50.0% Image=75.0%",
@@ -4630,10 +5460,10 @@
             "region": "KR",
             "zone": "KR-1"
           },
-          "publicIP": "223.130.156.82",
+          "publicIP": "101.79.10.57",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.7",
+          "privateIP": "10.0.1.6",
           "privateDNS": "",
           "rootDiskType": "HDD",
           "rootDiskSize": 50,
@@ -4685,22 +5515,22 @@
             "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
           },
           "vNetId": "my08-vnet-01",
-          "cspVNetId": "139135",
+          "cspVNetId": "139881",
           "subnetId": "my08-subnet-01",
-          "cspSubnetId": "300855",
+          "cspSubnetId": "302650",
           "networkInterface": "eth0",
           "securityGroupIds": [
             "my08-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my08-sshkey-01",
-          "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+          "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
             "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
             "keyType": "ecdsa-sha2-nistp256",
             "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-            "firstUsedAt": "2026-05-18T08:11:04Z"
+            "firstUsedAt": "2026-06-02T12:06:59Z"
           },
           "commandStatus": [
             {
@@ -4708,22 +5538,22 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:11:03Z",
-              "completedTime": "2026-05-18T08:11:05Z",
-              "elapsedTime": 2,
+              "startedTime": "2026-06-02T12:06:59Z",
+              "completedTime": "2026-06-02T12:07:00Z",
+              "elapsedTime": 1,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tbca72iou035q8bsubcf 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
           "addtionalDetails": [
             {
               "key": "ServerInstanceNo",
-              "value": "138993641"
+              "value": "140607082"
             },
             {
               "key": "ServerName",
-              "value": "tbd85ch6epr9ha6omvqjmg"
+              "value": "tbca72iou035q8bsubcf"
             },
             {
               "key": "CpuCount",
@@ -4739,7 +5569,7 @@
             },
             {
               "key": "LoginKeyName",
-              "value": "tbd85cg56pr9ha6omvqjj0"
+              "value": "tbbaetbunj5ueuro7mrm"
             },
             {
               "key": "ServerInstanceStatus",
@@ -4755,11 +5585,11 @@
             },
             {
               "key": "CreateDate",
-              "value": "2026-05-18T17:06:55+0900"
+              "value": "2026-06-02T21:02:39+0900"
             },
             {
               "key": "Uptime",
-              "value": "2026-05-18T17:09:13+0900"
+              "value": "2026-06-02T21:04:51+0900"
             },
             {
               "key": "ServerImageProductCode",
@@ -4783,19 +5613,19 @@
             },
             {
               "key": "VpcNo",
-              "value": "139135"
+              "value": "139881"
             },
             {
               "key": "SubnetNo",
-              "value": "300855"
+              "value": "302650"
             },
             {
               "key": "NetworkInterfaceNoList",
-              "value": "5694779"
+              "value": "5722303"
             },
             {
               "key": "InitScriptNo",
-              "value": "171473"
+              "value": "173391"
             },
             {
               "key": "ServerInstanceType",
@@ -4826,9 +5656,9 @@
         {
           "resourceType": "node",
           "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-          "uid": "tbd85ch6epr9ha6omvqjog",
-          "cspResourceName": "tbd85ch6epr9ha6omvqjog",
-          "cspResourceId": "138993649",
+          "uid": "tb62kdji13343nefcgpa",
+          "cspResourceName": "tb62kdji13343nefcgpa",
+          "cspResourceId": "140607087",
           "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
           "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
           "location": {
@@ -4842,13 +5672,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:10:58",
+          "createdTime": "2026-06-02 12:06:54",
           "label": {
             "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "ncp-kr",
-            "sys.createdTime": "2026-05-18 08:10:58",
-            "sys.cspResourceId": "138993649",
-            "sys.cspResourceName": "tbd85ch6epr9ha6omvqjog",
+            "sys.createdTime": "2026-06-02 12:06:54",
+            "sys.cspResourceId": "140607087",
+            "sys.cspResourceName": "tb62kdji13343nefcgpa",
             "sys.id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
             "sys.infraId": "my08-infra101",
             "sys.labelType": "node",
@@ -4857,7 +5687,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.subnetId": "my08-subnet-01",
-            "sys.uid": "tbd85ch6epr9ha6omvqjog",
+            "sys.uid": "tb62kdji13343nefcgpa",
             "sys.vNetId": "my08-vnet-01"
           },
           "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -4865,10 +5695,10 @@
             "region": "KR",
             "zone": "KR-1"
           },
-          "publicIP": "101.79.20.97",
+          "publicIP": "223.130.162.232",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.8",
+          "privateIP": "10.0.1.7",
           "privateDNS": "",
           "rootDiskType": "HDD",
           "rootDiskSize": 50,
@@ -4902,10 +5732,10 @@
             "regionRepresentative": true,
             "verified": true
           },
-          "specId": "ncp+kr+s2-g3a",
-          "cspSpecName": "s2-g3a",
+          "specId": "ncp+kr+s2-g3",
+          "cspSpecName": "s2-g3",
           "spec": {
-            "cspSpecName": "s2-g3a",
+            "cspSpecName": "s2-g3",
             "vCPU": 2,
             "memoryGiB": 8,
             "costPerHour": 0.0848
@@ -4920,22 +5750,22 @@
             "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
           },
           "vNetId": "my08-vnet-01",
-          "cspVNetId": "139135",
+          "cspVNetId": "139881",
           "subnetId": "my08-subnet-01",
-          "cspSubnetId": "300855",
+          "cspSubnetId": "302650",
           "networkInterface": "eth0",
           "securityGroupIds": [
             "my08-sg-03"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my08-sshkey-01",
-          "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+          "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
             "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
             "keyType": "ecdsa-sha2-nistp256",
             "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-            "firstUsedAt": "2026-05-18T08:11:04Z"
+            "firstUsedAt": "2026-06-02T12:07:00Z"
           },
           "commandStatus": [
             {
@@ -4943,22 +5773,22 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:11:03Z",
-              "completedTime": "2026-05-18T08:11:05Z",
+              "startedTime": "2026-06-02T12:06:59Z",
+              "completedTime": "2026-06-02T12:07:01Z",
               "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tb62kdji13343nefcgpa 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
           "addtionalDetails": [
             {
               "key": "ServerInstanceNo",
-              "value": "138993649"
+              "value": "140607087"
             },
             {
               "key": "ServerName",
-              "value": "tbd85ch6epr9ha6omvqjog"
+              "value": "tb62kdji13343nefcgpa"
             },
             {
               "key": "CpuCount",
@@ -4974,7 +5804,7 @@
             },
             {
               "key": "LoginKeyName",
-              "value": "tbd85cg56pr9ha6omvqjj0"
+              "value": "tbbaetbunj5ueuro7mrm"
             },
             {
               "key": "ServerInstanceStatus",
@@ -4990,11 +5820,11 @@
             },
             {
               "key": "CreateDate",
-              "value": "2026-05-18T17:06:58+0900"
+              "value": "2026-06-02T21:02:40+0900"
             },
             {
               "key": "Uptime",
-              "value": "2026-05-18T17:09:11+0900"
+              "value": "2026-06-02T21:05:00+0900"
             },
             {
               "key": "ServerImageProductCode",
@@ -5002,7 +5832,7 @@
             },
             {
               "key": "ServerProductCode",
-              "value": "SVR.VSVR.AMD.STAND.C002.M008.G003"
+              "value": "SVR.VSVR.STAND.C002.M008.G003"
             },
             {
               "key": "IsProtectServerTermination",
@@ -5018,19 +5848,19 @@
             },
             {
               "key": "VpcNo",
-              "value": "139135"
+              "value": "139881"
             },
             {
               "key": "SubnetNo",
-              "value": "300855"
+              "value": "302650"
             },
             {
               "key": "NetworkInterfaceNoList",
-              "value": "5694780"
+              "value": "5722304"
             },
             {
               "key": "InitScriptNo",
-              "value": "171474"
+              "value": "173392"
             },
             {
               "key": "ServerInstanceType",
@@ -5054,16 +5884,16 @@
             },
             {
               "key": "ServerSpecCode",
-              "value": "s2-g3a"
+              "value": "s2-g3"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-          "uid": "tbd85ch6epr9ha6omvqjng",
-          "cspResourceName": "tbd85ch6epr9ha6omvqjng",
-          "cspResourceId": "138993635",
+          "uid": "tb926lt0j2uls25i7d2u",
+          "cspResourceName": "tb926lt0j2uls25i7d2u",
+          "cspResourceId": "140607099",
           "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
           "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
           "location": {
@@ -5077,13 +5907,13 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-05-18 08:10:47",
+          "createdTime": "2026-06-02 12:06:31",
           "label": {
             "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.connectionName": "ncp-kr",
-            "sys.createdTime": "2026-05-18 08:10:47",
-            "sys.cspResourceId": "138993635",
-            "sys.cspResourceName": "tbd85ch6epr9ha6omvqjng",
+            "sys.createdTime": "2026-06-02 12:06:31",
+            "sys.cspResourceId": "140607099",
+            "sys.cspResourceName": "tb926lt0j2uls25i7d2u",
             "sys.id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
             "sys.infraId": "my08-infra101",
             "sys.labelType": "node",
@@ -5092,7 +5922,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
             "sys.subnetId": "my08-subnet-01",
-            "sys.uid": "tbd85ch6epr9ha6omvqjng",
+            "sys.uid": "tb926lt0j2uls25i7d2u",
             "sys.vNetId": "my08-vnet-01"
           },
           "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -5100,10 +5930,10 @@
             "region": "KR",
             "zone": "KR-1"
           },
-          "publicIP": "101.79.16.239",
+          "publicIP": "101.79.20.104",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.6",
+          "privateIP": "10.0.1.8",
           "privateDNS": "",
           "rootDiskType": "HDD",
           "rootDiskSize": 50,
@@ -5155,22 +5985,22 @@
             "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
           },
           "vNetId": "my08-vnet-01",
-          "cspVNetId": "139135",
+          "cspVNetId": "139881",
           "subnetId": "my08-subnet-01",
-          "cspSubnetId": "300855",
+          "cspSubnetId": "302650",
           "networkInterface": "eth0",
           "securityGroupIds": [
             "my08-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my08-sshkey-01",
-          "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+          "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
             "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
             "keyType": "ecdsa-sha2-nistp256",
             "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-            "firstUsedAt": "2026-05-18T08:11:03Z"
+            "firstUsedAt": "2026-06-02T12:07:00Z"
           },
           "commandStatus": [
             {
@@ -5178,22 +6008,22 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-05-18T08:11:03Z",
-              "completedTime": "2026-05-18T08:11:04Z",
-              "elapsedTime": 1,
+              "startedTime": "2026-06-02T12:06:59Z",
+              "completedTime": "2026-06-02T12:07:01Z",
+              "elapsedTime": 2,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux tb926lt0j2uls25i7d2u 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
           "addtionalDetails": [
             {
               "key": "ServerInstanceNo",
-              "value": "138993635"
+              "value": "140607099"
             },
             {
               "key": "ServerName",
-              "value": "tbd85ch6epr9ha6omvqjng"
+              "value": "tb926lt0j2uls25i7d2u"
             },
             {
               "key": "CpuCount",
@@ -5209,7 +6039,7 @@
             },
             {
               "key": "LoginKeyName",
-              "value": "tbd85cg56pr9ha6omvqjj0"
+              "value": "tbbaetbunj5ueuro7mrm"
             },
             {
               "key": "ServerInstanceStatus",
@@ -5225,11 +6055,11 @@
             },
             {
               "key": "CreateDate",
-              "value": "2026-05-18T17:06:54+0900"
+              "value": "2026-06-02T21:02:42+0900"
             },
             {
               "key": "Uptime",
-              "value": "2026-05-18T17:09:08+0900"
+              "value": "2026-06-02T21:04:42+0900"
             },
             {
               "key": "ServerImageProductCode",
@@ -5253,19 +6083,19 @@
             },
             {
               "key": "VpcNo",
-              "value": "139135"
+              "value": "139881"
             },
             {
               "key": "SubnetNo",
-              "value": "300855"
+              "value": "302650"
             },
             {
               "key": "NetworkInterfaceNoList",
-              "value": "5694778"
+              "value": "5722305"
             },
             {
               "key": "InitScriptNo",
-              "value": "171472"
+              "value": "173393"
             },
             {
               "key": "ServerInstanceType",
@@ -5305,13 +6135,28 @@
         "results": [
           {
             "infraId": "my08-infra101",
-            "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-            "nodeIp": "101.79.16.239",
+            "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+            "nodeIp": "101.79.10.57",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tbca72iou035q8bsubcf 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+            },
+            "stderr": {
+              "0": ""
+            },
+            "err": null
+          },
+          {
+            "infraId": "my08-infra101",
+            "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+            "nodeIp": "101.79.20.104",
+            "command": {
+              "0": "uname -a"
+            },
+            "stdout": {
+              "0": "Linux tb926lt0j2uls25i7d2u 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5321,27 +6166,12 @@
           {
             "infraId": "my08-infra101",
             "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-            "nodeIp": "101.79.20.97",
+            "nodeIp": "223.130.162.232",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
-            },
-            "stderr": {
-              "0": ""
-            },
-            "err": null
-          },
-          {
-            "infraId": "my08-infra101",
-            "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "223.130.156.82",
-            "command": {
-              "0": "uname -a"
-            },
-            "stdout": {
-              "0": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux tb62kdji13343nefcgpa 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -5375,6 +6205,7 @@
 ```json
 {
   "idList": [
+    "my03-infra101",
     "my08-infra101"
   ]
 }
@@ -5404,7 +6235,7 @@
 {
   "resourceType": "infra",
   "id": "my08-infra101",
-  "uid": "tbd85ch6epr9ha6omvqjlg",
+  "uid": "tb9k4svj3amakfqac867",
   "name": "my08-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -5432,7 +6263,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my08-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbd85ch6epr9ha6omvqjlg"
+    "sys.uid": "tb9k4svj3amakfqac867"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -5441,9 +6272,9 @@
     {
       "resourceType": "node",
       "id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbd85ch6epr9ha6omvqjmg",
-      "cspResourceName": "tbd85ch6epr9ha6omvqjmg",
-      "cspResourceId": "138993641",
+      "uid": "tbca72iou035q8bsubcf",
+      "cspResourceName": "tbca72iou035q8bsubcf",
+      "cspResourceId": "140607082",
       "name": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -5457,13 +6288,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:10:58",
+      "createdTime": "2026-06-02 12:06:31",
       "label": {
         "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-18 08:10:58",
-        "sys.cspResourceId": "138993641",
-        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjmg",
+        "sys.createdTime": "2026-06-02 12:06:31",
+        "sys.cspResourceId": "140607082",
+        "sys.cspResourceName": "tbca72iou035q8bsubcf",
         "sys.id": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
@@ -5472,7 +6303,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my08-subnet-01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjmg",
+        "sys.uid": "tbca72iou035q8bsubcf",
         "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=50.0% Image=75.0%",
@@ -5480,10 +6311,10 @@
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "223.130.156.82",
+      "publicIP": "101.79.10.57",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.7",
+      "privateIP": "10.0.1.6",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -5535,22 +6366,22 @@
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
       "vNetId": "my08-vnet-01",
-      "cspVNetId": "139135",
+      "cspVNetId": "139881",
       "subnetId": "my08-subnet-01",
-      "cspSubnetId": "300855",
+      "cspSubnetId": "302650",
       "networkInterface": "eth0",
       "securityGroupIds": [
         "my08-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my08-sshkey-01",
-      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+      "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-18T08:11:04Z"
+        "firstUsedAt": "2026-06-02T12:06:59Z"
       },
       "commandStatus": [
         {
@@ -5558,22 +6389,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:11:03Z",
-          "completedTime": "2026-05-18T08:11:05Z",
-          "elapsedTime": 2,
+          "startedTime": "2026-06-02T12:06:59Z",
+          "completedTime": "2026-06-02T12:07:00Z",
+          "elapsedTime": 1,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tbca72iou035q8bsubcf 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138993641"
+          "value": "140607082"
         },
         {
           "key": "ServerName",
-          "value": "tbd85ch6epr9ha6omvqjmg"
+          "value": "tbca72iou035q8bsubcf"
         },
         {
           "key": "CpuCount",
@@ -5589,7 +6420,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd85cg56pr9ha6omvqjj0"
+          "value": "tbbaetbunj5ueuro7mrm"
         },
         {
           "key": "ServerInstanceStatus",
@@ -5605,11 +6436,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-18T17:06:55+0900"
+          "value": "2026-06-02T21:02:39+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-18T17:09:13+0900"
+          "value": "2026-06-02T21:04:51+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -5633,19 +6464,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "139135"
+          "value": "139881"
         },
         {
           "key": "SubnetNo",
-          "value": "300855"
+          "value": "302650"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5694779"
+          "value": "5722303"
         },
         {
           "key": "InitScriptNo",
-          "value": "171473"
+          "value": "173391"
         },
         {
           "key": "ServerInstanceType",
@@ -5676,9 +6507,9 @@
     {
       "resourceType": "node",
       "id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "uid": "tbd85ch6epr9ha6omvqjog",
-      "cspResourceName": "tbd85ch6epr9ha6omvqjog",
-      "cspResourceId": "138993649",
+      "uid": "tb62kdji13343nefcgpa",
+      "cspResourceName": "tb62kdji13343nefcgpa",
+      "cspResourceId": "140607087",
       "name": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
       "nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "location": {
@@ -5692,13 +6523,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:10:58",
+      "createdTime": "2026-06-02 12:06:54",
       "label": {
         "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-18 08:10:58",
-        "sys.cspResourceId": "138993649",
-        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjog",
+        "sys.createdTime": "2026-06-02 12:06:54",
+        "sys.cspResourceId": "140607087",
+        "sys.cspResourceName": "tb62kdji13343nefcgpa",
         "sys.id": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
         "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
@@ -5707,7 +6538,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.subnetId": "my08-subnet-01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjog",
+        "sys.uid": "tb62kdji13343nefcgpa",
         "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -5715,10 +6546,10 @@
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.20.97",
+      "publicIP": "223.130.162.232",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.8",
+      "privateIP": "10.0.1.7",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -5752,10 +6583,10 @@
         "regionRepresentative": true,
         "verified": true
       },
-      "specId": "ncp+kr+s2-g3a",
-      "cspSpecName": "s2-g3a",
+      "specId": "ncp+kr+s2-g3",
+      "cspSpecName": "s2-g3",
       "spec": {
-        "cspSpecName": "s2-g3a",
+        "cspSpecName": "s2-g3",
         "vCPU": 2,
         "memoryGiB": 8,
         "costPerHour": 0.0848
@@ -5770,22 +6601,22 @@
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
       "vNetId": "my08-vnet-01",
-      "cspVNetId": "139135",
+      "cspVNetId": "139881",
       "subnetId": "my08-subnet-01",
-      "cspSubnetId": "300855",
+      "cspSubnetId": "302650",
       "networkInterface": "eth0",
       "securityGroupIds": [
         "my08-sg-03"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my08-sshkey-01",
-      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+      "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-18T08:11:04Z"
+        "firstUsedAt": "2026-06-02T12:07:00Z"
       },
       "commandStatus": [
         {
@@ -5793,22 +6624,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:11:03Z",
-          "completedTime": "2026-05-18T08:11:05Z",
+          "startedTime": "2026-06-02T12:06:59Z",
+          "completedTime": "2026-06-02T12:07:01Z",
           "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb62kdji13343nefcgpa 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138993649"
+          "value": "140607087"
         },
         {
           "key": "ServerName",
-          "value": "tbd85ch6epr9ha6omvqjog"
+          "value": "tb62kdji13343nefcgpa"
         },
         {
           "key": "CpuCount",
@@ -5824,7 +6655,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd85cg56pr9ha6omvqjj0"
+          "value": "tbbaetbunj5ueuro7mrm"
         },
         {
           "key": "ServerInstanceStatus",
@@ -5840,11 +6671,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-18T17:06:58+0900"
+          "value": "2026-06-02T21:02:40+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-18T17:09:11+0900"
+          "value": "2026-06-02T21:05:00+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -5852,7 +6683,7 @@
         },
         {
           "key": "ServerProductCode",
-          "value": "SVR.VSVR.AMD.STAND.C002.M008.G003"
+          "value": "SVR.VSVR.STAND.C002.M008.G003"
         },
         {
           "key": "IsProtectServerTermination",
@@ -5868,19 +6699,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "139135"
+          "value": "139881"
         },
         {
           "key": "SubnetNo",
-          "value": "300855"
+          "value": "302650"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5694780"
+          "value": "5722304"
         },
         {
           "key": "InitScriptNo",
-          "value": "171474"
+          "value": "173392"
         },
         {
           "key": "ServerInstanceType",
@@ -5904,16 +6735,16 @@
         },
         {
           "key": "ServerSpecCode",
-          "value": "s2-g3a"
+          "value": "s2-g3"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "uid": "tbd85ch6epr9ha6omvqjng",
-      "cspResourceName": "tbd85ch6epr9ha6omvqjng",
-      "cspResourceId": "138993635",
+      "uid": "tb926lt0j2uls25i7d2u",
+      "cspResourceName": "tb926lt0j2uls25i7d2u",
+      "cspResourceId": "140607099",
       "name": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
       "nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "location": {
@@ -5927,13 +6758,13 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-05-18 08:10:47",
+      "createdTime": "2026-06-02 12:06:31",
       "label": {
         "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.connectionName": "ncp-kr",
-        "sys.createdTime": "2026-05-18 08:10:47",
-        "sys.cspResourceId": "138993635",
-        "sys.cspResourceName": "tbd85ch6epr9ha6omvqjng",
+        "sys.createdTime": "2026-06-02 12:06:31",
+        "sys.cspResourceId": "140607099",
+        "sys.cspResourceName": "tb926lt0j2uls25i7d2u",
         "sys.id": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
         "sys.infraId": "my08-infra101",
         "sys.labelType": "node",
@@ -5942,7 +6773,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
         "sys.subnetId": "my08-subnet-01",
-        "sys.uid": "tbd85ch6epr9ha6omvqjng",
+        "sys.uid": "tb926lt0j2uls25i7d2u",
         "sys.vNetId": "my08-vnet-01"
       },
       "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=75.0%",
@@ -5950,10 +6781,10 @@
         "region": "KR",
         "zone": "KR-1"
       },
-      "publicIP": "101.79.16.239",
+      "publicIP": "101.79.20.104",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.6",
+      "privateIP": "10.0.1.8",
       "privateDNS": "",
       "rootDiskType": "HDD",
       "rootDiskSize": 50,
@@ -6005,22 +6836,22 @@
         "osDistribution": "ubuntu-22.04-base (Hypervisor:KVM)"
       },
       "vNetId": "my08-vnet-01",
-      "cspVNetId": "139135",
+      "cspVNetId": "139881",
       "subnetId": "my08-subnet-01",
-      "cspSubnetId": "300855",
+      "cspSubnetId": "302650",
       "networkInterface": "eth0",
       "securityGroupIds": [
         "my08-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my08-sshkey-01",
-      "cspSshKeyId": "tbd85cg56pr9ha6omvqjj0",
+      "cspSshKeyId": "tbbaetbunj5ueuro7mrm",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
         "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWlg+tXjkjnBfk0KfXIZnsAnFZeTiRoXl6rO1F9LAx0QmlAhB6H9S23i9Ye/A9ACdUpS363A6UvMT7MLqDkFNU=",
         "keyType": "ecdsa-sha2-nistp256",
         "fingerprint": "SHA256:2WSq7XAjDTgX/DGvHQOWkvXaevoO2kb8tl2cApRpCVE",
-        "firstUsedAt": "2026-05-18T08:11:03Z"
+        "firstUsedAt": "2026-06-02T12:07:00Z"
       },
       "commandStatus": [
         {
@@ -6028,22 +6859,22 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-05-18T08:11:03Z",
-          "completedTime": "2026-05-18T08:11:04Z",
-          "elapsedTime": 1,
+          "startedTime": "2026-06-02T12:06:59Z",
+          "completedTime": "2026-06-02T12:07:01Z",
+          "elapsedTime": 2,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux tb926lt0j2uls25i7d2u 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
       "addtionalDetails": [
         {
           "key": "ServerInstanceNo",
-          "value": "138993635"
+          "value": "140607099"
         },
         {
           "key": "ServerName",
-          "value": "tbd85ch6epr9ha6omvqjng"
+          "value": "tb926lt0j2uls25i7d2u"
         },
         {
           "key": "CpuCount",
@@ -6059,7 +6890,7 @@
         },
         {
           "key": "LoginKeyName",
-          "value": "tbd85cg56pr9ha6omvqjj0"
+          "value": "tbbaetbunj5ueuro7mrm"
         },
         {
           "key": "ServerInstanceStatus",
@@ -6075,11 +6906,11 @@
         },
         {
           "key": "CreateDate",
-          "value": "2026-05-18T17:06:54+0900"
+          "value": "2026-06-02T21:02:42+0900"
         },
         {
           "key": "Uptime",
-          "value": "2026-05-18T17:09:08+0900"
+          "value": "2026-06-02T21:04:42+0900"
         },
         {
           "key": "ServerImageProductCode",
@@ -6103,19 +6934,19 @@
         },
         {
           "key": "VpcNo",
-          "value": "139135"
+          "value": "139881"
         },
         {
           "key": "SubnetNo",
-          "value": "300855"
+          "value": "302650"
         },
         {
           "key": "NetworkInterfaceNoList",
-          "value": "5694778"
+          "value": "5722305"
         },
         {
           "key": "InitScriptNo",
-          "value": "171472"
+          "value": "173393"
         },
         {
           "key": "ServerInstanceType",
@@ -6155,13 +6986,28 @@
     "results": [
       {
         "infraId": "my08-infra101",
-        "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-        "nodeIp": "101.79.16.239",
+        "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
+        "nodeIp": "101.79.10.57",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tbca72iou035q8bsubcf 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+        },
+        "stderr": {
+          "0": ""
+        },
+        "err": null
+      },
+      {
+        "infraId": "my08-infra101",
+        "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
+        "nodeIp": "101.79.20.104",
+        "command": {
+          "0": "uname -a"
+        },
+        "stdout": {
+          "0": "Linux tb926lt0j2uls25i7d2u 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6171,27 +7017,12 @@
       {
         "infraId": "my08-infra101",
         "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-        "nodeIp": "101.79.20.97",
+        "nodeIp": "223.130.162.232",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
-        },
-        "stderr": {
-          "0": ""
-        },
-        "err": null
-      },
-      {
-        "infraId": "my08-infra101",
-        "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "223.130.156.82",
-        "command": {
-          "0": "uname -a"
-        },
-        "stdout": {
-          "0": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux tb62kdji13343nefcgpa 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -6249,8 +7080,8 @@
       "command": "uname -a",
       "nodeGroup": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624",
       "nodeId": "my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "output": "Linux tbd85ch6epr9ha6omvqjmg 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "223.130.156.82",
+      "output": "Linux tbca72iou035q8bsubcf 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "101.79.10.57",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 1,
@@ -6261,8 +7092,8 @@
       "command": "uname -a",
       "nodeGroup": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
       "nodeId": "my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1",
-      "output": "Linux tbd85ch6epr9ha6omvqjog 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "101.79.20.97",
+      "output": "Linux tb62kdji13343nefcgpa 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "223.130.162.232",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 2,
@@ -6273,8 +7104,8 @@
       "command": "uname -a",
       "nodeGroup": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
       "nodeId": "my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1",
-      "output": "Linux tbd85ch6epr9ha6omvqjng 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
-      "publicIP": "101.79.16.239",
+      "output": "Linux tb926lt0j2uls25i7d2u 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux",
+      "publicIP": "101.79.20.104",
       "sshTest": "successful",
       "status": "success",
       "testOrder": 3,
@@ -6304,7 +7135,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-05-18 08:11:39
+**Generated At:** 2026-06-02 12:07:41
 
 **Namespace:** mig01
 
@@ -6333,7 +7164,7 @@
 | Name | vCPUs | Memory (GiB) | GPU | Architecture | Disk Type | Cost/Hour (USD) | VMs Using This Spec |
 |------|-------|--------------|-----|--------------|-----------|-----------------|---------------------|
 | ci2-g3 | 2 | 4.0 | - | x86_64 | default | $0.0730 | 1 |
-| s2-g3a | 2 | 8.0 | - | x86_64 | default | $0.0848 | 1 |
+| s2-g3 | 2 | 8.0 | - | x86_64 | default | $0.0848 | 1 |
 | s4-g3a | 4 | 16.0 | - | x86_64 | default | $0.1747 | 1 |
 
 ### VM Images
@@ -6346,9 +7177,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 138993641 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 223.130.156.82<br>**Private IP:** 10.0.1.7<br>**SGs:** my08-sg-01<br>**SSH:** my08-sshkey-01 |
-| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 138993649 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.20.97<br>**Private IP:** 10.0.1.8<br>**SGs:** my08-sg-03<br>**SSH:** my08-sshkey-01 |
-| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 138993635 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.16.239<br>**Private IP:** 10.0.1.6<br>**SGs:** my08-sg-02<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | 140607082 | Running | 2 vCPU, 4.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.10.57<br>**Private IP:** 10.0.1.6<br>**SGs:** my08-sg-01<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | 140607087 | Running | 2 vCPU, 8.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 223.130.162.232<br>**Private IP:** 10.0.1.7<br>**SGs:** my08-sg-03<br>**SSH:** my08-sshkey-01 |
+| my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | 140607099 | Running | 4 vCPU, 16.0 GiB | ubuntu-22.04-base (Hypervisor:KVM) (ubuntu-22.04-base (Hypervisor:KVM)) | **VNet:** my08-vnet-01<br>**Subnet:** my08-subnet-01<br>**Public IP:** 101.79.20.104<br>**Private IP:** 10.0.1.8<br>**SGs:** my08-sg-02<br>**SSH:** my08-sshkey-01 |
 
 
 ## Network Resources
@@ -6360,7 +7191,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-vnet-01 |
-| **CSP VNet ID** | 139135 |
+| **CSP VNet ID** | 139881 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | ncp-kr |
 | **Subnet Count** | 1 |
@@ -6369,7 +7200,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my08-subnet-01 | 300855 | 10.0.1.0/24 | KR-1 |
+| my08-subnet-01 | 302650 | 10.0.1.0/24 | KR-1 |
 
 
 ## Security Resources
@@ -6378,7 +7209,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 | cb-user |  |
+| my08-sshkey-01 | tbbaetbunj5ueuro7mrm | cb-user |  |
 
 ### Security Groups
 
@@ -6387,7 +7218,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-sg-01 |
-| **CSP Security Group ID** | 353896 |
+| **CSP Security Group ID** | 356310 |
 | **VNet** | my08-vnet-01 |
 | **Rule Count** | 15 rules |
 
@@ -6416,7 +7247,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-sg-02 |
-| **CSP Security Group ID** | 353897 |
+| **CSP Security Group ID** | 356311 |
 | **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
@@ -6450,7 +7281,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my08-sg-03 |
-| **CSP Security Group ID** | 353898 |
+| **CSP Security Group ID** | 356314 |
 | **VNet** | my08-vnet-01 |
 | **Rule Count** | 20 rules |
 
@@ -6501,7 +7332,7 @@
 | VM Name | Spec | Cost/Hour (USD) | Cost/Month (USD) |
 |---------|------|-----------------|------------------|
 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | ci2-g3 | $0.0730 | $52.56 |
-| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3a | $0.0848 | $61.06 |
+| my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | s2-g3 | $0.0848 | $61.06 |
 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | s4-g3a | $0.1747 | $125.78 |
 
 
@@ -6526,7 +7357,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-05-18 08:11:44*
+*Report generated: 2026-06-02 12:07:47*
 
 ---
 
@@ -6555,7 +7386,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 3 | ✅ Selected | ci2-g3, s2-g3a, s4-g3a |
+| 2 | **VM Spec** | 3 | ✅ Selected | ci2-g3, s2-g3, s4-g3a |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my08-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my08-vnet-01) |
@@ -6570,9 +7401,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 138993641<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 138993649<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
-| 3 | **VM Name:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 138993635<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
+| 1 | **VM Name:** my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** 140607082<br>**Label(sourceMachineId):** vm-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f |
+| 2 | **VM Name:** my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1<br>**VM ID:** 140607087<br>**Label(sourceMachineId):** vm-ec288dd0-c6fa-8a49-2f60 | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 |
+| 3 | **VM Name:** my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1<br>**VM ID:** 140607099<br>**Label(sourceMachineId):** vm-ec2d32b5-98fb-5a96-7913 | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 |
 
 ---
 
@@ -6583,7 +7414,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | No. | Migrated VM | VM Spec | Source Server | Source Server Spec |
 |-----|-------------|---------|---------------|--------------------|
 | 1 | my08-vm-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** ci2-g3<br>**vCPUs:** 2<br>**Memory:** 4.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3a<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 2 | my08-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1 | **Spec ID:** s2-g3<br>**vCPUs:** 2<br>**Memory:** 8.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec288dd0-c6fa-8a49-2f60 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
 | 3 | my08-vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932-1 | **Spec ID:** s4-g3a<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** vm-ec2d32b5-98fb-5a96-7913 | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
 
 ---
@@ -6606,7 +7437,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my08-sg-01
 
-**CSP ID:** 353896 | **VNet:** my08-vnet-01 | **Rules:** 15
+**CSP ID:** 356310 | **VNet:** my08-vnet-01 | **Rules:** 15
 
 **Assigned VMs:**
 
@@ -6635,7 +7466,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my08-sg-02
 
-**CSP ID:** 353897 | **VNet:** my08-vnet-01 | **Rules:** 20
+**CSP ID:** 356311 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
@@ -6669,7 +7500,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my08-sg-03
 
-**CSP ID:** 353898 | **VNet:** my08-vnet-01 | **Rules:** 20
+**CSP ID:** 356314 | **VNet:** my08-vnet-01 | **Rules:** 20
 
 **Assigned VMs:**
 
@@ -6711,13 +7542,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my08-vnet-01<br>**ID:** 139135 | 10.0.0.0/21 |
+| 1 | **Name:** my08-vnet-01<br>**ID:** 139881 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my08-subnet-01<br>**ID:** 300855 | 10.0.1.0/24 | my08-vnet-01 |
+| 1 | **Name:** my08-subnet-01<br>**ID:** 302650 | 10.0.1.0/24 | my08-vnet-01 |
 
 ### Source Network Information
 
@@ -6759,7 +7590,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my08-sshkey-01 | tbd85cg56pr9ha6omvqjj0 |  | Used by all 3 VMs |
+| 1 | my08-sshkey-01 | tbbaetbunj5ueuro7mrm |  | Used by all 3 VMs |
 
 ---
 
@@ -6780,7 +7611,7 @@ Summary of key infrastructure resources created or configured in the target clou
 |-----------|------|--------------|------------|
 | ip-10-0-1-30 (migrated) | ci2-g3 | $52.56 | 22.0% |
 | ip-10-0-1-221 (migrated) | s4-g3a | $125.78 | 52.5% |
-| ip-10-0-1-138 (migrated) | s2-g3a | $61.06 | 25.5% |
+| ip-10-0-1-138 (migrated) | s2-g3 | $61.06 | 25.5% |
 
 ---
 

--- a/cmd/test-cli/infra/testresult/beetle-test-summary-all.md
+++ b/cmd/test-cli/infra/testresult/beetle-test-summary-all.md
@@ -5,13 +5,13 @@
 
 ## Test Run Information
 
-- **Date**: May 19, 2026
-- **Start Time**: 22:43:38 KST
-- **Total Duration**: 3m1.777s
+- **Date**: June 2, 2026
+- **Start Time**: 20:56:57 KST
+- **Total Duration**: 18m14.241s
 - **Execution Mode**: parallel
-- **CM-Beetle**: imdl/v0.1.5+ (fa1a108)
-- **CB-Tumblebug**: v0.12.10
-- **CB-Spider**: v0.12.24
+- **CM-Beetle**: imdl/v0.1.5+ (7e4bd21)
+- **CB-Tumblebug**: v0.12.13
+- **CB-Spider**: v0.12.26
 
 ## Overall Results
 
@@ -20,39 +20,134 @@
 | Metric | Count |
 |--------|-------|
 | Total CSP-Region Pairs | 10 |
-| Passed Pairs | 1 |
+| Passed Pairs | 6 |
 | Failed Pairs | 0 |
-| Skipped Pairs | 9 |
+| Skipped Pairs | 4 |
 | Total API Tests | 90 |
-| Passed API Tests | 9 |
+| Passed API Tests | 54 |
 | Failed API Tests | 0 |
 
 ## Per CSP-Region Pair Results
 
 | # | Display Name | CSP | Region | Status | Duration | Passed | Failed | Skipped |
 |---|--------------|-----|--------|--------|----------|--------|--------|--------|
-| 1 | Alibaba-Seoul | ALIBABA | ap-northeast-2 | ✅ PASS | 2m56.664s | 9/9 | 0/9 | 0/9 |
+| 1 | AWS-Seoul | AWS | ap-northeast-2 | ✅ PASS | 3m17.579s | 9/9 | 0/9 | 0/9 |
+| 2 | Azure-Busan | AZURE | koreasouth | ✅ PASS | 4m57.447s | 9/9 | 0/9 | 0/9 |
+| 3 | GCP-Seoul | GCP | asia-northeast3 | ✅ PASS | 18m4.998s | 9/9 | 0/9 | 0/9 |
+| 4 | Alibaba-Seoul | ALIBABA | ap-northeast-2 | ✅ PASS | 2m56.723s | 9/9 | 0/9 | 0/9 |
+| 5 | IBMCloud-Sydney | IBM | au-syd | ✅ PASS | 6m8.262s | 9/9 | 0/9 | 0/9 |
+| 6 | NCP-Seoul | NCP | kr | ✅ PASS | 13m20.277s | 9/9 | 0/9 | 0/9 |
 
 ## Detailed Results Per CSP-Region Pair
 
-### 1. Alibaba-Seoul (ALIBABA, ap-northeast-2) — ✅ PASS
+### 1. AWS-Seoul (AWS, ap-northeast-2) — ✅ PASS
 
-- **Start Time**: 2026-05-19 22:43:43 KST
-- **Duration**: 2m56.664s
+- **Start Time**: 2026-06-02 20:57:02 KST
+- **Duration**: 3m17.579s
 - **Namespace**: mig01
 
 | Step | Endpoint / Description | Status | Duration |
 |------|------------------------|--------|----------|
-| 1 | `POST /beetle/recommendation/infra` | ✅ PASS | 9.845s |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ PASS | 1m7.409s |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ PASS | 31ms |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ PASS | 6ms |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 18ms |
+| 1 | `POST /beetle/recommendation/infra` | ✅ PASS | 11.915s |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ PASS | 1m2.785s |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ PASS | 43ms |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ PASS | 5ms |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 24ms |
 | 6 | Remote SSH Accessibility | ✅ PASS | 0s |
-| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.341s |
-| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.351s |
-| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 27.031s |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.411s |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.503s |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 47.728s |
+
+### 2. Azure-Busan (AZURE, koreasouth) — ✅ PASS
+
+- **Start Time**: 2026-06-02 20:57:03 KST
+- **Duration**: 4m57.447s
+- **Namespace**: mig01
+
+| Step | Endpoint / Description | Status | Duration |
+|------|------------------------|--------|----------|
+| 1 | `POST /beetle/recommendation/infra` | ✅ PASS | 13.084s |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ PASS | 1m36.82s |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ PASS | 126ms |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ PASS | 16ms |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 28ms |
+| 6 | Remote SSH Accessibility | ✅ PASS | 0s |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.584s |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.604s |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 1m47.036s |
+
+### 3. GCP-Seoul (GCP, asia-northeast3) — ✅ PASS
+
+- **Start Time**: 2026-06-02 20:57:06 KST
+- **Duration**: 18m4.998s
+- **Namespace**: mig01
+
+| Step | Endpoint / Description | Status | Duration |
+|------|------------------------|--------|----------|
+| 1 | `POST /beetle/recommendation/infra` | ✅ PASS | 16.118s |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ PASS | 7m45.076s |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ PASS | 56ms |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ PASS | 3ms |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 17ms |
+| 6 | Remote SSH Accessibility | ✅ PASS | 0s |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.398s |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.324s |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 8m39.645s |
+
+### 4. Alibaba-Seoul (ALIBABA, ap-northeast-2) — ✅ PASS
+
+- **Start Time**: 2026-06-02 20:57:07 KST
+- **Duration**: 2m56.723s
+- **Namespace**: mig01
+
+| Step | Endpoint / Description | Status | Duration |
+|------|------------------------|--------|----------|
+| 1 | `POST /beetle/recommendation/infra` | ✅ PASS | 7.581s |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ PASS | 1m9.011s |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ PASS | 42ms |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ PASS | 9ms |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 20ms |
+| 6 | Remote SSH Accessibility | ✅ PASS | 0s |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.617s |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.392s |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 27.428s |
+
+### 5. IBMCloud-Sydney (IBM, au-syd) — ✅ PASS
+
+- **Start Time**: 2026-06-02 20:57:10 KST
+- **Duration**: 6m8.262s
+- **Namespace**: mig01
+
+| Step | Endpoint / Description | Status | Duration |
+|------|------------------------|--------|----------|
+| 1 | `POST /beetle/recommendation/infra` | ✅ PASS | 15.53s |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ PASS | 2m54.786s |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ PASS | 38ms |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ PASS | 7ms |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 26ms |
+| 6 | Remote SSH Accessibility | ✅ PASS | 0s |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.345s |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.3s |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 1m22.808s |
+
+### 6. NCP-Seoul (NCP, kr) — ✅ PASS
+
+- **Start Time**: 2026-06-02 20:57:11 KST
+- **Duration**: 13m20.277s
+- **Namespace**: mig01
+
+| Step | Endpoint / Description | Status | Duration |
+|------|------------------------|--------|----------|
+| 1 | `POST /beetle/recommendation/infra` | ✅ PASS | 2m15.919s |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ PASS | 7m24.368s |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ PASS | 1.069s |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ PASS | 7ms |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 26ms |
+| 6 | Remote SSH Accessibility | ✅ PASS | 0s |
+| 7 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.954s |
+| 8 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 5.433s |
+| 9 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ PASS | 2m14.464s |
 
 ---
 
-*Generated by CM-Beetle Test CLI on 2026-05-19 22:43:38 KST*
+*Generated by CM-Beetle Test CLI on 2026-06-02 20:56:57 KST*


### PR DESCRIPTION
- Update data migration tests across 10 CSP pairs
- Update infra migration tests (6 CSPs passing)
- Upgrade CB-Tumblebug to v0.12.13
- Upgrade CB-Spider to v0.12.26