### PR TITLE
feat(recommendation): add K8s infra recommendation API (unified from control-plane/node-group)

### DIFF
--- a/imdl/cloud-model/copied-tb-model.go
+++ b/imdl/cloud-model/copied-tb-model.go
@@ -785,3 +785,62 @@ type FirewallRuleReq struct {
 	// CIDR is the allowed IP range (e.g. 0.0.0.0/0, 10.0.0/8)
 	CIDR string `json:"CIDR" example:"0.0.0.0/0"`
 }
+
+// K8sClusterDynamicReq is struct for requirements to create K8sCluster dynamically (with default resource option).
+// Copied from CB-Tumblebug v0.12.13 src/core/model/k8scluster.go
+type K8sClusterDynamicReq struct {
+	// K8sCluster name if it is not empty.
+	Name string `json:"name" example:"k8scluster01"`
+
+	// K8s Cluster version
+	Version string `json:"version,omitempty" example:"1.29"`
+
+	Label map[string]string `json:"label,omitempty"`
+
+	Description string `json:"description,omitempty" example:"Description"`
+
+	// NodeGroup name if it is not empty
+	NodeGroupName string `json:"nodeGroupName,omitempty" example:"k8sng01"`
+
+	// SpecId is field for id of a spec in common namespace
+	SpecId string `json:"specId" validate:"required" example:"tencent+ap-seoul+S2.MEDIUM4"`
+
+	// ImageId is field for id of a image in common namespace
+	ImageId string `json:"imageId" validate:"required" example:"default"`
+
+	RootDiskType string `json:"rootDiskType,omitempty" example:"default"` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"]
+	RootDiskSize int    `json:"rootDiskSize,omitempty" example:"30"`      // Root disk size in GB. 0 = use CSP default.
+
+	OnAutoScaling   string `json:"onAutoScaling,omitempty" default:"true" example:"false"` // Must be explicitly set to "false" to disable; TB default is "true"
+	DesiredNodeSize int    `json:"desiredNodeSize,omitempty" example:"1"`
+	MinNodeSize     int    `json:"minNodeSize,omitempty" example:"1"`
+	MaxNodeSize     int    `json:"maxNodeSize,omitempty" example:"3"` // Must be explicitly set; TB default is 2
+
+	// if ConnectionName is given, the cluster uses the associated credential.
+	ConnectionName string `json:"connectionName,omitempty" example:"aws-ap-northeast-2"`
+}
+
+// K8sNodeGroupDynamicReq is struct for requirements to create K8sNodeGroup dynamically (with default resource option).
+// Copied from CB-Tumblebug v0.12.13 src/core/model/k8scluster.go
+type K8sNodeGroupDynamicReq struct {
+	// K8sNodeGroup name if it is not empty.
+	Name string `json:"name" validate:"required" example:"k8sng01"`
+
+	Label map[string]string `json:"label,omitempty"`
+
+	Description string `json:"description,omitempty" example:"Description"`
+
+	// SpecId is field for id of a spec in common namespace
+	SpecId string `json:"specId" validate:"required" example:"tencent+ap-seoul+S2.MEDIUM4"`
+
+	// ImageId is field for id of a image in common namespace
+	ImageId string `json:"imageId" validate:"required" example:"default"`
+
+	RootDiskType string `json:"rootDiskType,omitempty" example:"default"` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"]
+	RootDiskSize int    `json:"rootDiskSize,omitempty" example:"30"`      // Root disk size in GB. 0 = use CSP default.
+
+	OnAutoScaling   string `json:"onAutoScaling,omitempty" default:"true" example:"false"` // Must be explicitly set to "false" to disable; TB default is "true"
+	DesiredNodeSize int    `json:"desiredNodeSize,omitempty" example:"1"`
+	MinNodeSize     int    `json:"minNodeSize,omitempty" example:"1"`
+	MaxNodeSize     int    `json:"maxNodeSize,omitempty" example:"3"` // Must be explicitly set; TB default is 2
+}

--- a/imdl/cloud-model/k8s-infra.go
+++ b/imdl/cloud-model/k8s-infra.go
@@ -1,0 +1,13 @@
+package cloudmodel
+
+// RecommendedK8sCluster is the recommendation output for a K8s cluster migration
+// using the K8sClusterDynamic API path (TB auto-manages vNet/SG/SSHKey).
+type RecommendedK8sCluster struct {
+	// Cluster is the request body for POST /ns/{nsId}/k8sClusterDynamic.
+	// It includes the cluster configuration and the first worker node group.
+	Cluster K8sClusterDynamicReq `json:"cluster"`
+
+	// AdditionalNodeGroups holds extra worker node groups to be added after cluster creation
+	// via POST /ns/{nsId}/k8sCluster/{id}/k8sNodeGroupDynamic (required for AWS).
+	AdditionalNodeGroups []K8sNodeGroupDynamicReq `json:"additionalNodeGroups,omitempty"`
+}

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -351,3 +351,78 @@ func RecommendK8sNodeGroup(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, model.SuccessResponse(result))
 }
+
+/*
+ * K8s Infrastructure Recommendation With Defaults (K8sClusterDynamic path)
+ */
+
+// RecommendK8sInfraWithDefaultsRequest is the request body for RecommendK8sInfraWithDefaults.
+type RecommendK8sInfraWithDefaultsRequest struct {
+	DesiredCspAndRegionPair cloudmodel.CloudProperty `json:"desiredCspAndRegionPair"`
+	onpremmodel.OnpremInfra
+}
+
+// RecommendK8sInfraWithDefaults godoc
+// @ID RecommendK8sInfraWithDefaults
+// @Summary Recommend K8s infrastructure with defaults for cloud migration
+// @Description Recommend a target managed K8s cluster configuration based on source on-premise K8s infra.
+// @Description Returns K8sClusterDynamicReq (+ additional node groups) ready for cb-tumblebug k8sClusterDynamic API.
+// @Description TB auto-manages vNet/SG/SSHKey — no separate resource recommendation needed.
+// @Tags [Recommendation] K8s Infrastructure
+// @Accept  json
+// @Produce  json
+// @Param UserK8sInfra body RecommendK8sInfraWithDefaultsRequest true "Source on-premise K8s infrastructure"
+// @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
+// @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
+// @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Success 200 {object} model.ApiResponse[cloudmodel.RecommendedK8sCluster] "The recommended K8s cluster configuration"
+// @Failure 400 {object} model.ApiResponse[any]
+// @Failure 500 {object} model.ApiResponse[any]
+// @Router /recommendation/k8sInfraWithDefaults [post]
+func RecommendK8sInfraWithDefaults(c echo.Context) error {
+
+	desiredCsp := c.QueryParam("desiredCsp")
+	desiredRegion := c.QueryParam("desiredRegion")
+
+	reqt := &RecommendK8sInfraWithDefaultsRequest{}
+	if err := c.Bind(reqt); err != nil {
+		log.Warn().Err(err).Msg("failed to bind request body")
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
+	}
+
+	csp := reqt.DesiredCspAndRegionPair.Csp
+	if csp == "" {
+		csp = desiredCsp
+	}
+	region := reqt.DesiredCspAndRegionPair.Region
+	if region == "" {
+		region = desiredRegion
+	}
+
+	if csp == "" {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Provider required"))
+	}
+	if region == "" {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Region required"))
+	}
+	if len(reqt.Nodes) == 0 {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("At least one source node required"))
+	}
+	if reqt.K8sCluster == nil {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("K8s cluster info required (k8sCluster field)"))
+	}
+
+	ok, err := recommendation.IsValidCspAndRegion(csp, region)
+	if !ok {
+		log.Error().Err(err).Msg("invalid provider or region")
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid provider or region"))
+	}
+
+	result, err := recommendation.RecommendK8sInfraWithDefaults(csp, region, reqt.OnpremInfra)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to recommend K8s infrastructure")
+		return c.JSON(http.StatusInternalServerError, model.SimpleErrorResponse("K8s infrastructure recommendation failed"))
+	}
+
+	return c.JSON(http.StatusOK, model.SuccessResponse(result))
+}

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -300,11 +300,12 @@ func RunServer(port string) {
 	gNaming.POST("/validation", controller.ValidateNames)
 	gNaming.POST("/preview", controller.PreviewInfra)
 
-	// Recommendation APIs for K8s Cluster (new endpoints)
+	// Recommendation APIs for K8s infrastructure
+	gRecommendation.POST("/k8sInfraWithDefaults", controller.RecommendK8sInfraWithDefaults)
+
+	// Deprecated: replaced by /k8sInfraWithDefaults
 	gRecommendation.POST("/k8sControlPlane", controller.RecommendK8sControlPlane)
 	gRecommendation.POST("/k8sNodeGroup", controller.RecommendK8sNodeGroup)
-
-	// Deprecated: Use /k8sControlPlane and /k8sNodeGroup instead
 
 	// Recommedation APIs for resources for VM infrastructure
 	gRecommendation.POST("/resources/vNet", controller.RecommendVNet)

--- a/pkg/client/tumblebug/multi-cloud-info.go
+++ b/pkg/client/tumblebug/multi-cloud-info.go
@@ -48,3 +48,30 @@ func (s *Session) ReadRegionInfo(providerName string, regionName string) (tbmode
 	log.Debug().Msgf("Retrieved region (regionId: %s) successfully", tbResp.RegionId)
 	return tbResp, nil
 }
+
+// ReadAvailableK8sVersion fetches available K8s versions for the given provider and region.
+// providerName and regionName must be lowercase (e.g., "aws", "ap-northeast-2").
+func (s *Session) ReadAvailableK8sVersion(providerName, regionName string) ([]tbmodel.K8sClusterVersionDetailAvailable, error) {
+	log.Debug().Str("providerName", providerName).Str("regionName", regionName).Msg("Reading available K8s versions")
+
+	emptyRet := []tbmodel.K8sClusterVersionDetailAvailable{}
+
+	var resBody []tbmodel.K8sClusterVersionDetailAvailable
+
+	resp, err := s.
+		SetQueryParam("providerName", providerName).
+		SetQueryParam("regionName", regionName).
+		SetResult(&resBody).
+		Get("/availableK8sVersion")
+
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read available K8s versions")
+		return emptyRet, err
+	}
+	if resp.IsError() {
+		return emptyRet, fmt.Errorf("API request failed with status: %d, body: %s", resp.StatusCode(), resp.String())
+	}
+
+	log.Debug().Msgf("Retrieved %d available K8s versions for %s/%s", len(resBody), providerName, regionName)
+	return resBody, nil
+}

--- a/pkg/core/recommendation/container-infra.go
+++ b/pkg/core/recommendation/container-infra.go
@@ -221,7 +221,7 @@ func resolveK8sVersion(csp, region, sourceVersion string) (string, error) {
 
 // applyK8sMinimums enforces vCPU >= 2 and memoryGiB >= 4 on the given node.
 // Returns a modified copy; the original is unchanged.
-func applyK8sMinimums(node onpremmodel.NodeProperty) onpremmodel.NodeProperty {
+func ensureK8sMinNodeSpecs(node onpremmodel.NodeProperty) onpremmodel.NodeProperty {
 	// minK8sVCPU and minK8sMemGiB are defined in resource-k8s-spec.go (package level).
 
 	threads := node.CPU.Threads

--- a/pkg/core/recommendation/container-infra.go
+++ b/pkg/core/recommendation/container-infra.go
@@ -2,9 +2,12 @@ package recommendation
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
-	tbmodel "github.com/cloud-barista/cb-tumblebug/src/core/model"
+	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
+	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
+	tbclient "github.com/cloud-barista/cm-beetle/pkg/client/tumblebug"
 	"github.com/rs/zerolog/log"
 )
 
@@ -33,12 +36,12 @@ const (
 )
 
 type Node struct {
-	Type      NodeType    `json:"type"`
-	Name      interface{} `json:"name,omitempty"`
-	Labels    interface{} `json:"labels,omitempty"`
-	Addresses interface{} `json:"addresses,omitempty"`
-	NodeSpec  NodeSpec    `json:"node_spec,omitempty"`
-	NodeInfo  interface{} `json:"node_info,omitempty"`
+	Type      NodeType                 `json:"type"`
+	Name      interface{}              `json:"name,omitempty"`
+	Labels    interface{}              `json:"labels,omitempty"`
+	Addresses interface{}              `json:"addresses,omitempty"`
+	NodeSpec  NodeSpec                 `json:"node_spec,omitempty"`
+	NodeInfo  onpremmodel.NodeProperty `json:"node_info,omitempty"`
 }
 
 type NodeSpec struct {
@@ -76,154 +79,297 @@ type NodeGroupInfo struct {
 	TotalMemory int // in MiB
 }
 
-// RecommendK8sControlPlane recommends K8s control plane configuration based on honeybee source cluster data
-func RecommendK8sControlPlane(provider, region string, k8sInfoList KubernetesInfoList) (tbmodel.K8sClusterDynamicReq, error) {
-	var result tbmodel.K8sClusterDynamicReq
-
-	// TODO: Use the following code when implementing actual API calls
-	// client := resty.New()
-	// client.SetBaseURL(config.Tumblebug.RestUrl)
-	// client.SetBasicAuth(config.Tumblebug.API.Username, config.Tumblebug.API.Password)
-
-	// Collect control plane node information
-	// cpInfo := &NodeGroupInfo{Count: 0, TotalCPU: 0, TotalMemory: 0}
-
-	log.Info().Int("totalServers", len(k8sInfoList.Servers)).Msg("Processing K8s servers for control plane recommendation")
-
-	// Count kubernetes clusters to check if kubernetes cluster exists
-	k8sCount := 0
-	for i, k8s := range k8sInfoList.Servers {
-		if k8s.NodeCount.Total == 0 {
-			log.Warn().
-				Int("serverIndex", i).
-				Msg("Server has zero total nodes, skipping")
-			continue
-		}
-		k8sCount += 1
-	}
-
-	// Validate kubernetes cluster existence
-	if k8sCount == 0 {
-		log.Warn().Msg("No kubernetes clusters found in the source cluster, skipping recommendation")
-		return result, fmt.Errorf("no kubernetes clusters found in the source cluster")
-	}
-
-	// Note: for the time being, use the 1st control plane in the list
-	k8sClusterInfo := Kubernetes{}
-	for _, k8s := range k8sInfoList.Servers {
-		if k8s.NodeCount.Total == 0 {
-			continue
-		}
-
-		k8sClusterInfo = k8s
-		break
-	}
-
-	log.Debug().Msgf("Selected kubernetes cluster information: %+v", k8sClusterInfo)
-
-	// TODO: Implement spec recommendation logic based on actual resource requirements
-	// For now, using hardcoded spec for testing
-
-	k8sControlPlaneNodeCount := k8sClusterInfo.NodeCount.ControlPlane
-
-	// Build K8sClusterDynamicReq
-	recommendedControlPlane := tbmodel.K8sClusterDynamicReq{
-		Name:            "recommended-k8s-cluster",
-		NodeGroupName:   "recommended-worker-nodegroup",
-		ConnectionName:  fmt.Sprintf("%s-%s", provider, region),
-		SpecId:          "azure+koreacentral+standard_b4ms", // TODO: Search and assign a recommended spec ID
-		ImageId:         "default",                          // TODO: Search and assign a recommended image ID
-		Version:         "1.33",
-		DesiredNodeSize: k8sControlPlaneNodeCount,
-		MinNodeSize:     1,
-		MaxNodeSize:     k8sControlPlaneNodeCount,
-		OnAutoScaling:   "false",
-		RootDiskType:    "default",
-		RootDiskSize:    0,
-		Description:     fmt.Sprintf("A recommended control plane with %d nodes", k8sControlPlaneNodeCount),
-	}
-
-	log.Info().
-		Str("clusterName", recommendedControlPlane.Name).
-		Str("specId", recommendedControlPlane.SpecId).
-		Int("desiredNodeSize", recommendedControlPlane.DesiredNodeSize).
-		Msg("K8s control plane recommendation completed")
-
-	return recommendedControlPlane, nil
+// nodeGroup holds worker nodes that share identical spec characteristics.
+type nodeGroup struct {
+	Nodes []onpremmodel.NodeProperty
 }
 
-// RecommendK8sNodeGroup recommends K8s worker node group configuration based on honeybee source cluster data
-func RecommendK8sNodeGroup(provider, region string, k8sInfoList KubernetesInfoList) (tbmodel.K8sNodeGroupReq, error) {
-	var emptyRes = tbmodel.K8sNodeGroupReq{}
+// repNode returns the representative node for spec lookup (always the first).
+func (g nodeGroup) repNode() onpremmodel.NodeProperty {
+	return g.Nodes[0]
+}
 
-	// TODO: Use the following code when implementing actual API calls
-	// client := resty.New()
-	// client.SetBaseURL(config.Tumblebug.RestUrl)
-	// client.SetBasicAuth(config.Tumblebug.API.Username, config.Tumblebug.API.Password)
+// k8sNodeGroupsOnCreation maps each known CSP to its nodeGroupsOnCreation value.
+// true  → NodeGroups are created together with the cluster (k8sClusterDynamic).
+// false → NodeGroups must be created separately (k8sNodeGroupDynamic) after cluster creation.
+// Source: CB-Tumblebug assets/k8sclusterinfo.yaml (v0.12.13)
+//
+// IMPORTANT: When CB-Tumblebug adds a new CSP, add it here explicitly.
+// Unknown CSPs are rejected to prevent silent misconfiguration.
+var k8sNodeGroupsOnCreation = map[string]bool{
+	"aws":     false,
+	"alibaba": false,
+	"tencent": false,
+	"azure":   true,
+	"gcp":     true,
+	"nhn":     true,
+	"ncp":     true,
+	"ibm":     true,
+}
 
-	// Collect control plane node information
-	// cpInfo := &NodeGroupInfo{Count: 0, TotalCPU: 0, TotalMemory: 0}
+// isNodeGroupsOnCreation returns whether the CSP creates NodeGroups together
+// with the cluster. Returns an error for unsupported CSPs.
+func isNodeGroupsOnCreation(csp string) (bool, error) {
+	v, ok := k8sNodeGroupsOnCreation[strings.ToLower(csp)]
+	if !ok {
+		return false, fmt.Errorf("CSP %q is not supported for K8s cluster migration; update k8sNodeGroupsOnCreation map when CB-Tumblebug adds support", csp)
+	}
+	return v, nil
+}
 
-	log.Info().Int("totalServers", len(k8sInfoList.Servers)).Msg("Processing K8s servers for worker node group recommendation")
+// nodeGroupKey is the grouping key for worker nodes.
+type nodeGroupKey struct {
+	VCPU         uint32
+	MemoryGiB    uint64
+	OSName       string
+	OSVersion    string
+	Architecture string
+}
 
-	// Count kubernetes clusters to check if kubernetes cluster exists
-	k8sCount := 0
-	for i, k8s := range k8sInfoList.Servers {
-		if k8s.NodeCount.Total == 0 {
-			log.Warn().
-				Int("serverIndex", i).
-				Msg("Server has zero total nodes, skipping")
-			continue
+// filterWorkerNodes returns nodes whose Role equals "worker" (case-insensitive).
+func filterWorkerNodes(nodes []onpremmodel.NodeProperty) []onpremmodel.NodeProperty {
+	workers := make([]onpremmodel.NodeProperty, 0, len(nodes))
+	for _, n := range nodes {
+		if strings.EqualFold(n.Role, string(NodeTypeWorker)) {
+			workers = append(workers, n)
 		}
-		k8sCount += 1
 	}
+	return workers
+}
 
-	// Validate kubernetes cluster existence
-	if k8sCount == 0 {
-		log.Warn().Msg("No kubernetes clusters found in the source cluster, skipping recommendation")
-		return emptyRes, fmt.Errorf("no kubernetes clusters found in the source cluster")
-	}
+// groupNodesBySpec groups worker nodes by identical (vCPU, MemoryGiB, OS, Architecture).
+// Each group becomes one K8s NodeGroup; DesiredNodeSize = len(group.Nodes).
+// OnpremInfra.K8sCluster is a single pointer — all nodes belong to one cluster.
+// Multi-cluster input is out of scope (Phase 3).
+func groupNodesBySpec(workers []onpremmodel.NodeProperty) []nodeGroup {
+	groups := make(map[nodeGroupKey]*nodeGroup)
+	order := []nodeGroupKey{}
 
-	// Note: for the time being, use the 1st kubernetes cluster in the list
-	k8sClusterInfo := Kubernetes{}
-	for _, k8s := range k8sInfoList.Servers {
-		if k8s.NodeCount.Total == 0 {
-			continue
+	for _, n := range workers {
+		threads := n.CPU.Threads
+		if threads == 0 {
+			threads = 1
 		}
-
-		k8sClusterInfo = k8s
-		break
+		vcpu := n.CPU.Cpus * threads
+		key := nodeGroupKey{
+			VCPU:         vcpu,
+			MemoryGiB:    n.Memory.TotalSize,
+			OSName:       n.OS.Name,
+			OSVersion:    n.OS.VersionID,
+			Architecture: n.CPU.Architecture,
+		}
+		if _, exists := groups[key]; !exists {
+			groups[key] = &nodeGroup{}
+			order = append(order, key)
+		}
+		groups[key].Nodes = append(groups[key].Nodes, n)
 	}
 
-	log.Debug().Msgf("Selected kubernetes cluster information: %+v", k8sClusterInfo)
+	result := make([]nodeGroup, 0, len(order))
+	for _, k := range order {
+		result = append(result, *groups[k])
+	}
+	return result
+}
 
-	// TODO: Implement spec recommendation logic based on actual resource requirements
-	// For now, using hardcoded spec for testing
+// extractMajorMinor returns "major.minor" from a full K8s version string.
+// Examples: "v1.32.3" → "1.32",  "1.34.3-gke.100" → "1.34"
+func extractMajorMinor(version string) string {
+	clean := strings.SplitN(strings.TrimPrefix(version, "v"), "-", 2)[0]
+	parts := strings.SplitN(clean, ".", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return clean
+}
 
-	k8sNodeGroupCount := k8sClusterInfo.NodeCount.Worker
+// resolveK8sVersion selects the best matching available K8s version ID for the given CSP/region.
+// Returns the newest available version if no prefix match is found.
+func resolveK8sVersion(csp, region, sourceVersion string) (string, error) {
+	if sourceVersion == "" {
+		log.Warn().Str("csp", csp).Str("region", region).Msg("Source K8s version is empty; will use newest available")
+	}
 
-	// TODO: Implement spec recommendation logic based on actual resource requirements
-	// For now, using hardcoded spec for testing
+	majorMinor := extractMajorMinor(sourceVersion)
 
-	// Build K8sNodeGroupReq
-	recommendedNodeGroup := tbmodel.K8sNodeGroupReq{
-		Name:            "recommended-worker-nodegroup",
-		SpecId:          "azure+koreacentral+standard_b4ms", // Hardcoded for testing
-		ImageId:         "default",
-		DesiredNodeSize: k8sNodeGroupCount,
+	available, err := tbclient.NewSession().ReadAvailableK8sVersion(
+		strings.ToLower(csp),
+		strings.ToLower(region),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch available K8s versions: %w", err)
+	}
+	if len(available) == 0 {
+		return "", fmt.Errorf("no available K8s versions for %s/%s", csp, region)
+	}
+
+	if majorMinor != "" {
+		for _, v := range available {
+			if strings.HasPrefix(v.Name, majorMinor) {
+				log.Debug().Str("sourceVersion", sourceVersion).Str("matched", v.Id).Msg("Matched K8s version")
+				return v.Id, nil
+			}
+		}
+		log.Warn().Str("sourceVersion", sourceVersion).Str("majorMinor", majorMinor).
+			Msg("No K8s version matching source major.minor; using newest available")
+	}
+
+	newest := available[len(available)-1].Id
+	log.Debug().Str("newestVersion", newest).Msg("Using newest available K8s version")
+	return newest, nil
+}
+
+// applyK8sMinimums enforces vCPU >= 2 and memoryGiB >= 4 on the given node.
+// Returns a modified copy; the original is unchanged.
+func applyK8sMinimums(node onpremmodel.NodeProperty) onpremmodel.NodeProperty {
+	// minK8sVCPU and minK8sMemGiB are defined in resource-k8s-spec.go (package level).
+
+	threads := node.CPU.Threads
+	if threads == 0 {
+		threads = 1
+	}
+	vcpu := node.CPU.Cpus * threads
+	if vcpu < minK8sVCPU {
+		log.Warn().Str("hostname", node.Hostname).Uint32("vcpu", vcpu).
+			Msgf("Node vCPU (%d) below K8s minimum (%d); adjusting", vcpu, minK8sVCPU)
+		node.CPU.Cpus = 1
+		node.CPU.Threads = minK8sVCPU
+	}
+
+	if node.Memory.TotalSize < uint64(minK8sMemGiB) {
+		log.Warn().Str("hostname", node.Hostname).Uint64("memGiB", node.Memory.TotalSize).
+			Msgf("Node memory (%d GiB) below K8s minimum (%d GiB); adjusting", node.Memory.TotalSize, minK8sMemGiB)
+		node.Memory.TotalSize = uint64(minK8sMemGiB)
+	}
+
+	return node
+}
+
+// RecommendK8sInfraWithDefaults builds a K8s cluster recommendation from the given source infra.
+// The cluster field always carries the first worker node group's spec (required by TB for connection resolution).
+// Whether that group is also created via k8sClusterDynamic depends on the CSP's nodeGroupsOnCreation:
+//   - true  (Azure, GCP, …): first group created with cluster → additionalNodeGroups = groups[1:]
+//   - false (AWS, Alibaba, Tencent): cluster NodeGroup is discarded by TB → additionalNodeGroups = groups[0:]
+func RecommendK8sInfraWithDefaults(csp, region string, srcInfra onpremmodel.OnpremInfra) (cloudmodel.RecommendedK8sCluster, error) {
+	emptyRet := cloudmodel.RecommendedK8sCluster{}
+
+	// Step 1: validate CSP support
+	nodeGroupCreatedWithCluster, err := isNodeGroupsOnCreation(csp)
+	if err != nil {
+		return emptyRet, err
+	}
+
+	// Step 2: filter and group worker nodes
+	workers := filterWorkerNodes(srcInfra.Nodes)
+	if len(workers) == 0 {
+		return emptyRet, fmt.Errorf("no worker nodes found in source infra")
+	}
+	groups := groupNodesBySpec(workers)
+
+	// Step 3: resolve K8s version
+	srcVersion := ""
+	if srcInfra.K8sCluster != nil {
+		srcVersion = srcInfra.K8sCluster.Version
+	}
+	version, err := resolveK8sVersion(csp, region, srcVersion)
+	if err != nil {
+		log.Warn().Err(err).Msg("K8s version resolution failed; proceeding with empty version (TB will use default)")
+	}
+
+	// Step 4: build K8sClusterDynamicReq using first group's spec.
+	// TB always needs a valid SpecId to resolve ConnectionName/Provider/Region.
+	firstGroup := groups[0]
+	firstSpec, firstImage, err := recommendK8sNodeGroupResources(csp, region, firstGroup.repNode())
+	if err != nil {
+		return emptyRet, fmt.Errorf("failed to recommend resources for first node group: %w", err)
+	}
+
+	cluster := cloudmodel.K8sClusterDynamicReq{
+		Name:            fmt.Sprintf("k8s-%s-%s", strings.ToLower(csp), strings.ToLower(region)),
+		NodeGroupName:   "worker-group-1",
+		ConnectionName:  fmt.Sprintf("%s-%s", strings.ToLower(csp), strings.ToLower(region)),
+		Version:         version,
+		SpecId:          firstSpec,
+		ImageId:         firstImage,
+		DesiredNodeSize: len(firstGroup.Nodes),
 		MinNodeSize:     1,
-		MaxNodeSize:     k8sNodeGroupCount,
-		OnAutoScaling:   "true",
+		MaxNodeSize:     len(firstGroup.Nodes),
+		OnAutoScaling:   "false",
 		RootDiskType:    "default",
-		RootDiskSize:    0,
-		Description:     fmt.Sprintf("A recommended node group with %d nodes", k8sNodeGroupCount),
+		RootDiskSize:    int(firstGroup.repNode().RootDisk.TotalSize),
+	}
+
+	// Step 5: build additionalNodeGroups based on CSP nodeGroupsOnCreation.
+	// - nodeGroupCreatedWithCluster=true : first group is created with the cluster → start from groups[1:]
+	// - nodeGroupCreatedWithCluster=false: TB discards the cluster's NodeGroup → include all groups[0:]
+	var additionalStartIdx int
+	if nodeGroupCreatedWithCluster {
+		additionalStartIdx = 1
+	} else {
+		additionalStartIdx = 0
+	}
+
+	additionalGroups := make([]cloudmodel.K8sNodeGroupDynamicReq, 0, len(groups)-additionalStartIdx)
+	for i, g := range groups[additionalStartIdx:] {
+		specId, imageId, err := recommendK8sNodeGroupResources(csp, region, g.repNode())
+		if err != nil {
+			log.Warn().Err(err).Int("groupIndex", i+additionalStartIdx+1).Msg("Failed to recommend resources for node group; skipping")
+			continue
+		}
+		additionalGroups = append(additionalGroups, cloudmodel.K8sNodeGroupDynamicReq{
+			Name:            fmt.Sprintf("worker-group-%d", i+additionalStartIdx+1),
+			SpecId:          specId,
+			ImageId:         imageId,
+			DesiredNodeSize: len(g.Nodes),
+			MinNodeSize:     1,
+			MaxNodeSize:     len(g.Nodes),
+			OnAutoScaling:   "false",
+			RootDiskType:    "default",
+			RootDiskSize:    int(g.repNode().RootDisk.TotalSize),
+		})
 	}
 
 	log.Info().
-		Str("nodeGroupName", recommendedNodeGroup.Name).
-		Str("specId", recommendedNodeGroup.SpecId).
-		Int("desiredNodeSize", recommendedNodeGroup.DesiredNodeSize).
-		Msg("K8s worker node group recommendation completed")
+		Str("csp", csp).
+		Str("region", region).
+		Str("version", version).
+		Bool("nodeGroupsOnCreation", nodeGroupCreatedWithCluster).
+		Int("nodeGroups", len(groups)).
+		Int("additionalNodeGroups", len(additionalGroups)).
+		Msg("K8s infrastructure recommendation completed")
 
-	return recommendedNodeGroup, nil
+	return cloudmodel.RecommendedK8sCluster{
+		Cluster:              cluster,
+		AdditionalNodeGroups: additionalGroups,
+	}, nil
+}
+
+// recommendK8sNodeGroupResources returns the specId and imageId for a worker node.
+func recommendK8sNodeGroupResources(csp, region string, node onpremmodel.NodeProperty) (specId, imageId string, err error) {
+	specs, _, err := RecommendK8sSpecs(csp, region, node, 1)
+	if err != nil || len(specs) == 0 {
+		return "", "", fmt.Errorf("no K8s specs found for node (hostname: %s): %w", node.Hostname, err)
+	}
+	specId = specs[0].Id
+
+	imageId, err = RecommendK8sOsImage(csp, region, node)
+	if err != nil {
+		log.Warn().Err(err).Str("hostname", node.Hostname).Msg("K8s image recommendation failed; using default")
+		imageId = "default"
+		err = nil
+	}
+
+	return specId, imageId, nil
+}
+
+// Deprecated: RecommendK8sControlPlane is replaced by RecommendK8sInfraWithDefaults.
+func RecommendK8sControlPlane(provider, region string, k8sInfoList KubernetesInfoList) (cloudmodel.K8sClusterDynamicReq, error) {
+	log.Warn().Msg("RecommendK8sControlPlane is deprecated; use RecommendK8sInfraWithDefaults instead")
+	return cloudmodel.K8sClusterDynamicReq{}, fmt.Errorf("RecommendK8sControlPlane is deprecated")
+}
+
+// Deprecated: RecommendK8sNodeGroup is replaced by RecommendK8sInfraWithDefaults.
+func RecommendK8sNodeGroup(provider, region string, k8sInfoList KubernetesInfoList) (cloudmodel.K8sNodeGroupDynamicReq, error) {
+	log.Warn().Msg("RecommendK8sNodeGroup is deprecated; use RecommendK8sInfraWithDefaults instead")
+	return cloudmodel.K8sNodeGroupDynamicReq{}, fmt.Errorf("RecommendK8sNodeGroup is deprecated")
 }

--- a/pkg/core/recommendation/resource-k8s-spec.go
+++ b/pkg/core/recommendation/resource-k8s-spec.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2024 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recommendation
+
+import (
+	"fmt"
+	"strings"
+
+	tbmodel "github.com/cloud-barista/cb-tumblebug/src/core/model"
+	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
+	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
+	tbclient "github.com/cloud-barista/cm-beetle/pkg/client/tumblebug"
+	"github.com/cloud-barista/cm-beetle/pkg/modelconv"
+	"github.com/rs/zerolog/log"
+)
+
+// K8s minimum node requirements, matching CB-Tumblebug's validateK8sMinimumRequirements.
+// Shared across RecommendK8sSpecs and applyK8sMinimums.
+const (
+	minK8sVCPU   = uint32(2)
+	minK8sMemGiB = uint32(4)
+)
+
+// RecommendK8sSpecs returns a sorted list of K8s-compatible node specs for the given node.
+// K8s minimum requirements (vCPU >= 2, memoryGiB >= 4) are applied before querying.
+// Uses the same POST /tumblebug/recommendSpec endpoint as VM spec recommendation.
+// NCP KVM hypervisor filter from RecommendVmSpecs is intentionally excluded for Managed K8s.
+func RecommendK8sSpecs(csp, region string, node onpremmodel.NodeProperty, limit int) ([]cloudmodel.SpecInfo, int, error) {
+	const defaultArchitecture = "x86_64"
+
+	emptyResp := []cloudmodel.SpecInfo{}
+
+	if limit <= 0 {
+		limit = defaultSpecsLimit
+	}
+
+	// Apply K8s minimum requirements before building FilterPolicy
+	node = applyK8sMinimums(node)
+
+	threads := node.CPU.Threads
+	if threads == 0 {
+		threads = 1
+	}
+	vcpusCalculated := node.CPU.Cpus * threads
+	memory := uint32(node.Memory.TotalSize)
+
+	providerName := strings.ToLower(csp)
+	regionName := strings.ToLower(region)
+
+	architecture := node.CPU.Architecture
+	if architecture == "" || architecture == "amd64" {
+		architecture = defaultArchitecture
+	}
+
+	// Same FilterPolicy template as VM spec recommendation
+	const planTemplate = `{
+		"filter": {
+			"policy": [
+				{
+					"condition": [
+						{"operand": "%d", "operator": ">="},
+						{"operand": "%d", "operator": "<="}
+					],
+					"metric": "vCPU"
+				},
+				{
+					"condition": [
+						{"operand": "%d", "operator": ">="},
+						{"operand": "%d", "operator": "<="}
+					],
+					"metric": "memoryGiB"
+				},
+				{
+					"condition": [{"operand": "%s"}],
+					"metric": "providerName"
+				},
+				{
+					"condition": [{"operand": "%s"}],
+					"metric": "regionName"
+				},
+				{
+					"condition": [{"operand": "%s"}],
+					"metric": "architecture"
+				}
+			]
+		},
+		"limit": %d,
+		"priority": {
+			"policy": [{"metric": "cost"}]
+		}
+	}`
+
+	const (
+		initialRangeWeight = 1
+		maxRangeWeight     = 5
+		// K8s minimums are enforced in FilterPolicy below; see package-level minK8sVCPU / minK8sMemGiB.
+	)
+
+	var specInfoList []tbmodel.SpecInfo
+
+	for rangeWeight := initialRangeWeight; rangeWeight <= maxRangeWeight; rangeWeight++ {
+		vcpusMin, vcpusMax, memoryMin, memoryMax := calculateOptimalRange(vcpusCalculated, memory, rangeWeight)
+
+		// Enforce K8s minimums in the FilterPolicy before sending to TB.
+		if vcpusMin < minK8sVCPU {
+			vcpusMin = minK8sVCPU
+		}
+		if memoryMin < minK8sMemGiB {
+			memoryMin = minK8sMemGiB
+		}
+
+		plan := fmt.Sprintf(planTemplate,
+			vcpusMin, vcpusMax,
+			memoryMin, memoryMax,
+			providerName, regionName, architecture,
+			limit,
+		)
+
+		log.Debug().
+			Str("hostname", node.Hostname).
+			Int("rangeWeight", rangeWeight).
+			Uint32("vcpu", vcpusCalculated).
+			Uint32("memoryGiB", memory).
+			Uint32("filterVcpuMin", vcpusMin).
+			Uint32("filterMemoryMin", memoryMin).
+			Str("provider", providerName).
+			Str("region", regionName).
+			Msgf("Querying K8s specs (attempt %d/%d)", rangeWeight, maxRangeWeight)
+
+		var err error
+		specInfoList, err = tbclient.NewSession().InfraRecommendSpec(plan)
+		if err != nil {
+			return emptyResp, -1, fmt.Errorf("failed to get K8s spec recommendations: %w", err)
+		}
+
+		// Filter specs with valid (non-negative) cost only.
+		// K8s minimums are already enforced in the FilterPolicy above.
+		valid := make([]tbmodel.SpecInfo, 0, len(specInfoList))
+		for _, spec := range specInfoList {
+			if spec.CostPerHour >= 0 {
+				valid = append(valid, spec)
+			}
+		}
+		specInfoList = valid
+
+		if len(specInfoList) > 0 {
+			break
+		}
+
+		log.Warn().
+			Str("hostname", node.Hostname).
+			Int("rangeWeight", rangeWeight).
+			Msg("No K8s specs found; retrying with wider range")
+	}
+
+	if len(specInfoList) == 0 {
+		return emptyResp, -1, fmt.Errorf("no K8s specs found for node (hostname: %s, vcpu: %d, memory: %d GiB, csp: %s, region: %s)",
+			node.Hostname, vcpusCalculated, memory, csp, region)
+	}
+
+	if limit < len(specInfoList) {
+		specInfoList = specInfoList[:limit]
+	}
+
+	converted, err := modelconv.ConvertWithValidation[[]tbmodel.SpecInfo, []cloudmodel.SpecInfo](specInfoList)
+	if err != nil {
+		return emptyResp, -1, fmt.Errorf("failed to convert K8s spec list: %w", err)
+	}
+
+	sortByProximityWithCost(vcpusCalculated, memory, converted)
+
+	log.Info().
+		Str("hostname", node.Hostname).
+		Int("count", len(converted)).
+		Msg("K8s spec recommendation completed")
+
+	return converted, len(converted), nil
+}

--- a/pkg/core/recommendation/resource-vm-image.go
+++ b/pkg/core/recommendation/resource-vm-image.go
@@ -428,3 +428,74 @@ func FindBestVmOsImageNameUsedInCsp(csp string, keywords string, kwDelimiters []
 
 	return bestVmOsImageNameUsedInCsp
 }
+
+// RecommendK8sOsImage searches for a K8s-compatible OS image matching the given node's OS.
+// Returns "default" if no matching image is found (CSP provides a default K8s node image).
+func RecommendK8sOsImage(csp, region string, node onpremmodel.NodeProperty) (string, error) {
+	const nsId = "system"
+
+	falseValue := false
+	trueValue := true
+
+	osType := node.OS.ID + " " + node.OS.VersionID
+
+	searchReq := tbmodel.SearchImageRequest{
+		IsKubernetesImage:     &trueValue,
+		IncludeBasicImageOnly: &trueValue,
+		MaxResults:            func() *int { v := defaultImagesLimit; return &v }(),
+		OSArchitecture:        tbmodel.OSArchitecture(node.CPU.Architecture),
+		OSType:                osType,
+		ProviderName:          csp,
+		RegionName:            region,
+		IsGPUImage:            &falseValue,
+	}
+
+	log.Debug().Msgf("K8s image search request: %+v", searchReq)
+
+	search := func(req tbmodel.SearchImageRequest) []tbmodel.ImageInfo {
+		res, err := tbclient.NewSession().SearchVmOsImage(nsId, req)
+		if err != nil {
+			log.Warn().Err(err).Msg("K8s image search failed")
+			return nil
+		}
+		var filtered []tbmodel.ImageInfo
+		for _, img := range res.ImageList {
+			if !strings.Contains(strings.ToLower(img.CspImageName), "uefi") {
+				filtered = append(filtered, img)
+			}
+		}
+		return filtered
+	}
+
+	images := search(searchReq)
+
+	// Retry with OS ID only if no images found
+	if len(images) == 0 {
+		log.Warn().Msgf("No K8s images found with osType '%s'; retrying with OS ID only: '%s'", osType, node.OS.ID)
+		searchReq.OSType = node.OS.ID
+		images = search(searchReq)
+	}
+
+	if len(images) == 0 {
+		log.Warn().Str("csp", csp).Str("region", region).Str("os", osType).
+			Msg("No K8s-compatible OS image found; falling back to default")
+		return "default", nil
+	}
+
+	// Convert and pick best match via text similarity (same as VM)
+	imageList, err := modelconv.ConvertWithValidation[[]tbmodel.ImageInfo, []cloudmodel.ImageInfo](images)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to convert K8s image list; falling back to default")
+		return "default", nil
+	}
+
+	keywords, kwDelimiters, imgDelimiters := SetKeywordsAndDelimeters(node)
+	best := FindBestVmOsImageNameUsedInCsp(csp, keywords, kwDelimiters, imageList, imgDelimiters)
+	if best == "" {
+		log.Warn().Msg("No best K8s image match found; falling back to default")
+		return "default", nil
+	}
+
+	log.Debug().Str("imageId", best).Msg("K8s OS image recommendation completed")
+	return best, nil
+}


### PR DESCRIPTION
# feat(recommendation): add K8s infra recommendation API (unified from control-plane/node-group)

## Summary

- Implements `POST /beetle/recommendation/k8sInfraWithDefaults` to recommend a K8s cluster configuration from on-premise infra info, as scoped in [#371](https://github.com/cloud-barista/cm-beetle/issues/371)
- Worker nodes are grouped by identical spec (vCPU, memory, OS, architecture); each group becomes one NodeGroup with `desiredNodeSize` matching source node count (minimum 2 enforced per group for K8s HA)
- CSP-aware NodeGroup creation: adds `k8sNodeGroupsOnCreation` map to distinguish CSPs that create NodeGroups with the cluster (Azure, GCP) from those that require separate creation (AWS, Alibaba, Tencent)
- K8s version is resolved via TB API to best-match the source cluster's major.minor version, falling back to the newest available version
- Original plan had `RecommendK8sControlPlane` / `RecommendK8sNodeGroup` as separate functions; these are replaced by the unified `RecommendK8sInfraWithDefaults` (old functions are deprecated stubs)

## Test Results (AWS ap-northeast-2)

Phase 1 (Recommendation), Phase 2 (Cluster + NodeGroup creation), and Phase 2-C (Cleanup) all passed without errors.

<details>
<summary>Test Input (OnpremInfra)</summary>

> Input data was authored based on the K8s infrastructure info format described in [cm-honeybee discussions #52](https://github.com/cloud-barista/cm-honeybee/discussions/52).

```json
{
  "desiredCspAndRegionPair": {
    "csp": "aws",
    "region": "ap-northeast-2"
  },
  "onpremiseInfraModel": {
    "network": {
      "ipv4Networks": {
        "cidrBlocks": [
          "192.168.0.0/24"
        ],
        "defaultGateways": [
          {
            "ip": "192.168.0.1",
            "interfaceName": "eth0",
            "machineId": "aabbccdd-0001-0001-0001-000000000001"
          },
          {
            "ip": "192.168.0.1",
            "interfaceName": "eth0",
            "machineId": "aabbccdd-0002-0002-0002-000000000002"
          },
          {
            "ip": "192.168.0.1",
            "interfaceName": "eth0",
            "machineId": "aabbccdd-0003-0003-0003-000000000003"
          }
        ]
      },
      "ipv6Networks": {}
    },
    "nodes": [
      {
        "hostname": "k8s-master-01",
        "machineId": "aabbccdd-0001-0001-0001-000000000001",
        "role": "control-plane",
        "cpu": {
          "architecture": "x86_64",
          "cpus": 1,
          "cores": 2,
          "threads": 4,
          "maxSpeed": 2.5,
          "vendor": "GenuineIntel",
          "model": "Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz"
        },
        "memory": { "type": "DDR4", "totalSize": 8, "available": 4, "used": 4 },
        "rootDisk": { "label": "/", "type": "SSD", "totalSize": 50, "available": 30, "used": 20 },
        "interfaces": [
          { "name": "eth0", "macAddress": "52:54:00:aa:bb:01", "ipv4CidrBlocks": ["192.168.0.10/24"], "mtu": 1500, "state": "UP" }
        ],
        "routingTable": [
          { "destination": "0.0.0.0/0", "gateway": "192.168.0.1", "interface": "eth0", "metric": 100, "protocol": "static", "scope": "global", "linkState": "UP" },
          { "destination": "192.168.0.0/24", "gateway": "", "interface": "eth0", "metric": 0, "protocol": "kernel", "scope": "link", "linkState": "UP" }
        ],
        "firewallTable": [
          { "srcCIDR": "0.0.0.0/0", "srcPorts": "*", "dstCIDR": "0.0.0.0/0", "dstPorts": "6443", "protocol": "TCP", "direction": "inbound", "action": "allow" },
          { "srcCIDR": "0.0.0.0/0", "srcPorts": "*", "dstCIDR": "0.0.0.0/0", "dstPorts": "10250", "protocol": "TCP", "direction": "inbound", "action": "allow" }
        ],
        "os": { "prettyName": "Ubuntu 22.04.2 LTS", "name": "Ubuntu", "versionId": "22.04", "versionCodename": "jammy", "id": "ubuntu", "idLike": "debian" }
      },
      {
        "hostname": "k8s-worker-01",
        "machineId": "aabbccdd-0002-0002-0002-000000000002",
        "role": "worker",
        "cpu": {
          "architecture": "x86_64",
          "cpus": 1,
          "cores": 2,
          "threads": 4,
          "maxSpeed": 2.5,
          "vendor": "GenuineIntel",
          "model": "Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz"
        },
        "memory": { "type": "DDR4", "totalSize": 8, "available": 5, "used": 3 },
        "rootDisk": { "label": "/", "type": "SSD", "totalSize": 50, "available": 35, "used": 15 },
        "interfaces": [
          { "name": "eth0", "macAddress": "52:54:00:aa:bb:02", "ipv4CidrBlocks": ["192.168.0.11/24"], "mtu": 1500, "state": "UP" }
        ],
        "routingTable": [
          { "destination": "0.0.0.0/0", "gateway": "192.168.0.1", "interface": "eth0", "metric": 100, "protocol": "static", "scope": "global", "linkState": "UP" }
        ],
        "firewallTable": [
          { "srcCIDR": "0.0.0.0/0", "srcPorts": "*", "dstCIDR": "0.0.0.0/0", "dstPorts": "10250", "protocol": "TCP", "direction": "inbound", "action": "allow" },
          { "srcCIDR": "0.0.0.0/0", "srcPorts": "*", "dstCIDR": "0.0.0.0/0", "dstPorts": "30000-32767", "protocol": "TCP", "direction": "inbound", "action": "allow" }
        ],
        "os": { "prettyName": "Ubuntu 22.04.2 LTS", "name": "Ubuntu", "versionId": "22.04", "versionCodename": "jammy", "id": "ubuntu", "idLike": "debian" }
      },
      {
        "hostname": "k8s-worker-02",
        "machineId": "aabbccdd-0003-0003-0003-000000000003",
        "role": "worker",
        "cpu": {
          "architecture": "x86_64",
          "cpus": 1,
          "cores": 2,
          "threads": 4,
          "maxSpeed": 2.5,
          "vendor": "GenuineIntel",
          "model": "Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz"
        },
        "memory": { "type": "DDR4", "totalSize": 8, "available": 5, "used": 3 },
        "rootDisk": { "label": "/", "type": "SSD", "totalSize": 50, "available": 35, "used": 15 },
        "interfaces": [
          { "name": "eth0", "macAddress": "52:54:00:aa:bb:03", "ipv4CidrBlocks": ["192.168.0.12/24"], "mtu": 1500, "state": "UP" }
        ],
        "routingTable": [
          { "destination": "0.0.0.0/0", "gateway": "192.168.0.1", "interface": "eth0", "metric": 100, "protocol": "static", "scope": "global", "linkState": "UP" }
        ],
        "firewallTable": [
          { "srcCIDR": "0.0.0.0/0", "srcPorts": "*", "dstCIDR": "0.0.0.0/0", "dstPorts": "10250", "protocol": "TCP", "direction": "inbound", "action": "allow" },
          { "srcCIDR": "0.0.0.0/0", "srcPorts": "*", "dstCIDR": "0.0.0.0/0", "dstPorts": "30000-32767", "protocol": "TCP", "direction": "inbound", "action": "allow" }
        ],
        "os": { "prettyName": "Ubuntu 22.04.2 LTS", "name": "Ubuntu", "versionId": "22.04", "versionCodename": "jammy", "id": "ubuntu", "idLike": "debian" }
      }
    ],
    "k8sCluster": {
      "name": "on-prem-k8s-cluster",
      "version": "v1.32.3",
      "podCIDR": "10.244.0.0/16",
      "serviceCIDR": "10.96.0.0/12",
      "cniPlugin": "flannel",
      "nodePortRange": "30000-32767"
    }
  }
}
```

</details>

<details>
<summary>Recommendation Result (API Response)</summary>

`POST /beetle/recommendation/k8sInfraWithDefaults?desiredCsp=aws&desiredRegion=ap-northeast-2`

> Both worker nodes share the same spec (4 vCPU / 8 GiB / Ubuntu 22.04 / x86_64), so they are merged into a single NodeGroup (`worker-group-1`, `desiredNodeSize=2`).

```json
{
  "success": true,
  "data": {
    "cluster": {
      "name": "k8s-aws-ap-northeast-2",
      "version": "1.33",
      "nodeGroupName": "worker-group-1",
      "connectionName": "aws-ap-northeast-2",
      "specId": "aws+ap-northeast-2+t3a.medium",
      "imageId": "default",
      "rootDiskType": "default",
      "rootDiskSize": 50,
      "onAutoScaling": "false",
      "desiredNodeSize": 2,
      "minNodeSize": 1,
      "maxNodeSize": 2
    },
    "additionalNodeGroups": [
      {
        "name": "worker-group-1",
        "specId": "aws+ap-northeast-2+t3a.medium",
        "imageId": "default",
        "rootDiskType": "default",
        "rootDiskSize": 50,
        "onAutoScaling": "false",
        "desiredNodeSize": 2,
        "minNodeSize": 1,
        "maxNodeSize": 2
      }
    ]
  }
}
```

</details>

<details>
<summary>Migration Result</summary>

| Phase | Result | Duration |
|---|---|---|
| Phase 1: Recommendation | ✅ PASS | 633ms |
| Phase 2-A: Cluster creation (`k8s-aws-ap-northeast-2`) | ✅ PASS | ~7 min (including Active poll) |
| Phase 2-B: NodeGroup creation (`worker-group-1`, 2 nodes) | ✅ PASS | 2m7s |
| Phase 2-C: Cleanup (NodeGroup → Cluster deletion) | ✅ PASS | 6m14s |

AWS EKS cluster and NodeGroup creation/deletion completed successfully.
</details>

## References

- [cm-honeybee discussions #52](https://github.com/cloud-barista/cm-honeybee/discussions/52) — K8s infrastructure info collection format (basis for test input data)
- [cm-beetle issue #371](https://github.com/cloud-barista/cm-beetle/issues/371) — original implementation plan
