### PR TITLE
Sanitize GCP constraints on NLB recommendations

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -448,7 +448,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Delete a specific NLB from the target infra",
+                "description": "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2848,7 +2848,7 @@ const docTemplate = `{
         },
         "/recommendation/infraWithNlb": {
             "post": {
-                "description": "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to ` + "`" + `limit` + "`" + ` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] ` + "`" + `sourceInfra.nlbs` + "`" + ` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned ` + "`" + `targetInfra.nodeGroups[].name` + "`" + ` values are referenced by ` + "`" + `targetNlbList[].targetGroup.nodeGroupId` + "`" + `.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.",
+                "description": "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to ` + "`" + `limit` + "`" + ` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] ` + "`" + `sourceInfra.nlbs` + "`" + ` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned ` + "`" + `targetInfra.nodeGroups[].name` + "`" + ` values are referenced by ` + "`" + `targetNlbList[].targetGroup.nodeGroupId` + "`" + `.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.\n\n---\n## CSP-Specific NLB Notes\n\nAWS:\n- Port translation supported (e.g., listener 9999 → backend 8086).\n- DNS endpoint; allow ~5 min for propagation after creation.\n- [Auto] SG rule for backend port opened from 0.0.0.0/0.\n\nAzure:\n- Port translation supported. DNS + static IP endpoint.\n- [Auto] Health check timeout omitted (not supported by Azure).\n\nGCP:\n- Port translation NOT supported; traffic arrives at backend VMs on the listener port.\n- [Auto] Listener port is forced equal to the backend port — clients must connect on the application port (e.g., 8086, not 9999).\n- IP-only endpoint (no DNS name).\n\nIBM:\n- Port translation supported.\n- Listener address is assigned asynchronously; re-query if the address is empty after migration.\n- [Auto] Health check timeout forced strictly less than the interval.\n---",
                 "consumes": [
                     "application/json"
                 ],
@@ -5005,6 +5005,12 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
+                },
+                "keyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.KeyValue"
+                    }
                 },
                 "listener": {
                     "$ref": "#/definitions/cloudmodel.MigratedNlbListener"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -442,7 +442,7 @@
                 }
             },
             "delete": {
-                "description": "Delete a specific NLB from the target infra",
+                "description": "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2842,7 +2842,7 @@
         },
         "/recommendation/infraWithNlb": {
             "post": {
-                "description": "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to `limit` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.",
+                "description": "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to `limit` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.\n\n---\n## CSP-Specific NLB Notes\n\nAWS:\n- Port translation supported (e.g., listener 9999 → backend 8086).\n- DNS endpoint; allow ~5 min for propagation after creation.\n- [Auto] SG rule for backend port opened from 0.0.0.0/0.\n\nAzure:\n- Port translation supported. DNS + static IP endpoint.\n- [Auto] Health check timeout omitted (not supported by Azure).\n\nGCP:\n- Port translation NOT supported; traffic arrives at backend VMs on the listener port.\n- [Auto] Listener port is forced equal to the backend port — clients must connect on the application port (e.g., 8086, not 9999).\n- IP-only endpoint (no DNS name).\n\nIBM:\n- Port translation supported.\n- Listener address is assigned asynchronously; re-query if the address is empty after migration.\n- [Auto] Health check timeout forced strictly less than the interval.\n---",
                 "consumes": [
                     "application/json"
                 ],
@@ -4999,6 +4999,12 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "keyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.KeyValue"
+                    }
                 },
                 "listener": {
                     "$ref": "#/definitions/cloudmodel.MigratedNlbListener"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -804,6 +804,10 @@ definitions:
         $ref: '#/definitions/cloudmodel.MigratedNlbHealth'
       id:
         type: string
+      keyValueList:
+        items:
+          $ref: '#/definitions/cloudmodel.KeyValue'
+        type: array
       listener:
         $ref: '#/definitions/cloudmodel.MigratedNlbListener'
       name:
@@ -5537,7 +5541,12 @@ paths:
     delete:
       consumes:
       - application/json
-      description: Delete a specific NLB from the target infra
+      description: |-
+        Delete a specific NLB from the target infra.
+
+        [Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.
+        Deleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).
+        CM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.
       operationId: DeleteNlb
       parameters:
       - default: mig01
@@ -7363,6 +7372,29 @@ paths:
 
         [Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.
         Use the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.
+
+        ---
+        ## CSP-Specific NLB Notes
+
+        AWS:
+        - Port translation supported (e.g., listener 9999 → backend 8086).
+        - DNS endpoint; allow ~5 min for propagation after creation.
+        - [Auto] SG rule for backend port opened from 0.0.0.0/0.
+
+        Azure:
+        - Port translation supported. DNS + static IP endpoint.
+        - [Auto] Health check timeout omitted (not supported by Azure).
+
+        GCP:
+        - Port translation NOT supported; traffic arrives at backend VMs on the listener port.
+        - [Auto] Listener port is forced equal to the backend port — clients must connect on the application port (e.g., 8086, not 9999).
+        - IP-only endpoint (no DNS name).
+
+        IBM:
+        - Port translation supported.
+        - Listener address is assigned asynchronously; re-query if the address is empty after migration.
+        - [Auto] Health check timeout forced strictly less than the interval.
+        ---
       operationId: RecommendInfraWithNlbCandidates
       parameters:
       - default: aws

--- a/docs/feature-guide/managed-middleware.md
+++ b/docs/feature-guide/managed-middleware.md
@@ -25,7 +25,7 @@ See also: [Object Storage Migration Feature Guide](object-storage-migration-feat
 
 ## NLB (Preview)
 
-> NLB recommendation and migration are available as a **preview** feature. Tested on AWS.
+> NLB recommendation and migration are available as a **preview** feature. Tested on AWS, Azure, GCP, and IBM.
 
 | Feature        | AWS | Azure | GCP | Alibaba | Tencent | IBM | (OpenStack) | NCP | (NHN) | (KT) |
 | -------------- | :-: | :---: | :-: | :-----: | :-----: | :-: | :---------: | :-: | :---: | :--: |
@@ -34,6 +34,27 @@ See also: [Object Storage Migration Feature Guide](object-storage-migration-feat
 
 > - Recommendation groups source nodes by NLB backend topology (N:1) and returns Pareto-frontier spec candidates.
 > - Migration provisions NLBs on the target cloud after VM infrastructure is deployed.
+
+### CSP-Specific Characteristics and Constraints
+
+| CSP   | Port translation | Endpoint        | Key constraint / auto-adjustment |
+|-------|:---------------:|-----------------|----------------------------------|
+| AWS   | ✅              | DNS name        | SG: backend port opened from `0.0.0.0/0` automatically. DNS takes ~5 min to propagate. |
+| Azure | ✅              | DNS + static IP | Health check timeout not supported — omitted automatically. |
+| GCP   | ❌              | IP only         | Listener port forced = backend (application) port. Clients connect on the application port (e.g., 8086, not 9999). |
+| IBM   | ✅              | IP (async)      | Listener address assigned asynchronously — re-query if empty after migration. Timeout < interval enforced automatically. |
+
+> **GCP**: External Passthrough NLB uses target pools with no port translation. Traffic arrives at backend VMs on the listener port as-is, so the recommendation overrides the listener port to match the application port.
+>
+> **IBM**: The NLB listener address may be empty immediately after creation due to asynchronous provisioning. Retry the GET NLB call after a short wait.
+
+### NLB Deletion Behavior
+
+- Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.
+- Deleting VNet/subnets too soon may cause dependency errors (e.g., `DependencyViolation` on AWS).
+- CM-Beetle mitigations:
+  - `DeleteNlb`: waits after a successful deletion response before returning (e.g., 15s).
+  - `DeleteVMInfra` (VNet deletion): retries on failure with a back-off interval (e.g., 10s × up to 10 times).
 
 ## Roadmap
 

--- a/pkg/api/rest/controller/migration-nlb.go
+++ b/pkg/api/rest/controller/migration-nlb.go
@@ -235,7 +235,11 @@ func GetNlbHealth(c echo.Context) error {
 // DeleteNlb godoc
 // @ID DeleteNlb
 // @Summary Delete an NLB
-// @Description Delete a specific NLB from the target infra
+// @Description Delete a specific NLB from the target infra.
+// @Description
+// @Description [Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.
+// @Description Deleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).
+// @Description CM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.
 // @Tags [Migration] Managed Network Load Balancer (NLB) - preview
 // @Accept json
 // @Produce json

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -267,6 +267,29 @@ type RecommendInfraWithNlbRequest struct {
 // @Description
 // @Description [Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.
 // @Description Use the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.
+// @Description
+// @Description ---
+// @Description ## CSP-Specific NLB Notes
+// @Description
+// @Description AWS:
+// @Description - Port translation supported (e.g., listener 9999 → backend 8086).
+// @Description - DNS endpoint; allow ~5 min for propagation after creation.
+// @Description - [Auto] SG rule for backend port opened from 0.0.0.0/0.
+// @Description
+// @Description Azure:
+// @Description - Port translation supported. DNS + static IP endpoint.
+// @Description - [Auto] Health check timeout omitted (not supported by Azure).
+// @Description
+// @Description GCP:
+// @Description - Port translation NOT supported; traffic arrives at backend VMs on the listener port.
+// @Description - [Auto] Listener port is forced equal to the backend port — clients must connect on the application port (e.g., 8086, not 9999).
+// @Description - IP-only endpoint (no DNS name).
+// @Description
+// @Description IBM:
+// @Description - Port translation supported.
+// @Description - Listener address is assigned asynchronously; re-query if the address is empty after migration.
+// @Description - [Auto] Health check timeout forced strictly less than the interval.
+// @Description ---
 // @Tags [Recommendation] Infrastructure
 // @Accept json
 // @Produce json

--- a/pkg/core/recommendation/infra-with-nlb.go
+++ b/pkg/core/recommendation/infra-with-nlb.go
@@ -564,6 +564,16 @@ func sanitizeNlbListByCsp(nlbList []cloudmodel.NlbReq, csp string) []cloudmodel.
 				nlbList[i].HealthChecker.Timeout = newTimeout
 			}
 		}
+
+		// GCP External Passthrough NLB uses target pools and does NOT perform port translation.
+		// Traffic arrives at backend VMs on the same destination port as the forwarding rule
+		// (the listener port), not the application's backend port.
+		// To ensure traffic reaches the application, the listener port must equal the backend port.
+		// We use the backend (application) port as the authoritative value since the application
+		// cannot be reconfigured as part of the migration.
+		if csp == "gcp" {
+			nlbList[i].Listener.Port = nlbList[i].TargetGroup.Port
+		}
 	}
 	return nlbList
 }


### PR DESCRIPTION
* Port translation NOT supported; `listener port` and `backend node (vm) port` must be the same.