### PR TITLE
Sanitize IBM constraints on NLB recommendations

### DIFF
--- a/pkg/compat/compat-gcp.go
+++ b/pkg/compat/compat-gcp.go
@@ -10,7 +10,7 @@ func CheckGcp(spec cloudmodel.SpecInfo, image cloudmodel.ImageInfo) bool {
 	log.Trace().Msgf("Starting GCP compatibility check for Spec: %s, Image: %s", spec.CspSpecName, image.CspImageName)
 
 	// TODO: Add GCP-specific compatibility checks using Detail information
-	log.Info().Msg("GCP compatibility validation is planned for future implementation")
+	log.Debug().Msg("GCP compatibility validation is planned for future implementation")
 
 	log.Trace().Msgf("GCP compatibility check passed for Spec: %s, Image: %s", spec.CspSpecName, image.CspImageName)
 	return true

--- a/pkg/compat/compat-ibm.go
+++ b/pkg/compat/compat-ibm.go
@@ -10,7 +10,7 @@ func CheckIbm(spec cloudmodel.SpecInfo, image cloudmodel.ImageInfo) bool {
 	log.Trace().Msgf("Starting IBM Cloud compatibility check for Spec: %s, Image: %s", spec.CspSpecName, image.CspImageName)
 
 	// TODO: Add IBM Cloud-specific compatibility checks using Detail information
-	log.Info().Msg("IBM Cloud compatibility validation is planned for future implementation")
+	log.Debug().Msg("IBM Cloud compatibility validation is planned for future implementation")
 
 	log.Trace().Msgf("IBM Cloud compatibility check passed for Spec: %s, Image: %s", spec.CspSpecName, image.CspImageName)
 	return true

--- a/pkg/core/recommendation/infra-with-nlb.go
+++ b/pkg/core/recommendation/infra-with-nlb.go
@@ -542,6 +542,19 @@ func sanitizeNlbListByCsp(nlbList []cloudmodel.NlbReq, csp string) []cloudmodel.
 		if csp == "azure" {
 			nlbList[i].HealthChecker.Timeout = -1
 		}
+
+		// IBM Cloud Load Balancer requires the health check timeout to be strictly
+		// less than the health check interval (delay).
+		if csp == "ibm" {
+			if nlbList[i].HealthChecker.Timeout >= nlbList[i].HealthChecker.Interval {
+				// Adjust timeout to be half of the interval (capped at 1 or greater)
+				newTimeout := nlbList[i].HealthChecker.Interval / 2
+				if newTimeout < 1 {
+					newTimeout = 1
+				}
+				nlbList[i].HealthChecker.Timeout = newTimeout
+			}
+		}
 	}
 	return nlbList
 }


### PR DESCRIPTION
* Require the health check timeout to be less than the health check interval (delay)