### PR TITLE
fix(recommendation): prevent duplicate SG rules

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4101,6 +4101,16 @@ const docTemplate = `{
                     "type": "integer",
                     "example": 1
                 },
+                "lastOccurredTime": {
+                    "description": "LastOccurredTime is when the most recent repeat of this outcome happened.\nOnly set once RepeatCount is greater than 0; StartedTime/CompletedTime keep\nreferring to the first occurrence.",
+                    "type": "string",
+                    "example": "2024-01-15T10:35:00Z"
+                },
+                "repeatCount": {
+                    "description": "RepeatCount is the number of times this exact command produced this exact\noutcome (same CommandRequested, Status, ResultSummary, and ErrorMessage) on\nconsecutive attempts. Absent/0 means it has not repeated. Repeats are merged\ninto a single record instead of appended, so retry storms (e.g. a failing\ninstall script retried repeatedly) do not grow this VM's history unbounded.",
+                    "type": "integer",
+                    "example": 3
+                },
                 "resultSummary": {
                     "description": "ResultSummary provides a brief summary of the execution result",
                     "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4095,6 +4095,16 @@
                     "type": "integer",
                     "example": 1
                 },
+                "lastOccurredTime": {
+                    "description": "LastOccurredTime is when the most recent repeat of this outcome happened.\nOnly set once RepeatCount is greater than 0; StartedTime/CompletedTime keep\nreferring to the first occurrence.",
+                    "type": "string",
+                    "example": "2024-01-15T10:35:00Z"
+                },
+                "repeatCount": {
+                    "description": "RepeatCount is the number of times this exact command produced this exact\noutcome (same CommandRequested, Status, ResultSummary, and ErrorMessage) on\nconsecutive attempts. Absent/0 means it has not repeated. Repeats are merged\ninto a single record instead of appended, so retry storms (e.g. a failing\ninstall script retried repeatedly) do not grow this VM's history unbounded.",
+                    "type": "integer",
+                    "example": 3
+                },
                 "resultSummary": {
                     "description": "ResultSummary provides a brief summary of the execution result",
                     "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -59,6 +59,22 @@ definitions:
           2, 3, ...)
         example: 1
         type: integer
+      lastOccurredTime:
+        description: |-
+          LastOccurredTime is when the most recent repeat of this outcome happened.
+          Only set once RepeatCount is greater than 0; StartedTime/CompletedTime keep
+          referring to the first occurrence.
+        example: "2024-01-15T10:35:00Z"
+        type: string
+      repeatCount:
+        description: |-
+          RepeatCount is the number of times this exact command produced this exact
+          outcome (same CommandRequested, Status, ResultSummary, and ErrorMessage) on
+          consecutive attempts. Absent/0 means it has not repeated. Repeats are merged
+          into a single record instead of appended, so retry storms (e.g. a failing
+          install script retried repeatedly) do not grow this VM's history unbounded.
+        example: 3
+        type: integer
       resultSummary:
         description: ResultSummary provides a brief summary of the execution result
         example: Command executed successfully

--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -13,9 +13,9 @@ services:
   cm-beetle:
     image: cloudbaristaorg/cm-beetle:0.5.5
     container_name: cm-beetle
-    # build:
-    #   context: ${PROJECT_ROOT}
-    #   dockerfile: Dockerfile
+    build:
+      context: ${PROJECT_ROOT}
+      dockerfile: Dockerfile
     platform: linux/amd64
     networks:
       - cloud-barista

--- a/pkg/core/migration/vm-infra.go
+++ b/pkg/core/migration/vm-infra.go
@@ -222,6 +222,17 @@ func CreateInfra(nsId string, targetInfraModel *cloudmodel.RecommendedInfra) (cl
 
 		// Check if SSH access rule exists and add if missing
 		sgReq = checkAndSupportSSHAccessRule(sgReq)
+		
+		// Deduplicate firewall rules before sending to Tumblebug
+		if sgReq.FirewallRules != nil {
+			originalCount := len(*sgReq.FirewallRules)
+			dedupedRules := recommendation.DeduplicateFirewallRules(*sgReq.FirewallRules)
+			sgReq.FirewallRules = &dedupedRules
+			if originalCount != len(dedupedRules) {
+				log.Warn().Msgf("Removed %d duplicate firewall rule(s) for SG '%s' (original: %d, deduplicated: %d)",
+					originalCount-len(dedupedRules), sgReq.Name, originalCount, len(dedupedRules))
+			}
+		}
 
 		// Create security group
 		log.Debug().Msgf("Creating a security group (nsId: %s, sgReq.sgName: %s, sgReq.VNetId: %s, vNetInfo.vNetId: %s)",
@@ -897,6 +908,17 @@ func useOrCreateSecurityGroup(nsId string, sgReq SecurityGroupRequirement, sgCre
 	}
 
 	sgCreationReq = checkAndSupportSSHAccessRule(sgCreationReq)
+	
+	// Deduplicate firewall rules before sending to Tumblebug
+	if sgCreationReq.FirewallRules != nil {
+		originalCount := len(*sgCreationReq.FirewallRules)
+		dedupedRules := recommendation.DeduplicateFirewallRules(*sgCreationReq.FirewallRules)
+		sgCreationReq.FirewallRules = &dedupedRules
+		if originalCount != len(dedupedRules) {
+			log.Warn().Msgf("Removed %d duplicate firewall rule(s) for SG '%s' during fallback creation (original: %d, deduplicated: %d)",
+				originalCount-len(dedupedRules), sgCreationReq.Name, originalCount, len(dedupedRules))
+		}
+	}
 
 	log.Debug().Msgf("Creating a security group (nsId: %s, sgName: %s, VNetId: %s)", nsId, sgCreationReq.Name, sgCreationReq.VNetId)
 	tbSgReq, err := modelconv.ConvertWithValidation[cloudmodel.SecurityGroupReq, tbmodel.SecurityGroupReq](sgCreationReq)

--- a/pkg/core/recommendation/resource-sg.go
+++ b/pkg/core/recommendation/resource-sg.go
@@ -46,10 +46,21 @@ func RecommendSecurityGroup(csp string, region string, node onpremmodel.NodeProp
 	} else {
 		log.Info().Msgf("Generating security group rules based on %d firewall rules from node configuration", len(firewallRules))
 		sgRules = generateSecurityGroupRules(firewallRules)
+
+		// Deduplicate security group rules to prevent 'same permission multiple times' error
+		// This is necessary because input may contain both individual ports and comma-separated combinations
+		// Example: "80", "443", "80,443" → after split: "80", "443", "80", "443" (duplicates)
+		originalCount := len(sgRules)
+		sgRules = DeduplicateFirewallRules(sgRules)
+		if originalCount != len(sgRules) {
+			log.Warn().Msgf("Removed %d duplicate firewall rule(s) during recommendation (original: %d, deduplicated: %d)",
+				originalCount-len(sgRules), originalCount, len(sgRules))
+		}
+
 		firewallRulesPtr = &sgRules // Point to the generated rules
 	}
 
-	log.Debug().Msgf("sgRules: %+v", sgRules)
+	log.Debug().Msgf("sgRules after deduplication: %+v", sgRules)
 
 	// [Output]
 	// Create a security group for all rules
@@ -88,7 +99,7 @@ func RecommendSecurityGroups(csp string, region string, servers []onpremmodel.No
 		if err != nil {
 			log.Error().Err(err).Msgf("failed to recommend security group for node: %+v", node)
 			recommendedTargetSg.Description = fmt.Sprintf("Failed to recommend security group for %s", node.MachineId) // Set MachineId to identify the source node
-			recommendedTargetSg.FirewallRules = nil                                                                      // No rules if recommendation fails
+			recommendedTargetSg.FirewallRules = nil                                                                    // No rules if recommendation fails
 		}
 
 		// Check duplicates and append the recommended security group
@@ -294,33 +305,33 @@ func generateSecurityGroupRules(rules []onpremmodel.FirewallRuleProperty) []clou
 				var dstPorts string
 				// Handle wildcard ports based on protocol
 				if rule.DstPorts == "*" {
-					dstPorts = "1:65535" // TCP/UDP use 1-65535 range
+					dstPorts = "1-65535" // TCP/UDP use 1-65535 range
 				} else {
 					dstPorts = rule.DstPorts
 				}
 
-				// * Note: CB-Tumblebug will handle comma-separated ports and port ranges.
-				// In here, just convert : to - for port ranges.
-				if strings.Contains(dstPorts, ":") {
-					// Handle port range with colon notation (e.g., 30000:40000)
-					portRange := strings.Split(dstPorts, ":")
-					if len(portRange) == 2 {
-						dstPorts = strings.TrimSpace(portRange[0]) + "-" + strings.TrimSpace(portRange[1])
-					} else {
-						log.Warn().Msgf("Invalid port range format in rule.DstPorts: %s - skipping rule", dstPorts)
+				// Convert colon notation to dash for port ranges (e.g., 30000:40000 → 30000-40000)
+				dstPorts = strings.ReplaceAll(dstPorts, ":", "-")
+
+				// Split comma-separated ports (same as Tumblebug's ConvertFirewallRuleRequestObjToInfoObjs)
+				// This prevents duplication when Tumblebug expands the rules
+				portList := strings.Split(dstPorts, ",")
+				for _, port := range portList {
+					port = strings.TrimSpace(port)
+					if port == "" {
 						continue
 					}
-				}
 
-				tbRule := cloudmodel.FirewallRuleReq{
-					Direction: rule.Direction,
-					Protocol:  protocol,
-					CIDR:      srcCIDR,
-					Ports:     dstPorts,
-				}
+					tbRule := cloudmodel.FirewallRuleReq{
+						Direction: rule.Direction,
+						Protocol:  protocol,
+						CIDR:      srcCIDR,
+						Ports:     port,
+					}
 
-				tbRules = append(tbRules, tbRule)
-				log.Debug().Msgf("Created inbound rule for '%s' protocol: %+v", protocol, tbRule)
+					tbRules = append(tbRules, tbRule)
+					log.Debug().Msgf("Created inbound rule for '%s' protocol with port '%s': %+v", protocol, port, tbRule)
+				}
 			default:
 				log.Warn().Msgf("Unsupported protocol '%s' in inbound rule: %+v - skipping rule", protocol, rule)
 				continue
@@ -377,32 +388,32 @@ func generateSecurityGroupRules(rules []onpremmodel.FirewallRuleProperty) []clou
 				var dstPorts string
 				// Handle wildcard ports based on protocol
 				if rule.DstPorts == "*" {
-					dstPorts = "1:65535" // TCP/UDP use 1-65535 range
+					dstPorts = "1-65535" // TCP/UDP use 1-65535 range
 				} else {
 					dstPorts = rule.DstPorts
 				}
 
-				// * Note: CB-Tumblebug will handle comma-separated ports and port ranges.
-				// In here, just convert : to - for port ranges.
-				if strings.Contains(dstPorts, ":") {
-					// Handle port range with colon notation
-					portRange := strings.Split(dstPorts, ":")
-					if len(portRange) == 2 {
-						dstPorts = strings.TrimSpace(portRange[0]) + "-" + strings.TrimSpace(portRange[1])
-					} else {
-						log.Warn().Msgf("Invalid port range format: %s - skipping rule", dstPorts)
+				// Convert colon notation to dash for port ranges (e.g., 30000:40000 → 30000-40000)
+				dstPorts = strings.ReplaceAll(dstPorts, ":", "-")
+
+				// Split comma-separated ports (same as Tumblebug's ConvertFirewallRuleRequestObjToInfoObjs)
+				// This prevents duplication when Tumblebug expands the rules
+				portList := strings.Split(dstPorts, ",")
+				for _, port := range portList {
+					port = strings.TrimSpace(port)
+					if port == "" {
 						continue
 					}
-				}
 
-				tbRule := cloudmodel.FirewallRuleReq{
-					Direction: rule.Direction,
-					Protocol:  protocol,
-					CIDR:      dstCIDR,
-					Ports:     dstPorts,
+					tbRule := cloudmodel.FirewallRuleReq{
+						Direction: rule.Direction,
+						Protocol:  protocol,
+						CIDR:      dstCIDR,
+						Ports:     port,
+					}
+					tbRules = append(tbRules, tbRule)
+					log.Debug().Msgf("Created outbound rule for '%s' protocol with port '%s': %+v", protocol, port, tbRule)
 				}
-				tbRules = append(tbRules, tbRule)
-				log.Debug().Msgf("Created outbound rule for '%s' protocol: %+v", protocol, tbRule)
 			default:
 				log.Warn().Msgf("Unsupported protocol '%s' in outbound rule: %+v - skipping rule", protocol, rule)
 				continue
@@ -432,4 +443,63 @@ func isIPv6Rule(rule onpremmodel.FirewallRuleProperty) bool {
 	}
 
 	return false
+}
+
+// DeduplicateFirewallRules removes duplicate firewall rules from the given slice
+// Two rules are considered duplicate if they have the same Direction, Protocol, CIDR, and Ports
+// Protocol and Direction are compared case-insensitively
+// Note: This function expects rules to be already split by comma (same as Tumblebug's processing)
+func DeduplicateFirewallRules(rules []cloudmodel.FirewallRuleReq) []cloudmodel.FirewallRuleReq {
+	if len(rules) == 0 {
+		return rules
+	}
+
+	log.Info().Msgf("Starting deduplication for %d firewall rules", len(rules))
+
+	seen := make(map[string]bool)
+	result := []cloudmodel.FirewallRuleReq{}
+	duplicateCount := 0
+
+	for i, rule := range rules {
+		key := createRuleKey(rule)
+		log.Debug().Msgf("Rule %d: key='%s' (Direction=%s, Protocol=%s, CIDR=%s, Ports=%s)",
+			i+1, key, rule.Direction, rule.Protocol, rule.CIDR, rule.Ports)
+
+		if !seen[key] {
+			seen[key] = true
+			result = append(result, rule)
+			log.Debug().Msgf("  ✓ Keeping rule (first occurrence)")
+		} else {
+			duplicateCount++
+			log.Warn().Msgf("  ✗ DUPLICATE DETECTED - removing exact duplicate with key: %s", key)
+		}
+	}
+
+	log.Info().Msgf("Deduplication complete: %d duplicates removed, %d unique rules remaining",
+		duplicateCount, len(result))
+	return result
+}
+
+// createRuleKey creates a normalized unique key for a firewall rule
+// Format: direction|protocol|cidr|ports (all lowercase for case-insensitive comparison)
+func createRuleKey(rule cloudmodel.FirewallRuleReq) string {
+	// Normalize all fields to lowercase for consistent comparison
+	direction := strings.ToLower(strings.TrimSpace(rule.Direction))
+	protocol := strings.ToLower(strings.TrimSpace(rule.Protocol))
+	cidr := strings.TrimSpace(rule.CIDR)
+	ports := normalizePorts(rule.Ports)
+
+	// Create unique key
+	key := fmt.Sprintf("%s|%s|%s|%s", direction, protocol, cidr, ports)
+
+	return key
+}
+
+// normalizePorts normalizes port specification for consistent comparison
+// Note: At this point, ports are already split by comma in generateSecurityGroupRules,
+// so each rule contains only a single port or port range (e.g., "80" or "900-1000")
+func normalizePorts(ports string) string {
+	// Simply trim whitespace - no comma splitting or sorting needed
+	// as rules are already split into individual port/range entries
+	return strings.TrimSpace(ports)
 }


### PR DESCRIPTION
- Add DeduplicateFirewallRules() for exact duplicates
- Split comma-separated ports to match Tumblebug
- Apply deduplication in recommendation and migration

Now, duplicates can be eliminated if the following firewall rules are configured in the user's source environment.

```json
...,
{ 
"srcCIDR": "0.0.0.0/0", 
"srcPorts": "*", 
"dstCIDR": "0.0.0.0/0", 
"dstPorts": "80", 
"protocol": "tcp", 
"direction": "inbound", 
"action": "allow" 
}, 
{ 
"srcCIDR": "0.0.0.0/0", 
"srcPorts": "*", 
"dstCIDR": "0.0.0.0/0", 
"dstPorts": "443", 
"protocol": "tcp", 
"direction": "inbound", 
"action": "allow" 
}, 
{ 
"srcCIDR": "0.0.0.0/0", 
"srcPorts": "*", 
"dstCIDR": "0.0.0.0/0", 
"dstPorts": "80,443", 
"protocol": "tcp", 
"direction": "inbound", 
"action": "allow" 
},
...
```