### PR TITLE
refactor(report): use labels for node-to-server matching

### DIFF
--- a/cmd/test-cli/infra-with-nlb/main.go
+++ b/cmd/test-cli/infra-with-nlb/main.go
@@ -1674,6 +1674,11 @@ func loadSourceInfraModel(requestBodyPath string) (onpremmodel.OnpremInfra, stri
 	return tempRequest.SourceInfra, tempRequest.NameSeed, nil
 }
 
+// cmBeetleModulePath is the main module's path, used to distinguish the
+// repo-root go.mod from the nested imdl submodule's own go.mod when walking
+// up the directory tree in findRepoRoot.
+const cmBeetleModulePath = "github.com/cloud-barista/cm-beetle"
+
 // getGitHash returns the current git commit hash
 func getGitHash() string {
 	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
@@ -1685,96 +1690,127 @@ func getGitHash() string {
 	return strings.TrimSpace(string(output))
 }
 
-func getBeetleVersion() string {
-	cwd, err := os.Getwd()
+// findRepoRoot walks up from the current working directory to locate the
+// cm-beetle repo root, identified by its go.mod's exact module path (which
+// distinguishes it from the nested imdl submodule's own go.mod). This test-cli
+// is always run with its own directory as cwd (see Makefile: `cd
+// cmd/test-cli/infra-with-nlb && go run main.go ...`), so version-detection
+// helpers can't assume repo-root-relative paths resolve directly from cwd.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
 	if err != nil {
-		return "unknown"
+		return "", err
 	}
 
-	// Try to get version from cmd/beetle/main.go or similar
-	versionFilePath := filepath.Join(cwd, "pkg", "config", "config.go")
-	fileContent, err := os.ReadFile(versionFilePath)
-	if err != nil {
-		// Fallback to git hash
-		return getGitHash()
-	}
-
-	// Simple regex to find Version constant
-	re := regexp.MustCompile(`Version\s*=\s*"([^"]+)"`)
-	matches := re.FindStringSubmatch(string(fileContent))
-	if len(matches) > 1 {
-		return fmt.Sprintf("%s (%s)", matches[1], getGitHash())
-	}
-
-	return getGitHash()
-}
-
-func getVersionFromDockerCompose(serviceName string) string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "unknown"
-	}
-
-	composePath := filepath.Join(cwd, "docker-compose.yaml")
-	fileContent, err := os.ReadFile(composePath)
-	if err != nil {
-		// Try parent directory
-		composePath = filepath.Join(cwd, "..", "docker-compose.yaml")
-		fileContent, err = os.ReadFile(composePath)
-		if err != nil {
-			return "unknown"
-		}
-	}
-
-	// Parse yaml to find service image tag
-	var composeData map[string]interface{}
-	if err := yaml.Unmarshal(fileContent, &composeData); err != nil {
-		return "unknown"
-	}
-
-	if services, ok := composeData["services"].(map[string]interface{}); ok {
-		if service, ok := services[serviceName].(map[string]interface{}); ok {
-			if image, ok := service["image"].(string); ok {
-				// Extract tag from image name (e.g. cloudbarista/cb-tumblebug:0.12.1)
-				parts := strings.Split(image, ":")
-				if len(parts) > 1 {
-					return parts[len(parts)-1]
+	for {
+		if content, err := os.ReadFile(filepath.Join(dir, "go.mod")); err == nil {
+			for _, line := range strings.Split(string(content), "\n") {
+				if strings.TrimSpace(line) == "module "+cmBeetleModulePath {
+					return dir, nil
 				}
 			}
 		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("cm-beetle repo root not found (started from %s)", dir)
+		}
+		dir = parent
+	}
+}
+
+// getBeetleVersion returns the CM-Beetle version from git tags or commit hash.
+// Only beetle release tags (v[0-9]*) are matched to avoid picking up imdl/*, transx/* tags.
+// Expected format: v0.4.5 (exact tag) or v0.4.5+ (short hash) for commits after tag.
+func getBeetleVersion() string {
+	commitHash := getGitHash()
+
+	// Check if we are exactly on a beetle release tag (v[0-9]*)
+	cmdExact := exec.Command("git", "describe", "--tags", "--exact-match", "--match", "v[0-9]*")
+	if exactTag, err := cmdExact.Output(); err == nil {
+		return strings.TrimSpace(string(exactTag))
 	}
 
+	// Get the latest beetle release tag (we are ahead of it)
+	cmdTag := exec.Command("git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*")
+	if tag, err := cmdTag.Output(); err == nil {
+		tagStr := strings.TrimSpace(string(tag))
+		if tagStr != "" {
+			if commitHash != "unknown" {
+				return fmt.Sprintf("%s+ (%s)", tagStr, commitHash)
+			}
+			return fmt.Sprintf("%s+", tagStr)
+		}
+	}
+
+	// No beetle release tags available, fallback to main (hash)
+	if commitHash != "unknown" {
+		return fmt.Sprintf("main (%s)", commitHash)
+	}
+	return "main (unknown)"
+}
+
+// getVersionFromDockerCompose extracts version from docker-compose.yaml for a given service.
+func getVersionFromDockerCompose(serviceName string) string {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to locate cm-beetle repo root")
+		return "unknown"
+	}
+
+	composePath := filepath.Join(repoRoot, "deployments", "docker-compose", "docker-compose.yaml")
+	content, err := os.ReadFile(composePath)
+	if err != nil {
+		return "unknown"
+	}
+
+	// Pattern to match: image: cloudbaristaorg/serviceName:version (excluding commented lines)
+	// This pattern ensures we don't match lines starting with # (comments)
+	pattern := fmt.Sprintf(`(?m)^\s*image:\s*cloudbaristaorg/%s:([\d\.]+)`, serviceName)
+	re := regexp.MustCompile(pattern)
+	matches := re.FindStringSubmatch(string(content))
+
+	if len(matches) >= 2 {
+		return matches[1]
+	}
 	return "unknown"
 }
 
+// getImdlVersion returns the version of the imdl module from its git tags (format: imdl/vX.Y.Z).
 func getImdlVersion() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "unknown"
+	commitHash := getGitHash()
+
+	// Check if we are exactly on an imdl tag
+	cmdExact := exec.Command("git", "describe", "--tags", "--exact-match", "--match", "imdl/v*")
+	if exactTag, err := cmdExact.Output(); err == nil {
+		return strings.TrimPrefix(strings.TrimSpace(string(exactTag)), "imdl/")
 	}
 
-	// Check go.mod to extract imdl version if it's imported
-	goModPath := filepath.Join(cwd, "go.mod")
-	fileContent, err := os.ReadFile(goModPath)
-	if err != nil {
-		return "unknown"
+	// Get the latest imdl tag (we are ahead of it)
+	cmdTag := exec.Command("git", "describe", "--tags", "--abbrev=0", "--match", "imdl/v*")
+	if tag, err := cmdTag.Output(); err == nil {
+		tagStr := strings.TrimPrefix(strings.TrimSpace(string(tag)), "imdl/")
+		if tagStr != "" {
+			if commitHash != "unknown" {
+				return fmt.Sprintf("%s+ (%s)", tagStr, commitHash)
+			}
+			return fmt.Sprintf("%s+", tagStr)
+		}
 	}
 
-	// Simple regex to find imdl dependency
-	re := regexp.MustCompile(`github.com/cloud-barista/cm-beetle/imdl\s+(v\S+)`)
-	matches := re.FindStringSubmatch(string(fileContent))
-	if len(matches) > 1 {
-		return matches[1]
+	// No imdl tags available
+	if commitHash != "unknown" {
+		return fmt.Sprintf("main (%s)", commitHash)
 	}
-
-	return "local-workspace"
+	return "main (unknown)"
 }
 
+// formatServiceVersion returns "v{version}" or "unknown" when version is not available.
 func formatServiceVersion(version string) string {
 	if version == "unknown" {
-		return "Unknown (Fallback to Latest)"
+		return "unknown"
 	}
-	return version
+	return "v" + version
 }
 
 func generateMarkdownReport(report *CSPTestReport) error {

--- a/cmd/test-cli/infra-with-nlb/testresult/beetle-report-mig-source-to-aws.md
+++ b/cmd/test-cli/infra-with-nlb/testresult/beetle-report-mig-source-to-aws.md
@@ -2,7 +2,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-07-13 09:03:56*
+*Report generated: 2026-07-21 04:19:44*
 
 ---
 
@@ -31,7 +31,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 2 | ✅ Selected | t3a.xlarge, t3a.small |
+| 2 | **VM Spec** | 2 | ✅ Selected | t3a.small, t3a.xlarge |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my-mig-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my-mig-vnet-01) |
@@ -46,9 +46,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my-ng-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-07f638bb18bbb13e6<br>**Label(sourceMachineId):** ng-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** ng-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my-ng-influxdb-back-1<br>**VM ID:** i-0f63a3a34b581895d<br>**Label(sourceMachineId):** ng | **Hostname:** N/A<br>**Machine ID:** ng |
-| 3 | **VM Name:** my-ng-influxdb-back-2<br>**VM ID:** i-05fa2460fe53c2da4<br>**Label(sourceMachineId):** ng | **Hostname:** N/A<br>**Machine ID:** ng |
+| 1 | **VM Name:** my-ng-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-0054a217572ac064b<br>**Label(sourceMachineId):** ec268ed7-821e-9d73-e79f-961262161624 | **Hostname:** ip-10-0-1-30<br>**Machine ID:** ec268ed7-821e-9d73-e79f-961262161624 |
+| 2 | **VM Name:** my-ng-influxdb-back-1<br>**VM ID:** i-0a922ef6e86d46017<br>**Label(sourceMachineId):** ec2d32b5-98fb-5a96-7913-d3db1ec18932 | **Hostname:** ip-10-0-1-221<br>**Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932 |
+| 3 | **VM Name:** my-ng-influxdb-back-2<br>**VM ID:** i-06f3cc5c469f82f40<br>**Label(sourceMachineId):** ec288dd0-c6fa-8a49-2f60-bc898311febf | **Hostname:** ip-10-0-1-138<br>**Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf |
 
 ---
 
@@ -58,9 +58,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM Spec | Source Server | Source Server Spec |
 |-----|-------------|---------|---------------|--------------------|
-| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** t3a.small<br>**vCPUs:** 2<br>**Memory:** 2.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** ng-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 2 | my-ng-influxdb-back-1 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** ng | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 3 | my-ng-influxdb-back-2 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** ng | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** t3a.small<br>**vCPUs:** 2<br>**Memory:** 2.0 GB<br>**Root Disk:** 50 GB | **Hostname:** ip-10-0-1-30<br>**Machine ID:** ec268ed7-821e-9d73-e79f-961262161624 | **CPUs:** 1<br>**Threads:** 2<br>**Memory:** 2 GB<br>**Root Disk:** 8 GB |
+| 2 | my-ng-influxdb-back-1 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** ip-10-0-1-221<br>**Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932 | **CPUs:** 1<br>**Threads:** 4<br>**Memory:** 16 GB<br>**Root Disk:** 30 GB |
+| 3 | my-ng-influxdb-back-2 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** ip-10-0-1-138<br>**Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf | **CPUs:** 1<br>**Threads:** 4<br>**Memory:** 8 GB<br>**Root Disk:** 30 GB |
 
 ---
 
@@ -70,9 +70,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** N/A<br>**Machine ID:** ng-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my-ng-influxdb-back-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** N/A<br>**Machine ID:** ng | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my-ng-influxdb-back-2 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** N/A<br>**Machine ID:** ng | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** ip-10-0-1-30<br>**Machine ID:** ec268ed7-821e-9d73-e79f-961262161624 | **PrettyName:** Ubuntu 22.04.3 LTS<br>**Name:** Ubuntu<br>**Version:** 22.04.3 LTS (Jammy Jellyfish) |
+| 2 | my-ng-influxdb-back-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** ip-10-0-1-221<br>**Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932 | **PrettyName:** Ubuntu 22.04.3 LTS<br>**Name:** Ubuntu<br>**Version:** 22.04.3 LTS (Jammy Jellyfish) |
+| 3 | my-ng-influxdb-back-2 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** ip-10-0-1-138<br>**Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf | **PrettyName:** Ubuntu 22.04.3 LTS<br>**Name:** Ubuntu<br>**Version:** 22.04.3 LTS (Jammy Jellyfish) |
 
 ---
 
@@ -82,14 +82,14 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my-mig-sg-01
 
-**CSP ID:** sg-04f9aacbfff1339fd | **VNet:** my-mig-vnet-01 | **Rules:** 5
+**CSP ID:** sg-0b193070b1e7f5d29 | **VNet:** my-mig-vnet-01 | **Rules:** 5
 
 **Assigned VMs:**
 
 - **VM:** my-ng-influxdb-back-1
-  - **Source Server:** **Hostname:** N/A, **Machine ID:** ng
+  - **Source Server:** **Hostname:** ip-10-0-1-221, **Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932
 - **VM:** my-ng-influxdb-back-2
-  - **Source Server:** **Hostname:** N/A, **Machine ID:** ng
+  - **Source Server:** **Hostname:** ip-10-0-1-138, **Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf
 
 **Security Rules:**
 
@@ -103,12 +103,12 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my-mig-sg-02
 
-**CSP ID:** sg-06bff0ecdf53345f6 | **VNet:** my-mig-vnet-01 | **Rules:** 4
+**CSP ID:** sg-0b08a1f2cc70c3840 | **VNet:** my-mig-vnet-01 | **Rules:** 4
 
 **Assigned VMs:**
 
 - **VM:** my-ng-ec268ed7-821e-9d73-e79f-961262161624-1
-  - **Source Server:** **Hostname:** N/A, **Machine ID:** ng-ec268ed7-821e-9d73-e79f
+  - **Source Server:** **Hostname:** ip-10-0-1-30, **Machine ID:** ec268ed7-821e-9d73-e79f-961262161624
 
 **Security Rules:**
 
@@ -129,13 +129,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my-mig-vnet-01<br>**ID:** vpc-0e032ee5b40ca2cdd | 10.0.0.0/21 |
+| 1 | **Name:** my-mig-vnet-01<br>**ID:** vpc-0201fe7dacc5b3501 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my-mig-subnet-01<br>**ID:** subnet-0818566fb5fde1e2e | 10.0.1.0/24 | my-mig-vnet-01 |
+| 1 | **Name:** my-mig-subnet-01<br>**ID:** subnet-0b401ce3e440d6a88 | 10.0.1.0/24 | my-mig-vnet-01 |
 
 ### Source Network Information
 
@@ -150,6 +150,14 @@ Summary of key infrastructure resources created or configured in the target clou
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.30/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 #### 2. ip-10-0-1-221
 
@@ -158,6 +166,14 @@ Summary of key infrastructure resources created or configured in the target clou
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.221/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 #### 3. ip-10-0-1-138
 
@@ -166,6 +182,14 @@ Summary of key infrastructure resources created or configured in the target clou
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.138/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 ---
 
@@ -177,7 +201,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my-mig-sshkey-01 | tbt1bt5hiiqoqi38lfv2 | 2a:61:89:ab:5d:44:cb:cf:66:1d:da:b7:30:d6:8f:2d:d7:8a:57:81 | Used by all 3 VMs |
+| 1 | my-mig-sshkey-01 | tbh9rdeut22if8j5cv6k | 27:de:16:94:80:a4:a8:73:30:d0:f3:da:83:37:7d:43:54:bd:7c:1e | Used by all 3 VMs |
 
 ---
 
@@ -197,6 +221,8 @@ Summary of key infrastructure resources created or configured in the target clou
 | Component | Spec | Monthly Cost | Percentage |
 |-----------|------|--------------|------------|
 | ip-10-0-1-30 (migrated) | t3a.small | $16.85 | 5.9% |
+| ip-10-0-1-221 (migrated) | t3a.xlarge | $134.78 | 47.1% |
+| ip-10-0-1-138 (migrated) | t3a.xlarge | $134.78 | 47.1% |
 
 ---
 

--- a/cmd/test-cli/infra-with-nlb/testresult/beetle-summary-source.md
+++ b/cmd/test-cli/infra-with-nlb/testresult/beetle-summary-source.md
@@ -1,6 +1,6 @@
 # Source Infrastructure Summary
 
-**Generated At:** 2026-07-13 11:03:30
+**Generated At:** 2026-07-21 04:13:58
 
 **Infrastructure Name:** infra-3-nodes
 
@@ -92,6 +92,14 @@
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.30/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 #### 2. ip-10-0-1-221
 
@@ -100,6 +108,14 @@
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.221/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 #### 3. ip-10-0-1-138
 
@@ -108,6 +124,14 @@
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.138/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 
 ## Security Resources

--- a/cmd/test-cli/infra-with-nlb/testresult/beetle-summary-target-aws.md
+++ b/cmd/test-cli/infra-with-nlb/testresult/beetle-summary-target-aws.md
@@ -1,6 +1,6 @@
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-07-13 09:03:53
+**Generated At:** 2026-07-21 04:19:39
 
 **Namespace:** mig01
 
@@ -41,9 +41,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | i-07f638bb18bbb13e6 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 13.209.82.179<br>**Private IP:** 10.0.1.7<br>**SGs:** my-mig-sg-02<br>**SSH:** my-mig-sshkey-01 |
-| my-ng-influxdb-back-1 | i-0f63a3a34b581895d | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 3.38.214.237<br>**Private IP:** 10.0.1.208<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
-| my-ng-influxdb-back-2 | i-05fa2460fe53c2da4 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 54.180.128.3<br>**Private IP:** 10.0.1.177<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
+| my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | i-0054a217572ac064b | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 43.203.180.137<br>**Private IP:** 10.0.1.211<br>**SGs:** my-mig-sg-02<br>**SSH:** my-mig-sshkey-01 |
+| my-ng-influxdb-back-1 | i-0a922ef6e86d46017 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 3.38.153.7<br>**Private IP:** 10.0.1.233<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
+| my-ng-influxdb-back-2 | i-06f3cc5c469f82f40 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 3.39.251.226<br>**Private IP:** 10.0.1.145<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
 
 
 ## Network Resources
@@ -55,7 +55,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my-mig-vnet-01 |
-| **CSP VNet ID** | vpc-0e032ee5b40ca2cdd |
+| **CSP VNet ID** | vpc-0201fe7dacc5b3501 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -64,7 +64,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my-mig-subnet-01 | subnet-0818566fb5fde1e2e | 10.0.1.0/24 | ap-northeast-2a |
+| my-mig-subnet-01 | subnet-0b401ce3e440d6a88 | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -73,7 +73,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my-mig-sshkey-01 | tbt1bt5hiiqoqi38lfv2 |  | 2a:61:89:ab:5d:44:cb:cf:66:1d:da:b7:30:d6:8f:2d:d7:8a:57:81 |
+| my-mig-sshkey-01 | tbh9rdeut22if8j5cv6k |  | 27:de:16:94:80:a4:a8:73:30:d0:f3:da:83:37:7d:43:54:bd:7c:1e |
 
 ### Security Groups
 
@@ -82,7 +82,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my-mig-sg-01 |
-| **CSP Security Group ID** | sg-04f9aacbfff1339fd |
+| **CSP Security Group ID** | sg-0b193070b1e7f5d29 |
 | **VNet** | my-mig-vnet-01 |
 | **Rule Count** | 5 rules |
 
@@ -101,7 +101,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my-mig-sg-02 |
-| **CSP Security Group ID** | sg-06bff0ecdf53345f6 |
+| **CSP Security Group ID** | sg-0b08a1f2cc70c3840 |
 | **VNet** | my-mig-vnet-01 |
 | **Rule Count** | 4 rules |
 

--- a/cmd/test-cli/infra-with-nlb/testresult/beetle-test-results-aws.md
+++ b/cmd/test-cli/infra-with-nlb/testresult/beetle-test-results-aws.md
@@ -7,19 +7,19 @@
 
 ### Environment
 
-- CM-Beetle: b418c24
-- imdl: unknown
-- CB-Tumblebug: Unknown (Fallback to Latest)
-- CB-Spider: Unknown (Fallback to Latest)
-- CB-MapUI: Unknown (Fallback to Latest)
+- CM-Beetle: v0.5.5+ (726f2e8)
+- imdl: v0.1.10+ (726f2e8)
+- CB-Tumblebug: v0.12.25
+- CB-Spider: v0.12.35
+- CB-MapUI: v0.12.50
 - Target CSP: AWS
 - Target Region: ap-northeast-2
 - CM-Beetle URL: http://localhost:8056
 - Namespace: mig01
 - Test CLI: Custom automated testing tool
-- Test Date: July 13, 2026
-- Test Time: 17:58:26 KST
-- Test Execution: 2026-07-13 17:58:26 KST
+- Test Date: July 21, 2026
+- Test Time: 13:13:58 KST
+- Test Execution: 2026-07-21 13:13:58 KST
 
 ### Scenario
 
@@ -47,26 +47,26 @@
 
 | Test | Step (Endpoint / Description) | Status | Duration | Details |
 |------|-------------------------------|--------|----------|----------|
-| 1 | `POST /beetle/recommendation/infraWithNlb` | ✅ **PASS** | 3.11s | Pass |
-| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 49.745s | Pass |
-| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 20ms | Pass |
-| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 6ms | Pass |
-| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 15ms | Pass |
-| 6 | Remote Command Accessibility Check | ✅ **PASS** | 3.086s | Pass |
-| 7 | `POST /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb` | ✅ **PASS** | 2.863s | Pass |
-| 8 | `GET /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb` | ✅ **PASS** | 4ms | Pass |
-| 9 | `GET /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb/{{nlbId}}` | ✅ **PASS** | 6ms | Pass |
-| 10 | NLB Load Balancing Verification | ✅ **PASS** | 4m2.413s | Pass |
-| 11 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.727s | Pass |
-| 12 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.251s | Pass |
-| 13 | `DELETE /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb/{{nlbId}}` | ✅ **PASS** | 16.015s | Pass |
-| 14 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m48.093s | Pass |
+| 1 | `POST /beetle/recommendation/infraWithNlb` | ✅ **PASS** | 2.499s | Pass |
+| 2 | `POST /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 1m5.27s | Pass |
+| 3 | `GET /beetle/migration/ns/mig01/infra` | ✅ **PASS** | 16ms | Pass |
+| 4 | `GET /beetle/migration/ns/mig01/infra?option=id` | ✅ **PASS** | 4ms | Pass |
+| 5 | `GET /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 20ms | Pass |
+| 6 | Remote Command Accessibility Check | ✅ **PASS** | 2.888s | Pass |
+| 7 | `POST /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb` | ✅ **PASS** | 1.925s | Pass |
+| 8 | `GET /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb` | ✅ **PASS** | 5ms | Pass |
+| 9 | `GET /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb/{{nlbId}}` | ✅ **PASS** | 5ms | Pass |
+| 10 | NLB Load Balancing Verification | ✅ **PASS** | 4m5.423s | Pass |
+| 11 | `GET /beetle/summary/target/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.77s | Pass |
+| 12 | `POST /beetle/report/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 5.274s | Pass |
+| 13 | `DELETE /beetle/migration/middleware/ns/mig01/infra/{{infraId}}/nlb/{{nlbId}}` | ✅ **PASS** | 16.615s | Pass |
+| 14 | `DELETE /beetle/migration/ns/mig01/infra/{{infraId}}` | ✅ **PASS** | 1m31.014s | Pass |
 
 **Overall Result**: 14/14 tests passed ✅
 
-**Total Duration**: 8m1.711693771s
+**Total Duration**: 8m2.064529913s
 
-*Test executed on July 13, 2026 at 17:58:26 KST (2026-07-13 17:58:26 KST) using CM-Beetle automated test CLI*
+*Test executed on July 21, 2026 at 13:13:58 KST (2026-07-21 13:13:58 KST) using CM-Beetle automated test CLI*
 
 ---
 
@@ -1588,7 +1588,7 @@
 {
   "resourceType": "infra",
   "id": "my-infra101",
-  "uid": "tbcte7lmtbj6kgg04lbk",
+  "uid": "tb168engtfup19aher7k",
   "name": "my-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -1616,7 +1616,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbcte7lmtbj6kgg04lbk"
+    "sys.uid": "tb168engtfup19aher7k"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -1625,9 +1625,9 @@
     {
       "resourceType": "node",
       "id": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbnsj820p8s86akvvak8",
-      "cspResourceName": "tbnsj820p8s86akvvak8",
-      "cspResourceId": "i-07f638bb18bbb13e6",
+      "uid": "tb7u6fnsqi1moudbbif4",
+      "cspResourceName": "tb7u6fnsqi1moudbbif4",
+      "cspResourceId": "i-0054a217572ac064b",
       "name": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -1641,14 +1641,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-07-13 08:59:14",
+      "createdTime": "2026-07-21 04:14:43",
       "label": {
-        "Name": "tbnsj820p8s86akvvak8",
+        "Name": "tb7u6fnsqi1moudbbif4",
         "sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-07-13 08:59:14",
-        "sys.cspResourceId": "i-07f638bb18bbb13e6",
-        "sys.cspResourceName": "tbnsj820p8s86akvvak8",
+        "sys.createdTime": "2026-07-21 04:14:43",
+        "sys.cspResourceId": "i-0054a217572ac064b",
+        "sys.cspResourceName": "tb7u6fnsqi1moudbbif4",
         "sys.id": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my-infra101",
         "sys.labelType": "node",
@@ -1657,7 +1657,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my-mig-subnet-01",
-        "sys.uid": "tbnsj820p8s86akvvak8",
+        "sys.uid": "tb7u6fnsqi1moudbbif4",
         "sys.vNetId": "my-mig-vnet-01"
       },
       "description": "Recommended VM 01 for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -1665,11 +1665,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "13.209.82.179",
+      "publicIP": "43.203.180.137",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.7",
-      "privateDNS": "ip-10-0-1-7.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.211",
+      "privateDNS": "ip-10-0-1-211.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -1722,22 +1722,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
       },
       "vNetId": "my-mig-vnet-01",
-      "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+      "cspVNetId": "vpc-0201fe7dacc5b3501",
       "subnetId": "my-mig-subnet-01",
-      "cspSubnetId": "subnet-0818566fb5fde1e2e",
-      "networkInterface": "eni-04b86345932b66430",
+      "cspSubnetId": "subnet-0b401ce3e440d6a88",
+      "networkInterface": "eni-00965fb7b340143ce",
       "securityGroupIds": [
         "my-mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my-mig-sshkey-01",
-      "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+      "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD/0qUpBDvfH6Sq3d0/ETKDmOlgwPDBVy5DizyAsZL1hs+YE9PbOCdJGt8UhxZT/+QVTDFQtERT5Tv0TkOMDaiI=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJUyoe5mfCp1erfPjl3PyvVKByna3hSBCZfBexUKqGSCWPF+HIOnA4SGSO6StoOOpBbIFOOX2/Ey3TYWVaWJ7QI=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:gf4D4gHwNsVvb5kZipoaFExwQck+pWKXdWHGIRk6n4o",
-        "firstUsedAt": "2026-07-13T08:59:23Z"
+        "fingerprint": "SHA256:F8fQbYegCXDO7uswMxBAHK0gZ6O80QfpEksjXhvJFLw",
+        "firstUsedAt": "2026-07-21T04:14:50Z"
       },
       "commandStatus": [
         {
@@ -1745,11 +1745,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-07-13T08:59:20Z",
-          "completedTime": "2026-07-13T08:59:24Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-07-21T04:14:49Z",
+          "completedTime": "2026-07-21T04:15:10Z",
+          "elapsedTime": 21,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-7 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-211 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -1764,7 +1764,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:49Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-075df88ac94147398}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:22Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-02afa74102200f386}}"
         },
         {
           "key": "BootMode",
@@ -1776,7 +1776,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "159BC52D-D19C-4863-951F-6B9D4E4989B8"
+          "value": "E4154BA3-C8B5-404A-BDA3-BA6B2EBDBBDB"
         },
         {
           "key": "CpuOptions",
@@ -1808,7 +1808,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-07f638bb18bbb13e6"
+          "value": "i-0054a217572ac064b"
         },
         {
           "key": "InstanceType",
@@ -1816,11 +1816,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbt1bt5hiiqoqi38lfv2"
+          "value": "tbh9rdeut22if8j5cv6k"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-07-13T08:58:49Z"
+          "value": "2026-07-21T04:14:21Z"
         },
         {
           "key": "MetadataOptions",
@@ -1832,7 +1832,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.209.82.179},Attachment:{AttachTime:2026-07-13T08:58:49Z,AttachmentId:eni-attach-0f639e02ec800e8d6,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-06bff0ecdf53345f6,GroupName:tb06smul73eqooor762e}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c9:89:45:9b:3f,NetworkInterfaceId:eni-04b86345932b66430,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.7,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.209.82.179},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.7}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.180.137},Attachment:{AttachTime:2026-07-21T04:14:21Z,AttachmentId:eni-attach-043bbf6a874585d2d,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b08a1f2cc70c3840,GroupName:tb2sp42g38j3600jpagj}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:94:76:f8:09:4f,NetworkInterfaceId:eni-00965fb7b340143ce,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.211,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.180.137},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.211}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
         },
         {
           "key": "Placement",
@@ -1840,15 +1840,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-7.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-211.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.7"
+          "value": "10.0.1.211"
         },
         {
           "key": "PublicIpAddress",
-          "value": "13.209.82.179"
+          "value": "43.203.180.137"
         },
         {
           "key": "RootDeviceName",
@@ -1860,7 +1860,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-06bff0ecdf53345f6,GroupName:tb06smul73eqooor762e}"
+          "value": "{GroupId:sg-0b08a1f2cc70c3840,GroupName:tb2sp42g38j3600jpagj}"
         },
         {
           "key": "SourceDestCheck",
@@ -1872,11 +1872,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0818566fb5fde1e2e"
+          "value": "subnet-0b401ce3e440d6a88"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbnsj820p8s86akvvak8}"
+          "value": "{Key:Name,Value:tb7u6fnsqi1moudbbif4}"
         },
         {
           "key": "VirtualizationType",
@@ -1884,16 +1884,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my-ng-influxdb-back-1",
-      "uid": "tbhmis4r0rri307nakbj",
-      "cspResourceName": "tbhmis4r0rri307nakbj",
-      "cspResourceId": "i-0f63a3a34b581895d",
+      "uid": "tbneuo0rtp598mde00kl",
+      "cspResourceName": "tbneuo0rtp598mde00kl",
+      "cspResourceId": "i-0a922ef6e86d46017",
       "name": "my-ng-influxdb-back-1",
       "nodeGroupId": "my-ng-influxdb-back",
       "location": {
@@ -1907,15 +1907,15 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-07-13 08:59:09",
+      "createdTime": "2026-07-21 04:14:38",
       "label": {
-        "Name": "tbhmis4r0rri307nakbj",
+        "Name": "tbneuo0rtp598mde00kl",
         "nlbBackend": "influxdb_back",
         "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-07-13 08:59:09",
-        "sys.cspResourceId": "i-0f63a3a34b581895d",
-        "sys.cspResourceName": "tbhmis4r0rri307nakbj",
+        "sys.createdTime": "2026-07-21 04:14:38",
+        "sys.cspResourceId": "i-0a922ef6e86d46017",
+        "sys.cspResourceName": "tbneuo0rtp598mde00kl",
         "sys.id": "my-ng-influxdb-back-1",
         "sys.infraId": "my-infra101",
         "sys.labelType": "node",
@@ -1924,7 +1924,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my-ng-influxdb-back",
         "sys.subnetId": "my-mig-subnet-01",
-        "sys.uid": "tbhmis4r0rri307nakbj",
+        "sys.uid": "tbneuo0rtp598mde00kl",
         "sys.vNetId": "my-mig-vnet-01"
       },
       "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -1932,11 +1932,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.38.214.237",
+      "publicIP": "3.38.153.7",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.208",
-      "privateDNS": "ip-10-0-1-208.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.233",
+      "privateDNS": "ip-10-0-1-233.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 30,
       "RootDeviceName": "/dev/sda1",
@@ -1989,22 +1989,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
       },
       "vNetId": "my-mig-vnet-01",
-      "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+      "cspVNetId": "vpc-0201fe7dacc5b3501",
       "subnetId": "my-mig-subnet-01",
-      "cspSubnetId": "subnet-0818566fb5fde1e2e",
-      "networkInterface": "eni-0ad3dfa7e0e692ce9",
+      "cspSubnetId": "subnet-0b401ce3e440d6a88",
+      "networkInterface": "eni-073ba4bba97dcc800",
       "securityGroupIds": [
         "my-mig-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my-mig-sshkey-01",
-      "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+      "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBComOFAY0Apt4eqhfI5+O9HT1ftHQxMdtIcVg7FH7i/JK8/Nc0gRjgUQ/MrG94+U8KG9BGoieD9AtnNFSSUz1eQ=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBX1UeZ8Cvxy2X5GEJ5wGahwzx0xQQqAJ3ISprs4x9V6c841b1MM6mJD2Q1yL69L1G/xEh4fHhZ7vgk8vfGz5vA=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:4QHW7PbNu2KZEZGtyW4YRSQgH4cEnv5+Oxh/7CbtZ2s",
-        "firstUsedAt": "2026-07-13T08:59:21Z"
+        "fingerprint": "SHA256:cCWmDt/ho5e8VTO6vLsMygOlkc2X6wSbSRb21STGLcA",
+        "firstUsedAt": "2026-07-21T04:14:49Z"
       },
       "commandStatus": [
         {
@@ -2012,11 +2012,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-07-13T08:59:20Z",
-          "completedTime": "2026-07-13T08:59:26Z",
-          "elapsedTime": 6,
+          "startedTime": "2026-07-21T04:14:49Z",
+          "completedTime": "2026-07-21T04:15:10Z",
+          "elapsedTime": 21,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-208 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-233 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -2031,7 +2031,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:48Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c5846a38683c331b}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:18Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0eb13b9837198cd82}}"
         },
         {
           "key": "BootMode",
@@ -2043,7 +2043,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "364BAC1F-04F0-456A-ADE8-93943C5CE1F4"
+          "value": "49FA7C53-59BB-4609-A57B-F19D3761CE5C"
         },
         {
           "key": "CpuOptions",
@@ -2075,7 +2075,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0f63a3a34b581895d"
+          "value": "i-0a922ef6e86d46017"
         },
         {
           "key": "InstanceType",
@@ -2083,11 +2083,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbt1bt5hiiqoqi38lfv2"
+          "value": "tbh9rdeut22if8j5cv6k"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-07-13T08:58:47Z"
+          "value": "2026-07-21T04:14:17Z"
         },
         {
           "key": "MetadataOptions",
@@ -2099,7 +2099,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.214.237},Attachment:{AttachTime:2026-07-13T08:58:47Z,AttachmentId:eni-attach-07112d384a4be90ca,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f0:25:6d:0e:09,NetworkInterfaceId:eni-0ad3dfa7e0e692ce9,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.208,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.214.237},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.208}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.153.7},Attachment:{AttachTime:2026-07-21T04:14:17Z,AttachmentId:eni-attach-0446610409a40d148,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:9b:bd:e3:d6:59,NetworkInterfaceId:eni-073ba4bba97dcc800,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.233,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.153.7},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.233}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
         },
         {
           "key": "Placement",
@@ -2107,15 +2107,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-208.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-233.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.208"
+          "value": "10.0.1.233"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.38.214.237"
+          "value": "3.38.153.7"
         },
         {
           "key": "RootDeviceName",
@@ -2127,7 +2127,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}"
+          "value": "{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}"
         },
         {
           "key": "SourceDestCheck",
@@ -2139,11 +2139,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0818566fb5fde1e2e"
+          "value": "subnet-0b401ce3e440d6a88"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbhmis4r0rri307nakbj}"
+          "value": "{Key:Name,Value:tbneuo0rtp598mde00kl}"
         },
         {
           "key": "VirtualizationType",
@@ -2151,16 +2151,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my-ng-influxdb-back-2",
-      "uid": "tb8l2ijc96kov0sucic4",
-      "cspResourceName": "tb8l2ijc96kov0sucic4",
-      "cspResourceId": "i-05fa2460fe53c2da4",
+      "uid": "tbfcjl18emj99142cipm",
+      "cspResourceName": "tbfcjl18emj99142cipm",
+      "cspResourceId": "i-06f3cc5c469f82f40",
       "name": "my-ng-influxdb-back-2",
       "nodeGroupId": "my-ng-influxdb-back",
       "location": {
@@ -2174,15 +2174,15 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-07-13 08:59:10",
+      "createdTime": "2026-07-21 04:14:41",
       "label": {
-        "Name": "tb8l2ijc96kov0sucic4",
+        "Name": "tbfcjl18emj99142cipm",
         "nlbBackend": "influxdb_back",
         "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-07-13 08:59:10",
-        "sys.cspResourceId": "i-05fa2460fe53c2da4",
-        "sys.cspResourceName": "tb8l2ijc96kov0sucic4",
+        "sys.createdTime": "2026-07-21 04:14:41",
+        "sys.cspResourceId": "i-06f3cc5c469f82f40",
+        "sys.cspResourceName": "tbfcjl18emj99142cipm",
         "sys.id": "my-ng-influxdb-back-2",
         "sys.infraId": "my-infra101",
         "sys.labelType": "node",
@@ -2191,7 +2191,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my-ng-influxdb-back",
         "sys.subnetId": "my-mig-subnet-01",
-        "sys.uid": "tb8l2ijc96kov0sucic4",
+        "sys.uid": "tbfcjl18emj99142cipm",
         "sys.vNetId": "my-mig-vnet-01"
       },
       "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -2199,11 +2199,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "54.180.128.3",
+      "publicIP": "3.39.251.226",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.177",
-      "privateDNS": "ip-10-0-1-177.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.145",
+      "privateDNS": "ip-10-0-1-145.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 30,
       "RootDeviceName": "/dev/sda1",
@@ -2256,22 +2256,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
       },
       "vNetId": "my-mig-vnet-01",
-      "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+      "cspVNetId": "vpc-0201fe7dacc5b3501",
       "subnetId": "my-mig-subnet-01",
-      "cspSubnetId": "subnet-0818566fb5fde1e2e",
-      "networkInterface": "eni-0a69553e93cfd3c58",
+      "cspSubnetId": "subnet-0b401ce3e440d6a88",
+      "networkInterface": "eni-00e59e53d2438bedf",
       "securityGroupIds": [
         "my-mig-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my-mig-sshkey-01",
-      "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+      "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDKSW1urRTxcD8HxJHqH5H1LtqQ2Z9X8gvcXzyf3+/V1s0pueMR1LiK7uBEMAFmKwumnU+Ev/h8/hQW4UZTmt6k=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEUlFwV+LidXdVFjp33gpGja29R5Zllc2VcCP7KZq1ZCI9XqDBp/pOh+VeM7fpiSGPpJZOtVZc+kdv497A6ja3I=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:Fojp9r4Eu2t4EMXoKlBqAWOoQHzC/HjsxphpWTC5Lls",
-        "firstUsedAt": "2026-07-13T08:59:23Z"
+        "fingerprint": "SHA256:jF0XS+JJjHfi4QK/kgIBKgBL79pWqPan4ncwAbaPubE",
+        "firstUsedAt": "2026-07-21T04:14:50Z"
       },
       "commandStatus": [
         {
@@ -2279,11 +2279,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-07-13T08:59:20Z",
-          "completedTime": "2026-07-13T08:59:24Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-07-21T04:14:49Z",
+          "completedTime": "2026-07-21T04:14:52Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-177 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-145 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -2298,7 +2298,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:50Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-053ded65affcde4c9}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:21Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0a446b7810b00d3d5}}"
         },
         {
           "key": "BootMode",
@@ -2310,7 +2310,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "A4C60AB0-43CD-4016-BD40-26C7E17B944D"
+          "value": "C3F8023D-4CF6-4E4F-B17A-08FB56D4EDE6"
         },
         {
           "key": "CpuOptions",
@@ -2342,7 +2342,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-05fa2460fe53c2da4"
+          "value": "i-06f3cc5c469f82f40"
         },
         {
           "key": "InstanceType",
@@ -2350,11 +2350,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbt1bt5hiiqoqi38lfv2"
+          "value": "tbh9rdeut22if8j5cv6k"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-07-13T08:58:49Z"
+          "value": "2026-07-21T04:14:20Z"
         },
         {
           "key": "MetadataOptions",
@@ -2366,7 +2366,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.128.3},Attachment:{AttachTime:2026-07-13T08:58:49Z,AttachmentId:eni-attach-04f6287c37f556e46,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:17:fd:56:c7:27,NetworkInterfaceId:eni-0a69553e93cfd3c58,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.177,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.128.3},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.177}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.39.251.226},Attachment:{AttachTime:2026-07-21T04:14:20Z,AttachmentId:eni-attach-06a41c8ec19fbdce5,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:43:e9:6b:c4:b1,NetworkInterfaceId:eni-00e59e53d2438bedf,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.145,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.39.251.226},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.145}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
         },
         {
           "key": "Placement",
@@ -2374,15 +2374,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-177.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-145.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.177"
+          "value": "10.0.1.145"
         },
         {
           "key": "PublicIpAddress",
-          "value": "54.180.128.3"
+          "value": "3.39.251.226"
         },
         {
           "key": "RootDeviceName",
@@ -2394,7 +2394,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}"
+          "value": "{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}"
         },
         {
           "key": "SourceDestCheck",
@@ -2406,11 +2406,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0818566fb5fde1e2e"
+          "value": "subnet-0b401ce3e440d6a88"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tb8l2ijc96kov0sucic4}"
+          "value": "{Key:Name,Value:tbfcjl18emj99142cipm}"
         },
         {
           "key": "VirtualizationType",
@@ -2418,7 +2418,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     }
@@ -2435,12 +2435,12 @@
       {
         "infraId": "my-infra101",
         "nodeId": "my-ng-influxdb-back-2",
-        "nodeIp": "54.180.128.3",
+        "nodeIp": "3.39.251.226",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-177 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-145 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -2450,12 +2450,12 @@
       {
         "infraId": "my-infra101",
         "nodeId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "13.209.82.179",
+        "nodeIp": "43.203.180.137",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-7 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-211 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -2465,12 +2465,12 @@
       {
         "infraId": "my-infra101",
         "nodeId": "my-ng-influxdb-back-1",
-        "nodeIp": "3.38.214.237",
+        "nodeIp": "3.38.153.7",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-208 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-233 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -2508,7 +2508,7 @@
     {
       "resourceType": "infra",
       "id": "my-infra101",
-      "uid": "tbcte7lmtbj6kgg04lbk",
+      "uid": "tb168engtfup19aher7k",
       "name": "my-infra101",
       "status": "Running:3 (R:3/3)",
       "statusCount": {
@@ -2536,7 +2536,7 @@
         "sys.manager": "cb-tumblebug",
         "sys.name": "my-infra101",
         "sys.namespace": "mig01",
-        "sys.uid": "tbcte7lmtbj6kgg04lbk"
+        "sys.uid": "tb168engtfup19aher7k"
       },
       "systemLabel": "",
       "systemMessage": null,
@@ -2545,9 +2545,9 @@
         {
           "resourceType": "node",
           "id": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
-          "uid": "tbnsj820p8s86akvvak8",
-          "cspResourceName": "tbnsj820p8s86akvvak8",
-          "cspResourceId": "i-07f638bb18bbb13e6",
+          "uid": "tb7u6fnsqi1moudbbif4",
+          "cspResourceName": "tb7u6fnsqi1moudbbif4",
+          "cspResourceId": "i-0054a217572ac064b",
           "name": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
           "nodeGroupId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624",
           "location": {
@@ -2561,14 +2561,14 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-07-13 08:59:14",
+          "createdTime": "2026-07-21 04:14:43",
           "label": {
-            "Name": "tbnsj820p8s86akvvak8",
+            "Name": "tb7u6fnsqi1moudbbif4",
             "sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-07-13 08:59:14",
-            "sys.cspResourceId": "i-07f638bb18bbb13e6",
-            "sys.cspResourceName": "tbnsj820p8s86akvvak8",
+            "sys.createdTime": "2026-07-21 04:14:43",
+            "sys.cspResourceId": "i-0054a217572ac064b",
+            "sys.cspResourceName": "tb7u6fnsqi1moudbbif4",
             "sys.id": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
             "sys.infraId": "my-infra101",
             "sys.labelType": "node",
@@ -2577,7 +2577,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624",
             "sys.subnetId": "my-mig-subnet-01",
-            "sys.uid": "tbnsj820p8s86akvvak8",
+            "sys.uid": "tb7u6fnsqi1moudbbif4",
             "sys.vNetId": "my-mig-vnet-01"
           },
           "description": "Recommended VM 01 for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -2585,11 +2585,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "13.209.82.179",
+          "publicIP": "43.203.180.137",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.7",
-          "privateDNS": "ip-10-0-1-7.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.211",
+          "privateDNS": "ip-10-0-1-211.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 10,
           "RootDeviceName": "/dev/sda1",
@@ -2642,22 +2642,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
           },
           "vNetId": "my-mig-vnet-01",
-          "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+          "cspVNetId": "vpc-0201fe7dacc5b3501",
           "subnetId": "my-mig-subnet-01",
-          "cspSubnetId": "subnet-0818566fb5fde1e2e",
-          "networkInterface": "eni-04b86345932b66430",
+          "cspSubnetId": "subnet-0b401ce3e440d6a88",
+          "networkInterface": "eni-00965fb7b340143ce",
           "securityGroupIds": [
             "my-mig-sg-02"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my-mig-sshkey-01",
-          "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+          "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD/0qUpBDvfH6Sq3d0/ETKDmOlgwPDBVy5DizyAsZL1hs+YE9PbOCdJGt8UhxZT/+QVTDFQtERT5Tv0TkOMDaiI=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJUyoe5mfCp1erfPjl3PyvVKByna3hSBCZfBexUKqGSCWPF+HIOnA4SGSO6StoOOpBbIFOOX2/Ey3TYWVaWJ7QI=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:gf4D4gHwNsVvb5kZipoaFExwQck+pWKXdWHGIRk6n4o",
-            "firstUsedAt": "2026-07-13T08:59:23Z"
+            "fingerprint": "SHA256:F8fQbYegCXDO7uswMxBAHK0gZ6O80QfpEksjXhvJFLw",
+            "firstUsedAt": "2026-07-21T04:14:50Z"
           },
           "commandStatus": [
             {
@@ -2665,11 +2665,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-07-13T08:59:20Z",
-              "completedTime": "2026-07-13T08:59:24Z",
-              "elapsedTime": 4,
+              "startedTime": "2026-07-21T04:14:49Z",
+              "completedTime": "2026-07-21T04:15:10Z",
+              "elapsedTime": 21,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-7 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-211 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -2684,7 +2684,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:49Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-075df88ac94147398}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:22Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-02afa74102200f386}}"
             },
             {
               "key": "BootMode",
@@ -2696,7 +2696,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "159BC52D-D19C-4863-951F-6B9D4E4989B8"
+              "value": "E4154BA3-C8B5-404A-BDA3-BA6B2EBDBBDB"
             },
             {
               "key": "CpuOptions",
@@ -2728,7 +2728,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-07f638bb18bbb13e6"
+              "value": "i-0054a217572ac064b"
             },
             {
               "key": "InstanceType",
@@ -2736,11 +2736,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbt1bt5hiiqoqi38lfv2"
+              "value": "tbh9rdeut22if8j5cv6k"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-07-13T08:58:49Z"
+              "value": "2026-07-21T04:14:21Z"
             },
             {
               "key": "MetadataOptions",
@@ -2752,7 +2752,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.209.82.179},Attachment:{AttachTime:2026-07-13T08:58:49Z,AttachmentId:eni-attach-0f639e02ec800e8d6,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-06bff0ecdf53345f6,GroupName:tb06smul73eqooor762e}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c9:89:45:9b:3f,NetworkInterfaceId:eni-04b86345932b66430,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.7,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.209.82.179},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.7}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.180.137},Attachment:{AttachTime:2026-07-21T04:14:21Z,AttachmentId:eni-attach-043bbf6a874585d2d,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b08a1f2cc70c3840,GroupName:tb2sp42g38j3600jpagj}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:94:76:f8:09:4f,NetworkInterfaceId:eni-00965fb7b340143ce,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.211,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.180.137},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.211}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
             },
             {
               "key": "Placement",
@@ -2760,15 +2760,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-7.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-211.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.7"
+              "value": "10.0.1.211"
             },
             {
               "key": "PublicIpAddress",
-              "value": "13.209.82.179"
+              "value": "43.203.180.137"
             },
             {
               "key": "RootDeviceName",
@@ -2780,7 +2780,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-06bff0ecdf53345f6,GroupName:tb06smul73eqooor762e}"
+              "value": "{GroupId:sg-0b08a1f2cc70c3840,GroupName:tb2sp42g38j3600jpagj}"
             },
             {
               "key": "SourceDestCheck",
@@ -2792,11 +2792,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0818566fb5fde1e2e"
+              "value": "subnet-0b401ce3e440d6a88"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbnsj820p8s86akvvak8}"
+              "value": "{Key:Name,Value:tb7u6fnsqi1moudbbif4}"
             },
             {
               "key": "VirtualizationType",
@@ -2804,16 +2804,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-0e032ee5b40ca2cdd"
+              "value": "vpc-0201fe7dacc5b3501"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my-ng-influxdb-back-1",
-          "uid": "tbhmis4r0rri307nakbj",
-          "cspResourceName": "tbhmis4r0rri307nakbj",
-          "cspResourceId": "i-0f63a3a34b581895d",
+          "uid": "tbneuo0rtp598mde00kl",
+          "cspResourceName": "tbneuo0rtp598mde00kl",
+          "cspResourceId": "i-0a922ef6e86d46017",
           "name": "my-ng-influxdb-back-1",
           "nodeGroupId": "my-ng-influxdb-back",
           "location": {
@@ -2827,15 +2827,15 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-07-13 08:59:09",
+          "createdTime": "2026-07-21 04:14:38",
           "label": {
-            "Name": "tbhmis4r0rri307nakbj",
+            "Name": "tbneuo0rtp598mde00kl",
             "nlbBackend": "influxdb_back",
             "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-07-13 08:59:09",
-            "sys.cspResourceId": "i-0f63a3a34b581895d",
-            "sys.cspResourceName": "tbhmis4r0rri307nakbj",
+            "sys.createdTime": "2026-07-21 04:14:38",
+            "sys.cspResourceId": "i-0a922ef6e86d46017",
+            "sys.cspResourceName": "tbneuo0rtp598mde00kl",
             "sys.id": "my-ng-influxdb-back-1",
             "sys.infraId": "my-infra101",
             "sys.labelType": "node",
@@ -2844,7 +2844,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my-ng-influxdb-back",
             "sys.subnetId": "my-mig-subnet-01",
-            "sys.uid": "tbhmis4r0rri307nakbj",
+            "sys.uid": "tbneuo0rtp598mde00kl",
             "sys.vNetId": "my-mig-vnet-01"
           },
           "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -2852,11 +2852,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "3.38.214.237",
+          "publicIP": "3.38.153.7",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.208",
-          "privateDNS": "ip-10-0-1-208.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.233",
+          "privateDNS": "ip-10-0-1-233.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 30,
           "RootDeviceName": "/dev/sda1",
@@ -2909,22 +2909,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
           },
           "vNetId": "my-mig-vnet-01",
-          "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+          "cspVNetId": "vpc-0201fe7dacc5b3501",
           "subnetId": "my-mig-subnet-01",
-          "cspSubnetId": "subnet-0818566fb5fde1e2e",
-          "networkInterface": "eni-0ad3dfa7e0e692ce9",
+          "cspSubnetId": "subnet-0b401ce3e440d6a88",
+          "networkInterface": "eni-073ba4bba97dcc800",
           "securityGroupIds": [
             "my-mig-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my-mig-sshkey-01",
-          "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+          "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBComOFAY0Apt4eqhfI5+O9HT1ftHQxMdtIcVg7FH7i/JK8/Nc0gRjgUQ/MrG94+U8KG9BGoieD9AtnNFSSUz1eQ=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBX1UeZ8Cvxy2X5GEJ5wGahwzx0xQQqAJ3ISprs4x9V6c841b1MM6mJD2Q1yL69L1G/xEh4fHhZ7vgk8vfGz5vA=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:4QHW7PbNu2KZEZGtyW4YRSQgH4cEnv5+Oxh/7CbtZ2s",
-            "firstUsedAt": "2026-07-13T08:59:21Z"
+            "fingerprint": "SHA256:cCWmDt/ho5e8VTO6vLsMygOlkc2X6wSbSRb21STGLcA",
+            "firstUsedAt": "2026-07-21T04:14:49Z"
           },
           "commandStatus": [
             {
@@ -2932,11 +2932,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-07-13T08:59:20Z",
-              "completedTime": "2026-07-13T08:59:26Z",
-              "elapsedTime": 6,
+              "startedTime": "2026-07-21T04:14:49Z",
+              "completedTime": "2026-07-21T04:15:10Z",
+              "elapsedTime": 21,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-208 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-233 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -2951,7 +2951,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:48Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c5846a38683c331b}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:18Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0eb13b9837198cd82}}"
             },
             {
               "key": "BootMode",
@@ -2963,7 +2963,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "364BAC1F-04F0-456A-ADE8-93943C5CE1F4"
+              "value": "49FA7C53-59BB-4609-A57B-F19D3761CE5C"
             },
             {
               "key": "CpuOptions",
@@ -2995,7 +2995,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-0f63a3a34b581895d"
+              "value": "i-0a922ef6e86d46017"
             },
             {
               "key": "InstanceType",
@@ -3003,11 +3003,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbt1bt5hiiqoqi38lfv2"
+              "value": "tbh9rdeut22if8j5cv6k"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-07-13T08:58:47Z"
+              "value": "2026-07-21T04:14:17Z"
             },
             {
               "key": "MetadataOptions",
@@ -3019,7 +3019,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.214.237},Attachment:{AttachTime:2026-07-13T08:58:47Z,AttachmentId:eni-attach-07112d384a4be90ca,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f0:25:6d:0e:09,NetworkInterfaceId:eni-0ad3dfa7e0e692ce9,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.208,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.214.237},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.208}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.153.7},Attachment:{AttachTime:2026-07-21T04:14:17Z,AttachmentId:eni-attach-0446610409a40d148,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:9b:bd:e3:d6:59,NetworkInterfaceId:eni-073ba4bba97dcc800,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.233,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.153.7},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.233}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
             },
             {
               "key": "Placement",
@@ -3027,15 +3027,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-208.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-233.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.208"
+              "value": "10.0.1.233"
             },
             {
               "key": "PublicIpAddress",
-              "value": "3.38.214.237"
+              "value": "3.38.153.7"
             },
             {
               "key": "RootDeviceName",
@@ -3047,7 +3047,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}"
+              "value": "{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}"
             },
             {
               "key": "SourceDestCheck",
@@ -3059,11 +3059,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0818566fb5fde1e2e"
+              "value": "subnet-0b401ce3e440d6a88"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tbhmis4r0rri307nakbj}"
+              "value": "{Key:Name,Value:tbneuo0rtp598mde00kl}"
             },
             {
               "key": "VirtualizationType",
@@ -3071,16 +3071,16 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-0e032ee5b40ca2cdd"
+              "value": "vpc-0201fe7dacc5b3501"
             }
           ]
         },
         {
           "resourceType": "node",
           "id": "my-ng-influxdb-back-2",
-          "uid": "tb8l2ijc96kov0sucic4",
-          "cspResourceName": "tb8l2ijc96kov0sucic4",
-          "cspResourceId": "i-05fa2460fe53c2da4",
+          "uid": "tbfcjl18emj99142cipm",
+          "cspResourceName": "tbfcjl18emj99142cipm",
+          "cspResourceId": "i-06f3cc5c469f82f40",
           "name": "my-ng-influxdb-back-2",
           "nodeGroupId": "my-ng-influxdb-back",
           "location": {
@@ -3094,15 +3094,15 @@
           "monAgentStatus": "notInstalled",
           "networkAgentStatus": "notInstalled",
           "systemMessage": "",
-          "createdTime": "2026-07-13 08:59:10",
+          "createdTime": "2026-07-21 04:14:41",
           "label": {
-            "Name": "tb8l2ijc96kov0sucic4",
+            "Name": "tbfcjl18emj99142cipm",
             "nlbBackend": "influxdb_back",
             "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf",
             "sys.connectionName": "aws-ap-northeast-2",
-            "sys.createdTime": "2026-07-13 08:59:10",
-            "sys.cspResourceId": "i-05fa2460fe53c2da4",
-            "sys.cspResourceName": "tb8l2ijc96kov0sucic4",
+            "sys.createdTime": "2026-07-21 04:14:41",
+            "sys.cspResourceId": "i-06f3cc5c469f82f40",
+            "sys.cspResourceName": "tbfcjl18emj99142cipm",
             "sys.id": "my-ng-influxdb-back-2",
             "sys.infraId": "my-infra101",
             "sys.labelType": "node",
@@ -3111,7 +3111,7 @@
             "sys.namespace": "mig01",
             "sys.nodeGroupId": "my-ng-influxdb-back",
             "sys.subnetId": "my-mig-subnet-01",
-            "sys.uid": "tb8l2ijc96kov0sucic4",
+            "sys.uid": "tbfcjl18emj99142cipm",
             "sys.vNetId": "my-mig-vnet-01"
           },
           "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -3119,11 +3119,11 @@
             "region": "ap-northeast-2",
             "zone": "ap-northeast-2a"
           },
-          "publicIP": "54.180.128.3",
+          "publicIP": "3.39.251.226",
           "sshPort": 22,
           "publicDNS": "",
-          "privateIP": "10.0.1.177",
-          "privateDNS": "ip-10-0-1-177.ap-northeast-2.compute.internal",
+          "privateIP": "10.0.1.145",
+          "privateDNS": "ip-10-0-1-145.ap-northeast-2.compute.internal",
           "rootDiskType": "gp2",
           "rootDiskSize": 30,
           "RootDeviceName": "/dev/sda1",
@@ -3176,22 +3176,22 @@
             "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
           },
           "vNetId": "my-mig-vnet-01",
-          "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+          "cspVNetId": "vpc-0201fe7dacc5b3501",
           "subnetId": "my-mig-subnet-01",
-          "cspSubnetId": "subnet-0818566fb5fde1e2e",
-          "networkInterface": "eni-0a69553e93cfd3c58",
+          "cspSubnetId": "subnet-0b401ce3e440d6a88",
+          "networkInterface": "eni-00e59e53d2438bedf",
           "securityGroupIds": [
             "my-mig-sg-01"
           ],
           "dataDiskIds": null,
           "sshKeyId": "my-mig-sshkey-01",
-          "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+          "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
           "nodeUserName": "cb-user",
           "sshHostKeyInfo": {
-            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDKSW1urRTxcD8HxJHqH5H1LtqQ2Z9X8gvcXzyf3+/V1s0pueMR1LiK7uBEMAFmKwumnU+Ev/h8/hQW4UZTmt6k=",
+            "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEUlFwV+LidXdVFjp33gpGja29R5Zllc2VcCP7KZq1ZCI9XqDBp/pOh+VeM7fpiSGPpJZOtVZc+kdv497A6ja3I=",
             "keyType": "ecdsa-sha2-nistp256",
-            "fingerprint": "SHA256:Fojp9r4Eu2t4EMXoKlBqAWOoQHzC/HjsxphpWTC5Lls",
-            "firstUsedAt": "2026-07-13T08:59:23Z"
+            "fingerprint": "SHA256:jF0XS+JJjHfi4QK/kgIBKgBL79pWqPan4ncwAbaPubE",
+            "firstUsedAt": "2026-07-21T04:14:50Z"
           },
           "commandStatus": [
             {
@@ -3199,11 +3199,11 @@
               "commandRequested": "uname -a",
               "commandExecuted": "uname -a",
               "status": "Completed",
-              "startedTime": "2026-07-13T08:59:20Z",
-              "completedTime": "2026-07-13T08:59:24Z",
-              "elapsedTime": 4,
+              "startedTime": "2026-07-21T04:14:49Z",
+              "completedTime": "2026-07-21T04:14:52Z",
+              "elapsedTime": 3,
               "resultSummary": "Command executed successfully",
-              "stdout": "Linux ip-10-0-1-177 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+              "stdout": "Linux ip-10-0-1-145 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
               "stderr": "\n"
             }
           ],
@@ -3218,7 +3218,7 @@
             },
             {
               "key": "BlockDeviceMappings",
-              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:50Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-053ded65affcde4c9}}"
+              "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:21Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0a446b7810b00d3d5}}"
             },
             {
               "key": "BootMode",
@@ -3230,7 +3230,7 @@
             },
             {
               "key": "ClientToken",
-              "value": "A4C60AB0-43CD-4016-BD40-26C7E17B944D"
+              "value": "C3F8023D-4CF6-4E4F-B17A-08FB56D4EDE6"
             },
             {
               "key": "CpuOptions",
@@ -3262,7 +3262,7 @@
             },
             {
               "key": "InstanceId",
-              "value": "i-05fa2460fe53c2da4"
+              "value": "i-06f3cc5c469f82f40"
             },
             {
               "key": "InstanceType",
@@ -3270,11 +3270,11 @@
             },
             {
               "key": "KeyName",
-              "value": "tbt1bt5hiiqoqi38lfv2"
+              "value": "tbh9rdeut22if8j5cv6k"
             },
             {
               "key": "LaunchTime",
-              "value": "2026-07-13T08:58:49Z"
+              "value": "2026-07-21T04:14:20Z"
             },
             {
               "key": "MetadataOptions",
@@ -3286,7 +3286,7 @@
             },
             {
               "key": "NetworkInterfaces",
-              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.128.3},Attachment:{AttachTime:2026-07-13T08:58:49Z,AttachmentId:eni-attach-04f6287c37f556e46,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:17:fd:56:c7:27,NetworkInterfaceId:eni-0a69553e93cfd3c58,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.177,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.128.3},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.177}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+              "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.39.251.226},Attachment:{AttachTime:2026-07-21T04:14:20Z,AttachmentId:eni-attach-06a41c8ec19fbdce5,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:43:e9:6b:c4:b1,NetworkInterfaceId:eni-00e59e53d2438bedf,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.145,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.39.251.226},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.145}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
             },
             {
               "key": "Placement",
@@ -3294,15 +3294,15 @@
             },
             {
               "key": "PrivateDnsName",
-              "value": "ip-10-0-1-177.ap-northeast-2.compute.internal"
+              "value": "ip-10-0-1-145.ap-northeast-2.compute.internal"
             },
             {
               "key": "PrivateIpAddress",
-              "value": "10.0.1.177"
+              "value": "10.0.1.145"
             },
             {
               "key": "PublicIpAddress",
-              "value": "54.180.128.3"
+              "value": "3.39.251.226"
             },
             {
               "key": "RootDeviceName",
@@ -3314,7 +3314,7 @@
             },
             {
               "key": "SecurityGroups",
-              "value": "{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}"
+              "value": "{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}"
             },
             {
               "key": "SourceDestCheck",
@@ -3326,11 +3326,11 @@
             },
             {
               "key": "SubnetId",
-              "value": "subnet-0818566fb5fde1e2e"
+              "value": "subnet-0b401ce3e440d6a88"
             },
             {
               "key": "Tags",
-              "value": "{Key:Name,Value:tb8l2ijc96kov0sucic4}"
+              "value": "{Key:Name,Value:tbfcjl18emj99142cipm}"
             },
             {
               "key": "VirtualizationType",
@@ -3338,7 +3338,7 @@
             },
             {
               "key": "VpcId",
-              "value": "vpc-0e032ee5b40ca2cdd"
+              "value": "vpc-0201fe7dacc5b3501"
             }
           ]
         }
@@ -3355,12 +3355,12 @@
           {
             "infraId": "my-infra101",
             "nodeId": "my-ng-influxdb-back-2",
-            "nodeIp": "54.180.128.3",
+            "nodeIp": "3.39.251.226",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-177 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-145 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -3370,12 +3370,12 @@
           {
             "infraId": "my-infra101",
             "nodeId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
-            "nodeIp": "13.209.82.179",
+            "nodeIp": "43.203.180.137",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-7 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-211 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -3385,12 +3385,12 @@
           {
             "infraId": "my-infra101",
             "nodeId": "my-ng-influxdb-back-1",
-            "nodeIp": "3.38.214.237",
+            "nodeIp": "3.38.153.7",
             "command": {
               "0": "uname -a"
             },
             "stdout": {
-              "0": "Linux ip-10-0-1-208 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+              "0": "Linux ip-10-0-1-233 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
             },
             "stderr": {
               "0": ""
@@ -3436,7 +3436,7 @@
 {
   "resourceType": "infra",
   "id": "my-infra101",
-  "uid": "tbcte7lmtbj6kgg04lbk",
+  "uid": "tb168engtfup19aher7k",
   "name": "my-infra101",
   "status": "Running:3 (R:3/3)",
   "statusCount": {
@@ -3464,7 +3464,7 @@
     "sys.manager": "cb-tumblebug",
     "sys.name": "my-infra101",
     "sys.namespace": "mig01",
-    "sys.uid": "tbcte7lmtbj6kgg04lbk"
+    "sys.uid": "tb168engtfup19aher7k"
   },
   "systemLabel": "",
   "systemMessage": null,
@@ -3473,9 +3473,9 @@
     {
       "resourceType": "node",
       "id": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
-      "uid": "tbnsj820p8s86akvvak8",
-      "cspResourceName": "tbnsj820p8s86akvvak8",
-      "cspResourceId": "i-07f638bb18bbb13e6",
+      "uid": "tb7u6fnsqi1moudbbif4",
+      "cspResourceName": "tb7u6fnsqi1moudbbif4",
+      "cspResourceId": "i-0054a217572ac064b",
       "name": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
       "nodeGroupId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624",
       "location": {
@@ -3489,14 +3489,14 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-07-13 08:59:14",
+      "createdTime": "2026-07-21 04:14:43",
       "label": {
-        "Name": "tbnsj820p8s86akvvak8",
+        "Name": "tb7u6fnsqi1moudbbif4",
         "sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-07-13 08:59:14",
-        "sys.cspResourceId": "i-07f638bb18bbb13e6",
-        "sys.cspResourceName": "tbnsj820p8s86akvvak8",
+        "sys.createdTime": "2026-07-21 04:14:43",
+        "sys.cspResourceId": "i-0054a217572ac064b",
+        "sys.cspResourceName": "tb7u6fnsqi1moudbbif4",
         "sys.id": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
         "sys.infraId": "my-infra101",
         "sys.labelType": "node",
@@ -3505,7 +3505,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624",
         "sys.subnetId": "my-mig-subnet-01",
-        "sys.uid": "tbnsj820p8s86akvvak8",
+        "sys.uid": "tb7u6fnsqi1moudbbif4",
         "sys.vNetId": "my-mig-vnet-01"
       },
       "description": "Recommended VM 01 for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -3513,11 +3513,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "13.209.82.179",
+      "publicIP": "43.203.180.137",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.7",
-      "privateDNS": "ip-10-0-1-7.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.211",
+      "privateDNS": "ip-10-0-1-211.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 10,
       "RootDeviceName": "/dev/sda1",
@@ -3570,22 +3570,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
       },
       "vNetId": "my-mig-vnet-01",
-      "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+      "cspVNetId": "vpc-0201fe7dacc5b3501",
       "subnetId": "my-mig-subnet-01",
-      "cspSubnetId": "subnet-0818566fb5fde1e2e",
-      "networkInterface": "eni-04b86345932b66430",
+      "cspSubnetId": "subnet-0b401ce3e440d6a88",
+      "networkInterface": "eni-00965fb7b340143ce",
       "securityGroupIds": [
         "my-mig-sg-02"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my-mig-sshkey-01",
-      "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+      "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBD/0qUpBDvfH6Sq3d0/ETKDmOlgwPDBVy5DizyAsZL1hs+YE9PbOCdJGt8UhxZT/+QVTDFQtERT5Tv0TkOMDaiI=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJUyoe5mfCp1erfPjl3PyvVKByna3hSBCZfBexUKqGSCWPF+HIOnA4SGSO6StoOOpBbIFOOX2/Ey3TYWVaWJ7QI=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:gf4D4gHwNsVvb5kZipoaFExwQck+pWKXdWHGIRk6n4o",
-        "firstUsedAt": "2026-07-13T08:59:23Z"
+        "fingerprint": "SHA256:F8fQbYegCXDO7uswMxBAHK0gZ6O80QfpEksjXhvJFLw",
+        "firstUsedAt": "2026-07-21T04:14:50Z"
       },
       "commandStatus": [
         {
@@ -3593,11 +3593,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-07-13T08:59:20Z",
-          "completedTime": "2026-07-13T08:59:24Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-07-21T04:14:49Z",
+          "completedTime": "2026-07-21T04:15:10Z",
+          "elapsedTime": 21,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-7 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-211 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -3612,7 +3612,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:49Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-075df88ac94147398}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:22Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-02afa74102200f386}}"
         },
         {
           "key": "BootMode",
@@ -3624,7 +3624,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "159BC52D-D19C-4863-951F-6B9D4E4989B8"
+          "value": "E4154BA3-C8B5-404A-BDA3-BA6B2EBDBBDB"
         },
         {
           "key": "CpuOptions",
@@ -3656,7 +3656,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-07f638bb18bbb13e6"
+          "value": "i-0054a217572ac064b"
         },
         {
           "key": "InstanceType",
@@ -3664,11 +3664,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbt1bt5hiiqoqi38lfv2"
+          "value": "tbh9rdeut22if8j5cv6k"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-07-13T08:58:49Z"
+          "value": "2026-07-21T04:14:21Z"
         },
         {
           "key": "MetadataOptions",
@@ -3680,7 +3680,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.209.82.179},Attachment:{AttachTime:2026-07-13T08:58:49Z,AttachmentId:eni-attach-0f639e02ec800e8d6,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-06bff0ecdf53345f6,GroupName:tb06smul73eqooor762e}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:c9:89:45:9b:3f,NetworkInterfaceId:eni-04b86345932b66430,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.7,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:13.209.82.179},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.7}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.180.137},Attachment:{AttachTime:2026-07-21T04:14:21Z,AttachmentId:eni-attach-043bbf6a874585d2d,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b08a1f2cc70c3840,GroupName:tb2sp42g38j3600jpagj}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:94:76:f8:09:4f,NetworkInterfaceId:eni-00965fb7b340143ce,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.211,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:43.203.180.137},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.211}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
         },
         {
           "key": "Placement",
@@ -3688,15 +3688,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-7.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-211.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.7"
+          "value": "10.0.1.211"
         },
         {
           "key": "PublicIpAddress",
-          "value": "13.209.82.179"
+          "value": "43.203.180.137"
         },
         {
           "key": "RootDeviceName",
@@ -3708,7 +3708,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-06bff0ecdf53345f6,GroupName:tb06smul73eqooor762e}"
+          "value": "{GroupId:sg-0b08a1f2cc70c3840,GroupName:tb2sp42g38j3600jpagj}"
         },
         {
           "key": "SourceDestCheck",
@@ -3720,11 +3720,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0818566fb5fde1e2e"
+          "value": "subnet-0b401ce3e440d6a88"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbnsj820p8s86akvvak8}"
+          "value": "{Key:Name,Value:tb7u6fnsqi1moudbbif4}"
         },
         {
           "key": "VirtualizationType",
@@ -3732,16 +3732,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my-ng-influxdb-back-1",
-      "uid": "tbhmis4r0rri307nakbj",
-      "cspResourceName": "tbhmis4r0rri307nakbj",
-      "cspResourceId": "i-0f63a3a34b581895d",
+      "uid": "tbneuo0rtp598mde00kl",
+      "cspResourceName": "tbneuo0rtp598mde00kl",
+      "cspResourceId": "i-0a922ef6e86d46017",
       "name": "my-ng-influxdb-back-1",
       "nodeGroupId": "my-ng-influxdb-back",
       "location": {
@@ -3755,15 +3755,15 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-07-13 08:59:09",
+      "createdTime": "2026-07-21 04:14:38",
       "label": {
-        "Name": "tbhmis4r0rri307nakbj",
+        "Name": "tbneuo0rtp598mde00kl",
         "nlbBackend": "influxdb_back",
         "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-07-13 08:59:09",
-        "sys.cspResourceId": "i-0f63a3a34b581895d",
-        "sys.cspResourceName": "tbhmis4r0rri307nakbj",
+        "sys.createdTime": "2026-07-21 04:14:38",
+        "sys.cspResourceId": "i-0a922ef6e86d46017",
+        "sys.cspResourceName": "tbneuo0rtp598mde00kl",
         "sys.id": "my-ng-influxdb-back-1",
         "sys.infraId": "my-infra101",
         "sys.labelType": "node",
@@ -3772,7 +3772,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my-ng-influxdb-back",
         "sys.subnetId": "my-mig-subnet-01",
-        "sys.uid": "tbhmis4r0rri307nakbj",
+        "sys.uid": "tbneuo0rtp598mde00kl",
         "sys.vNetId": "my-mig-vnet-01"
       },
       "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -3780,11 +3780,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "3.38.214.237",
+      "publicIP": "3.38.153.7",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.208",
-      "privateDNS": "ip-10-0-1-208.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.233",
+      "privateDNS": "ip-10-0-1-233.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 30,
       "RootDeviceName": "/dev/sda1",
@@ -3837,22 +3837,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
       },
       "vNetId": "my-mig-vnet-01",
-      "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+      "cspVNetId": "vpc-0201fe7dacc5b3501",
       "subnetId": "my-mig-subnet-01",
-      "cspSubnetId": "subnet-0818566fb5fde1e2e",
-      "networkInterface": "eni-0ad3dfa7e0e692ce9",
+      "cspSubnetId": "subnet-0b401ce3e440d6a88",
+      "networkInterface": "eni-073ba4bba97dcc800",
       "securityGroupIds": [
         "my-mig-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my-mig-sshkey-01",
-      "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+      "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBComOFAY0Apt4eqhfI5+O9HT1ftHQxMdtIcVg7FH7i/JK8/Nc0gRjgUQ/MrG94+U8KG9BGoieD9AtnNFSSUz1eQ=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBX1UeZ8Cvxy2X5GEJ5wGahwzx0xQQqAJ3ISprs4x9V6c841b1MM6mJD2Q1yL69L1G/xEh4fHhZ7vgk8vfGz5vA=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:4QHW7PbNu2KZEZGtyW4YRSQgH4cEnv5+Oxh/7CbtZ2s",
-        "firstUsedAt": "2026-07-13T08:59:21Z"
+        "fingerprint": "SHA256:cCWmDt/ho5e8VTO6vLsMygOlkc2X6wSbSRb21STGLcA",
+        "firstUsedAt": "2026-07-21T04:14:49Z"
       },
       "commandStatus": [
         {
@@ -3860,11 +3860,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-07-13T08:59:20Z",
-          "completedTime": "2026-07-13T08:59:26Z",
-          "elapsedTime": 6,
+          "startedTime": "2026-07-21T04:14:49Z",
+          "completedTime": "2026-07-21T04:15:10Z",
+          "elapsedTime": 21,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-208 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-233 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -3879,7 +3879,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:48Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0c5846a38683c331b}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:18Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0eb13b9837198cd82}}"
         },
         {
           "key": "BootMode",
@@ -3891,7 +3891,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "364BAC1F-04F0-456A-ADE8-93943C5CE1F4"
+          "value": "49FA7C53-59BB-4609-A57B-F19D3761CE5C"
         },
         {
           "key": "CpuOptions",
@@ -3923,7 +3923,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-0f63a3a34b581895d"
+          "value": "i-0a922ef6e86d46017"
         },
         {
           "key": "InstanceType",
@@ -3931,11 +3931,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbt1bt5hiiqoqi38lfv2"
+          "value": "tbh9rdeut22if8j5cv6k"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-07-13T08:58:47Z"
+          "value": "2026-07-21T04:14:17Z"
         },
         {
           "key": "MetadataOptions",
@@ -3947,7 +3947,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.214.237},Attachment:{AttachTime:2026-07-13T08:58:47Z,AttachmentId:eni-attach-07112d384a4be90ca,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:f0:25:6d:0e:09,NetworkInterfaceId:eni-0ad3dfa7e0e692ce9,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.208,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.214.237},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.208}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.153.7},Attachment:{AttachTime:2026-07-21T04:14:17Z,AttachmentId:eni-attach-0446610409a40d148,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:9b:bd:e3:d6:59,NetworkInterfaceId:eni-073ba4bba97dcc800,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.233,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.38.153.7},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.233}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
         },
         {
           "key": "Placement",
@@ -3955,15 +3955,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-208.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-233.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.208"
+          "value": "10.0.1.233"
         },
         {
           "key": "PublicIpAddress",
-          "value": "3.38.214.237"
+          "value": "3.38.153.7"
         },
         {
           "key": "RootDeviceName",
@@ -3975,7 +3975,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}"
+          "value": "{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}"
         },
         {
           "key": "SourceDestCheck",
@@ -3987,11 +3987,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0818566fb5fde1e2e"
+          "value": "subnet-0b401ce3e440d6a88"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tbhmis4r0rri307nakbj}"
+          "value": "{Key:Name,Value:tbneuo0rtp598mde00kl}"
         },
         {
           "key": "VirtualizationType",
@@ -3999,16 +3999,16 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     },
     {
       "resourceType": "node",
       "id": "my-ng-influxdb-back-2",
-      "uid": "tb8l2ijc96kov0sucic4",
-      "cspResourceName": "tb8l2ijc96kov0sucic4",
-      "cspResourceId": "i-05fa2460fe53c2da4",
+      "uid": "tbfcjl18emj99142cipm",
+      "cspResourceName": "tbfcjl18emj99142cipm",
+      "cspResourceId": "i-06f3cc5c469f82f40",
       "name": "my-ng-influxdb-back-2",
       "nodeGroupId": "my-ng-influxdb-back",
       "location": {
@@ -4022,15 +4022,15 @@
       "monAgentStatus": "notInstalled",
       "networkAgentStatus": "notInstalled",
       "systemMessage": "",
-      "createdTime": "2026-07-13 08:59:10",
+      "createdTime": "2026-07-21 04:14:41",
       "label": {
-        "Name": "tb8l2ijc96kov0sucic4",
+        "Name": "tbfcjl18emj99142cipm",
         "nlbBackend": "influxdb_back",
         "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf",
         "sys.connectionName": "aws-ap-northeast-2",
-        "sys.createdTime": "2026-07-13 08:59:10",
-        "sys.cspResourceId": "i-05fa2460fe53c2da4",
-        "sys.cspResourceName": "tb8l2ijc96kov0sucic4",
+        "sys.createdTime": "2026-07-21 04:14:41",
+        "sys.cspResourceId": "i-06f3cc5c469f82f40",
+        "sys.cspResourceName": "tbfcjl18emj99142cipm",
         "sys.id": "my-ng-influxdb-back-2",
         "sys.infraId": "my-infra101",
         "sys.labelType": "node",
@@ -4039,7 +4039,7 @@
         "sys.namespace": "mig01",
         "sys.nodeGroupId": "my-ng-influxdb-back",
         "sys.subnetId": "my-mig-subnet-01",
-        "sys.uid": "tb8l2ijc96kov0sucic4",
+        "sys.uid": "tbfcjl18emj99142cipm",
         "sys.vNetId": "my-mig-vnet-01"
       },
       "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
@@ -4047,11 +4047,11 @@
         "region": "ap-northeast-2",
         "zone": "ap-northeast-2a"
       },
-      "publicIP": "54.180.128.3",
+      "publicIP": "3.39.251.226",
       "sshPort": 22,
       "publicDNS": "",
-      "privateIP": "10.0.1.177",
-      "privateDNS": "ip-10-0-1-177.ap-northeast-2.compute.internal",
+      "privateIP": "10.0.1.145",
+      "privateDNS": "ip-10-0-1-145.ap-northeast-2.compute.internal",
       "rootDiskType": "gp2",
       "rootDiskSize": 30,
       "RootDeviceName": "/dev/sda1",
@@ -4104,22 +4104,22 @@
         "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
       },
       "vNetId": "my-mig-vnet-01",
-      "cspVNetId": "vpc-0e032ee5b40ca2cdd",
+      "cspVNetId": "vpc-0201fe7dacc5b3501",
       "subnetId": "my-mig-subnet-01",
-      "cspSubnetId": "subnet-0818566fb5fde1e2e",
-      "networkInterface": "eni-0a69553e93cfd3c58",
+      "cspSubnetId": "subnet-0b401ce3e440d6a88",
+      "networkInterface": "eni-00e59e53d2438bedf",
       "securityGroupIds": [
         "my-mig-sg-01"
       ],
       "dataDiskIds": null,
       "sshKeyId": "my-mig-sshkey-01",
-      "cspSshKeyId": "tbt1bt5hiiqoqi38lfv2",
+      "cspSshKeyId": "tbh9rdeut22if8j5cv6k",
       "nodeUserName": "cb-user",
       "sshHostKeyInfo": {
-        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDKSW1urRTxcD8HxJHqH5H1LtqQ2Z9X8gvcXzyf3+/V1s0pueMR1LiK7uBEMAFmKwumnU+Ev/h8/hQW4UZTmt6k=",
+        "hostKey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEUlFwV+LidXdVFjp33gpGja29R5Zllc2VcCP7KZq1ZCI9XqDBp/pOh+VeM7fpiSGPpJZOtVZc+kdv497A6ja3I=",
         "keyType": "ecdsa-sha2-nistp256",
-        "fingerprint": "SHA256:Fojp9r4Eu2t4EMXoKlBqAWOoQHzC/HjsxphpWTC5Lls",
-        "firstUsedAt": "2026-07-13T08:59:23Z"
+        "fingerprint": "SHA256:jF0XS+JJjHfi4QK/kgIBKgBL79pWqPan4ncwAbaPubE",
+        "firstUsedAt": "2026-07-21T04:14:50Z"
       },
       "commandStatus": [
         {
@@ -4127,11 +4127,11 @@
           "commandRequested": "uname -a",
           "commandExecuted": "uname -a",
           "status": "Completed",
-          "startedTime": "2026-07-13T08:59:20Z",
-          "completedTime": "2026-07-13T08:59:24Z",
-          "elapsedTime": 4,
+          "startedTime": "2026-07-21T04:14:49Z",
+          "completedTime": "2026-07-21T04:14:52Z",
+          "elapsedTime": 3,
           "resultSummary": "Command executed successfully",
-          "stdout": "Linux ip-10-0-1-177 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
+          "stdout": "Linux ip-10-0-1-145 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n\n",
           "stderr": "\n"
         }
       ],
@@ -4146,7 +4146,7 @@
         },
         {
           "key": "BlockDeviceMappings",
-          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-13T08:58:50Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-053ded65affcde4c9}}"
+          "value": "{DeviceName:/dev/sda1,Ebs:{AttachTime:2026-07-21T04:14:21Z,DeleteOnTermination:true,Status:attached,VolumeId:vol-0a446b7810b00d3d5}}"
         },
         {
           "key": "BootMode",
@@ -4158,7 +4158,7 @@
         },
         {
           "key": "ClientToken",
-          "value": "A4C60AB0-43CD-4016-BD40-26C7E17B944D"
+          "value": "C3F8023D-4CF6-4E4F-B17A-08FB56D4EDE6"
         },
         {
           "key": "CpuOptions",
@@ -4190,7 +4190,7 @@
         },
         {
           "key": "InstanceId",
-          "value": "i-05fa2460fe53c2da4"
+          "value": "i-06f3cc5c469f82f40"
         },
         {
           "key": "InstanceType",
@@ -4198,11 +4198,11 @@
         },
         {
           "key": "KeyName",
-          "value": "tbt1bt5hiiqoqi38lfv2"
+          "value": "tbh9rdeut22if8j5cv6k"
         },
         {
           "key": "LaunchTime",
-          "value": "2026-07-13T08:58:49Z"
+          "value": "2026-07-21T04:14:20Z"
         },
         {
           "key": "MetadataOptions",
@@ -4214,7 +4214,7 @@
         },
         {
           "key": "NetworkInterfaces",
-          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.128.3},Attachment:{AttachTime:2026-07-13T08:58:49Z,AttachmentId:eni-attach-04f6287c37f556e46,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:17:fd:56:c7:27,NetworkInterfaceId:eni-0a69553e93cfd3c58,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.177,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:54.180.128.3},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.177}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0818566fb5fde1e2e,VpcId:vpc-0e032ee5b40ca2cdd}"
+          "value": "{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.39.251.226},Attachment:{AttachTime:2026-07-21T04:14:20Z,AttachmentId:eni-attach-06a41c8ec19fbdce5,DeleteOnTermination:true,DeviceIndex:0,NetworkCardIndex:0,Status:attached},Description:,Groups:[{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}],InterfaceType:interface,Ipv6Addresses:null,MacAddress:02:43:e9:6b:c4:b1,NetworkInterfaceId:eni-00e59e53d2438bedf,OwnerId:635484366616,PrivateDnsName:null,PrivateIpAddress:10.0.1.145,PrivateIpAddresses:[{Association:{CarrierIp:null,IpOwnerId:amazon,PublicDnsName:,PublicIp:3.39.251.226},Primary:true,PrivateDnsName:null,PrivateIpAddress:10.0.1.145}],SourceDestCheck:true,Status:in-use,SubnetId:subnet-0b401ce3e440d6a88,VpcId:vpc-0201fe7dacc5b3501}"
         },
         {
           "key": "Placement",
@@ -4222,15 +4222,15 @@
         },
         {
           "key": "PrivateDnsName",
-          "value": "ip-10-0-1-177.ap-northeast-2.compute.internal"
+          "value": "ip-10-0-1-145.ap-northeast-2.compute.internal"
         },
         {
           "key": "PrivateIpAddress",
-          "value": "10.0.1.177"
+          "value": "10.0.1.145"
         },
         {
           "key": "PublicIpAddress",
-          "value": "54.180.128.3"
+          "value": "3.39.251.226"
         },
         {
           "key": "RootDeviceName",
@@ -4242,7 +4242,7 @@
         },
         {
           "key": "SecurityGroups",
-          "value": "{GroupId:sg-04f9aacbfff1339fd,GroupName:tb24qf0441l7ole2a9lq}"
+          "value": "{GroupId:sg-0b193070b1e7f5d29,GroupName:tb9je04sf7uqsdimkv49}"
         },
         {
           "key": "SourceDestCheck",
@@ -4254,11 +4254,11 @@
         },
         {
           "key": "SubnetId",
-          "value": "subnet-0818566fb5fde1e2e"
+          "value": "subnet-0b401ce3e440d6a88"
         },
         {
           "key": "Tags",
-          "value": "{Key:Name,Value:tb8l2ijc96kov0sucic4}"
+          "value": "{Key:Name,Value:tbfcjl18emj99142cipm}"
         },
         {
           "key": "VirtualizationType",
@@ -4266,7 +4266,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     }
@@ -4283,12 +4283,12 @@
       {
         "infraId": "my-infra101",
         "nodeId": "my-ng-influxdb-back-2",
-        "nodeIp": "54.180.128.3",
+        "nodeIp": "3.39.251.226",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-177 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-145 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4298,12 +4298,12 @@
       {
         "infraId": "my-infra101",
         "nodeId": "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
-        "nodeIp": "13.209.82.179",
+        "nodeIp": "43.203.180.137",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-7 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-211 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4313,12 +4313,12 @@
       {
         "infraId": "my-infra101",
         "nodeId": "my-ng-influxdb-back-1",
-        "nodeIp": "3.38.214.237",
+        "nodeIp": "3.38.153.7",
         "command": {
           "0": "uname -a"
         },
         "stdout": {
-          "0": "Linux ip-10-0-1-208 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
+          "0": "Linux ip-10-0-1-233 6.8.0-1057-aws #60~22.04.1-Ubuntu SMP Wed May 27 08:16:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux\n"
         },
         "stderr": {
           "0": ""
@@ -4370,8 +4370,8 @@
     {
       "resourceType": "",
       "id": "my-ng-influxdb-back",
-      "cspResourceName": "tbv2qrvi0523u9nt3lsj",
-      "cspResourceId": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8",
+      "cspResourceName": "tbm6ig3fnsnpgomdcvi5",
+      "cspResourceId": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c",
       "name": "my-ng-influxdb-back",
       "connectionName": "aws-ap-northeast-2",
       "connectionConfig": {
@@ -4404,19 +4404,19 @@
       "listener": {
         "protocol": "TCP",
         "port": "9999",
-        "dnsName": "tbv2qrvi0523u9nt3lsj-c259831020222ea8.elb.ap-northeast-2.amazonaws.com",
+        "dnsName": "tbm6ig3fnsnpgomdcvi5-b41f7d221abf517c.elb.ap-northeast-2.amazonaws.com",
         "keyValueList": [
           {
             "key": "DefaultActions",
-            "value": "{AuthenticateCognitoConfig:null,AuthenticateOidcConfig:null,FixedResponseConfig:null,ForwardConfig:{TargetGroupStickinessConfig:{DurationSeconds:null,Enabled:false},TargetGroups:[{TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30,Weight:null}]},Order:null,RedirectConfig:null,TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30,Type:forward}"
+            "value": "{AuthenticateCognitoConfig:null,AuthenticateOidcConfig:null,FixedResponseConfig:null,ForwardConfig:{TargetGroupStickinessConfig:{DurationSeconds:null,Enabled:false},TargetGroups:[{TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483,Weight:null}]},Order:null,RedirectConfig:null,TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483,Type:forward}"
           },
           {
             "key": "ListenerArn",
-            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:listener/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8/27e309495956767e"
+            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:listener/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c/47c9428e6a5a3e63"
           },
           {
             "key": "LoadBalancerArn",
-            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
           },
           {
             "key": "Port",
@@ -4433,8 +4433,8 @@
         "port": "8086",
         "nodeGroupId": "my-ng-influxdb-back",
         "nodes": [
-          "my-ng-influxdb-back-1",
-          "my-ng-influxdb-back-2"
+          "my-ng-influxdb-back-2",
+          "my-ng-influxdb-back-1"
         ],
         "keyValueList": [
           {
@@ -4463,7 +4463,7 @@
           },
           {
             "key": "LoadBalancerArns",
-            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
           },
           {
             "key": "Port",
@@ -4475,11 +4475,11 @@
           },
           {
             "key": "TargetGroupArn",
-            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30"
+            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483"
           },
           {
             "key": "TargetGroupName",
-            "value": "tbv2qrvi0523u9nt3lsj"
+            "value": "tbm6ig3fnsnpgomdcvi5"
           },
           {
             "key": "TargetType",
@@ -4491,7 +4491,7 @@
           },
           {
             "key": "VpcId",
-            "value": "vpc-0e032ee5b40ca2cdd"
+            "value": "vpc-0201fe7dacc5b3501"
           }
         ]
       },
@@ -4528,7 +4528,7 @@
           },
           {
             "key": "LoadBalancerArns",
-            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
           },
           {
             "key": "Port",
@@ -4540,11 +4540,11 @@
           },
           {
             "key": "TargetGroupArn",
-            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30"
+            "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483"
           },
           {
             "key": "TargetGroupName",
-            "value": "tbv2qrvi0523u9nt3lsj"
+            "value": "tbm6ig3fnsnpgomdcvi5"
           },
           {
             "key": "TargetType",
@@ -4556,17 +4556,17 @@
           },
           {
             "key": "VpcId",
-            "value": "vpc-0e032ee5b40ca2cdd"
+            "value": "vpc-0201fe7dacc5b3501"
           }
         ]
       },
-      "createdTime": "2026-07-13T08:59:51.475Z",
+      "createdTime": "2026-07-21T04:15:36.764Z",
       "description": "Migrated from HAProxy backend: influxdb_back",
       "status": "",
       "keyValueList": [
         {
           "key": "AvailabilityZones",
-          "value": "{LoadBalancerAddresses:null,OutpostId:null,SubnetId:subnet-0818566fb5fde1e2e,ZoneName:ap-northeast-2a}"
+          "value": "{LoadBalancerAddresses:null,OutpostId:null,SubnetId:subnet-0b401ce3e440d6a88,ZoneName:ap-northeast-2a}"
         },
         {
           "key": "CanonicalHostedZoneId",
@@ -4574,11 +4574,11 @@
         },
         {
           "key": "CreatedTime",
-          "value": "2026-07-13T08:59:51.475Z"
+          "value": "2026-07-21T04:15:36.764Z"
         },
         {
           "key": "DNSName",
-          "value": "tbv2qrvi0523u9nt3lsj-c259831020222ea8.elb.ap-northeast-2.amazonaws.com"
+          "value": "tbm6ig3fnsnpgomdcvi5-b41f7d221abf517c.elb.ap-northeast-2.amazonaws.com"
         },
         {
           "key": "IpAddressType",
@@ -4586,11 +4586,11 @@
         },
         {
           "key": "LoadBalancerArn",
-          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
         },
         {
           "key": "LoadBalancerName",
-          "value": "tbv2qrvi0523u9nt3lsj"
+          "value": "tbm6ig3fnsnpgomdcvi5"
         },
         {
           "key": "Scheme",
@@ -4606,7 +4606,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ],
       "isAutoGenerated": false,
@@ -4642,8 +4642,8 @@
   {
     "resourceType": "",
     "id": "my-ng-influxdb-back",
-    "cspResourceName": "tbv2qrvi0523u9nt3lsj",
-    "cspResourceId": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8",
+    "cspResourceName": "tbm6ig3fnsnpgomdcvi5",
+    "cspResourceId": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c",
     "name": "my-ng-influxdb-back",
     "connectionName": "aws-ap-northeast-2",
     "connectionConfig": {
@@ -4676,19 +4676,19 @@
     "listener": {
       "protocol": "TCP",
       "port": "9999",
-      "dnsName": "tbv2qrvi0523u9nt3lsj-c259831020222ea8.elb.ap-northeast-2.amazonaws.com",
+      "dnsName": "tbm6ig3fnsnpgomdcvi5-b41f7d221abf517c.elb.ap-northeast-2.amazonaws.com",
       "keyValueList": [
         {
           "key": "DefaultActions",
-          "value": "{AuthenticateCognitoConfig:null,AuthenticateOidcConfig:null,FixedResponseConfig:null,ForwardConfig:{TargetGroupStickinessConfig:{DurationSeconds:null,Enabled:false},TargetGroups:[{TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30,Weight:null}]},Order:null,RedirectConfig:null,TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30,Type:forward}"
+          "value": "{AuthenticateCognitoConfig:null,AuthenticateOidcConfig:null,FixedResponseConfig:null,ForwardConfig:{TargetGroupStickinessConfig:{DurationSeconds:null,Enabled:false},TargetGroups:[{TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483,Weight:null}]},Order:null,RedirectConfig:null,TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483,Type:forward}"
         },
         {
           "key": "ListenerArn",
-          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:listener/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8/27e309495956767e"
+          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:listener/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c/47c9428e6a5a3e63"
         },
         {
           "key": "LoadBalancerArn",
-          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
         },
         {
           "key": "Port",
@@ -4705,8 +4705,8 @@
       "port": "8086",
       "nodeGroupId": "my-ng-influxdb-back",
       "nodes": [
-        "my-ng-influxdb-back-1",
-        "my-ng-influxdb-back-2"
+        "my-ng-influxdb-back-2",
+        "my-ng-influxdb-back-1"
       ],
       "keyValueList": [
         {
@@ -4735,7 +4735,7 @@
         },
         {
           "key": "LoadBalancerArns",
-          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
         },
         {
           "key": "Port",
@@ -4747,11 +4747,11 @@
         },
         {
           "key": "TargetGroupArn",
-          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30"
+          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483"
         },
         {
           "key": "TargetGroupName",
-          "value": "tbv2qrvi0523u9nt3lsj"
+          "value": "tbm6ig3fnsnpgomdcvi5"
         },
         {
           "key": "TargetType",
@@ -4763,7 +4763,7 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     },
@@ -4800,7 +4800,7 @@
         },
         {
           "key": "LoadBalancerArns",
-          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
         },
         {
           "key": "Port",
@@ -4812,11 +4812,11 @@
         },
         {
           "key": "TargetGroupArn",
-          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30"
+          "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483"
         },
         {
           "key": "TargetGroupName",
-          "value": "tbv2qrvi0523u9nt3lsj"
+          "value": "tbm6ig3fnsnpgomdcvi5"
         },
         {
           "key": "TargetType",
@@ -4828,17 +4828,17 @@
         },
         {
           "key": "VpcId",
-          "value": "vpc-0e032ee5b40ca2cdd"
+          "value": "vpc-0201fe7dacc5b3501"
         }
       ]
     },
-    "createdTime": "2026-07-13T08:59:51.475Z",
+    "createdTime": "2026-07-21T04:15:36.764Z",
     "description": "Migrated from HAProxy backend: influxdb_back",
     "status": "",
     "keyValueList": [
       {
         "key": "AvailabilityZones",
-        "value": "{LoadBalancerAddresses:null,OutpostId:null,SubnetId:subnet-0818566fb5fde1e2e,ZoneName:ap-northeast-2a}"
+        "value": "{LoadBalancerAddresses:null,OutpostId:null,SubnetId:subnet-0b401ce3e440d6a88,ZoneName:ap-northeast-2a}"
       },
       {
         "key": "CanonicalHostedZoneId",
@@ -4846,11 +4846,11 @@
       },
       {
         "key": "CreatedTime",
-        "value": "2026-07-13T08:59:51.475Z"
+        "value": "2026-07-21T04:15:36.764Z"
       },
       {
         "key": "DNSName",
-        "value": "tbv2qrvi0523u9nt3lsj-c259831020222ea8.elb.ap-northeast-2.amazonaws.com"
+        "value": "tbm6ig3fnsnpgomdcvi5-b41f7d221abf517c.elb.ap-northeast-2.amazonaws.com"
       },
       {
         "key": "IpAddressType",
@@ -4858,11 +4858,11 @@
       },
       {
         "key": "LoadBalancerArn",
-        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
       },
       {
         "key": "LoadBalancerName",
-        "value": "tbv2qrvi0523u9nt3lsj"
+        "value": "tbm6ig3fnsnpgomdcvi5"
       },
       {
         "key": "Scheme",
@@ -4878,7 +4878,7 @@
       },
       {
         "key": "VpcId",
-        "value": "vpc-0e032ee5b40ca2cdd"
+        "value": "vpc-0201fe7dacc5b3501"
       }
     ],
     "isAutoGenerated": false,
@@ -4912,8 +4912,8 @@
 {
   "resourceType": "",
   "id": "my-ng-influxdb-back",
-  "cspResourceName": "tbv2qrvi0523u9nt3lsj",
-  "cspResourceId": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8",
+  "cspResourceName": "tbm6ig3fnsnpgomdcvi5",
+  "cspResourceId": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c",
   "name": "my-ng-influxdb-back",
   "connectionName": "aws-ap-northeast-2",
   "connectionConfig": {
@@ -4946,19 +4946,19 @@
   "listener": {
     "protocol": "TCP",
     "port": "9999",
-    "dnsName": "tbv2qrvi0523u9nt3lsj-c259831020222ea8.elb.ap-northeast-2.amazonaws.com",
+    "dnsName": "tbm6ig3fnsnpgomdcvi5-b41f7d221abf517c.elb.ap-northeast-2.amazonaws.com",
     "keyValueList": [
       {
         "key": "DefaultActions",
-        "value": "{AuthenticateCognitoConfig:null,AuthenticateOidcConfig:null,FixedResponseConfig:null,ForwardConfig:{TargetGroupStickinessConfig:{DurationSeconds:null,Enabled:false},TargetGroups:[{TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30,Weight:null}]},Order:null,RedirectConfig:null,TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30,Type:forward}"
+        "value": "{AuthenticateCognitoConfig:null,AuthenticateOidcConfig:null,FixedResponseConfig:null,ForwardConfig:{TargetGroupStickinessConfig:{DurationSeconds:null,Enabled:false},TargetGroups:[{TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483,Weight:null}]},Order:null,RedirectConfig:null,TargetGroupArn:arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483,Type:forward}"
       },
       {
         "key": "ListenerArn",
-        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:listener/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8/27e309495956767e"
+        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:listener/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c/47c9428e6a5a3e63"
       },
       {
         "key": "LoadBalancerArn",
-        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
       },
       {
         "key": "Port",
@@ -4975,8 +4975,8 @@
     "port": "8086",
     "nodeGroupId": "my-ng-influxdb-back",
     "nodes": [
-      "my-ng-influxdb-back-1",
-      "my-ng-influxdb-back-2"
+      "my-ng-influxdb-back-2",
+      "my-ng-influxdb-back-1"
     ],
     "keyValueList": [
       {
@@ -5005,7 +5005,7 @@
       },
       {
         "key": "LoadBalancerArns",
-        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
       },
       {
         "key": "Port",
@@ -5017,11 +5017,11 @@
       },
       {
         "key": "TargetGroupArn",
-        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30"
+        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483"
       },
       {
         "key": "TargetGroupName",
-        "value": "tbv2qrvi0523u9nt3lsj"
+        "value": "tbm6ig3fnsnpgomdcvi5"
       },
       {
         "key": "TargetType",
@@ -5033,7 +5033,7 @@
       },
       {
         "key": "VpcId",
-        "value": "vpc-0e032ee5b40ca2cdd"
+        "value": "vpc-0201fe7dacc5b3501"
       }
     ]
   },
@@ -5070,7 +5070,7 @@
       },
       {
         "key": "LoadBalancerArns",
-        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
       },
       {
         "key": "Port",
@@ -5082,11 +5082,11 @@
       },
       {
         "key": "TargetGroupArn",
-        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbv2qrvi0523u9nt3lsj/b14faa5b2e35fa30"
+        "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:targetgroup/tbm6ig3fnsnpgomdcvi5/20e273ac5a5e5483"
       },
       {
         "key": "TargetGroupName",
-        "value": "tbv2qrvi0523u9nt3lsj"
+        "value": "tbm6ig3fnsnpgomdcvi5"
       },
       {
         "key": "TargetType",
@@ -5098,17 +5098,17 @@
       },
       {
         "key": "VpcId",
-        "value": "vpc-0e032ee5b40ca2cdd"
+        "value": "vpc-0201fe7dacc5b3501"
       }
     ]
   },
-  "createdTime": "2026-07-13T08:59:51.475Z",
+  "createdTime": "2026-07-21T04:15:36.764Z",
   "description": "Migrated from HAProxy backend: influxdb_back",
   "status": "",
   "keyValueList": [
     {
       "key": "AvailabilityZones",
-      "value": "{LoadBalancerAddresses:null,OutpostId:null,SubnetId:subnet-0818566fb5fde1e2e,ZoneName:ap-northeast-2a}"
+      "value": "{LoadBalancerAddresses:null,OutpostId:null,SubnetId:subnet-0b401ce3e440d6a88,ZoneName:ap-northeast-2a}"
     },
     {
       "key": "CanonicalHostedZoneId",
@@ -5116,11 +5116,11 @@
     },
     {
       "key": "CreatedTime",
-      "value": "2026-07-13T08:59:51.475Z"
+      "value": "2026-07-21T04:15:36.764Z"
     },
     {
       "key": "DNSName",
-      "value": "tbv2qrvi0523u9nt3lsj-c259831020222ea8.elb.ap-northeast-2.amazonaws.com"
+      "value": "tbm6ig3fnsnpgomdcvi5-b41f7d221abf517c.elb.ap-northeast-2.amazonaws.com"
     },
     {
       "key": "IpAddressType",
@@ -5128,11 +5128,11 @@
     },
     {
       "key": "LoadBalancerArn",
-      "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbv2qrvi0523u9nt3lsj/c259831020222ea8"
+      "value": "arn:aws:elasticloadbalancing:ap-northeast-2:635484366616:loadbalancer/net/tbm6ig3fnsnpgomdcvi5/b41f7d221abf517c"
     },
     {
       "key": "LoadBalancerName",
-      "value": "tbv2qrvi0523u9nt3lsj"
+      "value": "tbm6ig3fnsnpgomdcvi5"
     },
     {
       "key": "Scheme",
@@ -5148,7 +5148,7 @@
     },
     {
       "key": "VpcId",
-      "value": "vpc-0e032ee5b40ca2cdd"
+      "value": "vpc-0201fe7dacc5b3501"
     }
   ],
   "isAutoGenerated": false,
@@ -5191,7 +5191,7 @@
 
 # Target Cloud Infrastructure Summary
 
-**Generated At:** 2026-07-13 09:03:53
+**Generated At:** 2026-07-21 04:19:39
 
 **Namespace:** mig01
 
@@ -5232,9 +5232,9 @@
 
 | VM Name | CSP VM ID | Status | Spec (vCPU, Memory GiB) | Image | Misc |
 |---------|-----------|--------|-------------------------|-------|------|
-| my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | i-07f638bb18bbb13e6 | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 13.209.82.179<br>**Private IP:** 10.0.1.7<br>**SGs:** my-mig-sg-02<br>**SSH:** my-mig-sshkey-01 |
-| my-ng-influxdb-back-1 | i-0f63a3a34b581895d | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 3.38.214.237<br>**Private IP:** 10.0.1.208<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
-| my-ng-influxdb-back-2 | i-05fa2460fe53c2da4 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 54.180.128.3<br>**Private IP:** 10.0.1.177<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
+| my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | i-0054a217572ac064b | Running | 2 vCPU, 2.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 43.203.180.137<br>**Private IP:** 10.0.1.211<br>**SGs:** my-mig-sg-02<br>**SSH:** my-mig-sshkey-01 |
+| my-ng-influxdb-back-1 | i-0a922ef6e86d46017 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 3.38.153.7<br>**Private IP:** 10.0.1.233<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
+| my-ng-influxdb-back-2 | i-06f3cc5c469f82f40 | Running | 4 vCPU, 16.0 GiB | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 (ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610) | **VNet:** my-mig-vnet-01<br>**Subnet:** my-mig-subnet-01<br>**Public IP:** 3.39.251.226<br>**Private IP:** 10.0.1.145<br>**SGs:** my-mig-sg-01<br>**SSH:** my-mig-sshkey-01 |
 
 
 ## Network Resources
@@ -5246,7 +5246,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my-mig-vnet-01 |
-| **CSP VNet ID** | vpc-0e032ee5b40ca2cdd |
+| **CSP VNet ID** | vpc-0201fe7dacc5b3501 |
 | **CIDR Block** | 10.0.0.0/21 |
 | **Connection** | aws-ap-northeast-2 |
 | **Subnet Count** | 1 |
@@ -5255,7 +5255,7 @@
 
 | Name | CSP Subnet ID | CIDR Block | Zone |
 |------|---------------|------------|------|
-| my-mig-subnet-01 | subnet-0818566fb5fde1e2e | 10.0.1.0/24 | ap-northeast-2a |
+| my-mig-subnet-01 | subnet-0b401ce3e440d6a88 | 10.0.1.0/24 | ap-northeast-2a |
 
 
 ## Security Resources
@@ -5264,7 +5264,7 @@
 
 | Name | CSP SSH Key ID | Username | Fingerprint |
 |------|----------------|----------|-------------|
-| my-mig-sshkey-01 | tbt1bt5hiiqoqi38lfv2 |  | 2a:61:89:ab:5d:44:cb:cf:66:1d:da:b7:30:d6:8f:2d:d7:8a:57:81 |
+| my-mig-sshkey-01 | tbh9rdeut22if8j5cv6k |  | 27:de:16:94:80:a4:a8:73:30:d0:f3:da:83:37:7d:43:54:bd:7c:1e |
 
 ### Security Groups
 
@@ -5273,7 +5273,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my-mig-sg-01 |
-| **CSP Security Group ID** | sg-04f9aacbfff1339fd |
+| **CSP Security Group ID** | sg-0b193070b1e7f5d29 |
 | **VNet** | my-mig-vnet-01 |
 | **Rule Count** | 5 rules |
 
@@ -5292,7 +5292,7 @@
 | Property | Value |
 |----------|-------|
 | **Name** | my-mig-sg-02 |
-| **CSP Security Group ID** | sg-06bff0ecdf53345f6 |
+| **CSP Security Group ID** | sg-0b08a1f2cc70c3840 |
 | **VNet** | my-mig-vnet-01 |
 | **Rule Count** | 4 rules |
 
@@ -5349,7 +5349,7 @@
 
 This report provides a comprehensive summary of the infrastructure migration from on-premise to cloud environment, including detailed information about migrated resources, costs, and configurations.
 
-*Report generated: 2026-07-13 09:03:56*
+*Report generated: 2026-07-21 04:19:44*
 
 ---
 
@@ -5378,7 +5378,7 @@ Summary of key infrastructure resources created or configured in the target clou
 | # | Resource Type | Count | Status | Details |
 |---|---------------|-------|--------|----------|
 | 1 | **Virtual Machine** | 3 | ✅ Created | 3 running, 3 total |
-| 2 | **VM Spec** | 2 | ✅ Selected | t3a.xlarge, t3a.small |
+| 2 | **VM Spec** | 2 | ✅ Selected | t3a.small, t3a.xlarge |
 | 3 | **VM OS Image** | 1 | ✅ Selected | Ubuntu 22.04 |
 | 4 | **VNet (VPC)** | 1 | ✅ Created | my-mig-vnet-01, CIDR: 10.0.0.0/21 |
 | 5 | **Subnet** | 1 | ✅ Created | 10.0.1.0/24 (in my-mig-vnet-01) |
@@ -5393,9 +5393,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | Source Server |
 |-----|-------------|---------------|
-| 1 | **VM Name:** my-ng-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-07f638bb18bbb13e6<br>**Label(sourceMachineId):** ng-ec268ed7-821e-9d73-e79f | **Hostname:** N/A<br>**Machine ID:** ng-ec268ed7-821e-9d73-e79f |
-| 2 | **VM Name:** my-ng-influxdb-back-1<br>**VM ID:** i-0f63a3a34b581895d<br>**Label(sourceMachineId):** ng | **Hostname:** N/A<br>**Machine ID:** ng |
-| 3 | **VM Name:** my-ng-influxdb-back-2<br>**VM ID:** i-05fa2460fe53c2da4<br>**Label(sourceMachineId):** ng | **Hostname:** N/A<br>**Machine ID:** ng |
+| 1 | **VM Name:** my-ng-ec268ed7-821e-9d73-e79f-961262161624-1<br>**VM ID:** i-0054a217572ac064b<br>**Label(sourceMachineId):** ec268ed7-821e-9d73-e79f-961262161624 | **Hostname:** ip-10-0-1-30<br>**Machine ID:** ec268ed7-821e-9d73-e79f-961262161624 |
+| 2 | **VM Name:** my-ng-influxdb-back-1<br>**VM ID:** i-0a922ef6e86d46017<br>**Label(sourceMachineId):** ec2d32b5-98fb-5a96-7913-d3db1ec18932 | **Hostname:** ip-10-0-1-221<br>**Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932 |
+| 3 | **VM Name:** my-ng-influxdb-back-2<br>**VM ID:** i-06f3cc5c469f82f40<br>**Label(sourceMachineId):** ec288dd0-c6fa-8a49-2f60-bc898311febf | **Hostname:** ip-10-0-1-138<br>**Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf |
 
 ---
 
@@ -5405,9 +5405,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM Spec | Source Server | Source Server Spec |
 |-----|-------------|---------|---------------|--------------------|
-| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** t3a.small<br>**vCPUs:** 2<br>**Memory:** 2.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** ng-ec268ed7-821e-9d73-e79f | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 2 | my-ng-influxdb-back-1 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** ng | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
-| 3 | my-ng-influxdb-back-2 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** N/A<br>**Machine ID:** ng | **CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A |
+| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Spec ID:** t3a.small<br>**vCPUs:** 2<br>**Memory:** 2.0 GB<br>**Root Disk:** 50 GB | **Hostname:** ip-10-0-1-30<br>**Machine ID:** ec268ed7-821e-9d73-e79f-961262161624 | **CPUs:** 1<br>**Threads:** 2<br>**Memory:** 2 GB<br>**Root Disk:** 8 GB |
+| 2 | my-ng-influxdb-back-1 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** ip-10-0-1-221<br>**Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932 | **CPUs:** 1<br>**Threads:** 4<br>**Memory:** 16 GB<br>**Root Disk:** 30 GB |
+| 3 | my-ng-influxdb-back-2 | **Spec ID:** t3a.xlarge<br>**vCPUs:** 4<br>**Memory:** 16.0 GB<br>**Root Disk:** 50 GB | **Hostname:** ip-10-0-1-138<br>**Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf | **CPUs:** 1<br>**Threads:** 4<br>**Memory:** 8 GB<br>**Root Disk:** 30 GB |
 
 ---
 
@@ -5417,9 +5417,9 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | Migrated VM | VM OS Image Info | Source Server | Source OS |
 |-----|-------------|------------------|---------------|-----------|
-| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** N/A<br>**Machine ID:** ng-ec268ed7-821e-9d73-e79f | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 2 | my-ng-influxdb-back-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** N/A<br>**Machine ID:** ng | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
-| 3 | my-ng-influxdb-back-2 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** N/A<br>**Machine ID:** ng | **PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A |
+| 1 | my-ng-ec268ed7-821e-9d73-e79f-961262161624-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** ip-10-0-1-30<br>**Machine ID:** ec268ed7-821e-9d73-e79f-961262161624 | **PrettyName:** Ubuntu 22.04.3 LTS<br>**Name:** Ubuntu<br>**Version:** 22.04.3 LTS (Jammy Jellyfish) |
+| 2 | my-ng-influxdb-back-1 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** ip-10-0-1-221<br>**Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932 | **PrettyName:** Ubuntu 22.04.3 LTS<br>**Name:** Ubuntu<br>**Version:** 22.04.3 LTS (Jammy Jellyfish) |
+| 3 | my-ng-influxdb-back-2 | **Image ID:** ami-0afe1fd15675c3f15<br>**OS Type:** Ubuntu 22.04<br>**OS Distribution:** ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610 | **Hostname:** ip-10-0-1-138<br>**Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf | **PrettyName:** Ubuntu 22.04.3 LTS<br>**Name:** Ubuntu<br>**Version:** 22.04.3 LTS (Jammy Jellyfish) |
 
 ---
 
@@ -5429,14 +5429,14 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my-mig-sg-01
 
-**CSP ID:** sg-04f9aacbfff1339fd | **VNet:** my-mig-vnet-01 | **Rules:** 5
+**CSP ID:** sg-0b193070b1e7f5d29 | **VNet:** my-mig-vnet-01 | **Rules:** 5
 
 **Assigned VMs:**
 
 - **VM:** my-ng-influxdb-back-1
-  - **Source Server:** **Hostname:** N/A, **Machine ID:** ng
+  - **Source Server:** **Hostname:** ip-10-0-1-221, **Machine ID:** ec2d32b5-98fb-5a96-7913-d3db1ec18932
 - **VM:** my-ng-influxdb-back-2
-  - **Source Server:** **Hostname:** N/A, **Machine ID:** ng
+  - **Source Server:** **Hostname:** ip-10-0-1-138, **Machine ID:** ec288dd0-c6fa-8a49-2f60-bc898311febf
 
 **Security Rules:**
 
@@ -5450,12 +5450,12 @@ Summary of key infrastructure resources created or configured in the target clou
 
 ### Security Group: my-mig-sg-02
 
-**CSP ID:** sg-06bff0ecdf53345f6 | **VNet:** my-mig-vnet-01 | **Rules:** 4
+**CSP ID:** sg-0b08a1f2cc70c3840 | **VNet:** my-mig-vnet-01 | **Rules:** 4
 
 **Assigned VMs:**
 
 - **VM:** my-ng-ec268ed7-821e-9d73-e79f-961262161624-1
-  - **Source Server:** **Hostname:** N/A, **Machine ID:** ng-ec268ed7-821e-9d73-e79f
+  - **Source Server:** **Hostname:** ip-10-0-1-30, **Machine ID:** ec268ed7-821e-9d73-e79f-961262161624
 
 **Security Rules:**
 
@@ -5476,13 +5476,13 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | VPC(VNet) | CIDR Block |
 |-----|-----------|------------|
-| 1 | **Name:** my-mig-vnet-01<br>**ID:** vpc-0e032ee5b40ca2cdd | 10.0.0.0/21 |
+| 1 | **Name:** my-mig-vnet-01<br>**ID:** vpc-0201fe7dacc5b3501 | 10.0.0.0/21 |
 
 ### Subnets
 
 | No. | Subnet | CIDR Block | Associated VPC(VNet) |
 |-----|--------|------------|----------------------|
-| 1 | **Name:** my-mig-subnet-01<br>**ID:** subnet-0818566fb5fde1e2e | 10.0.1.0/24 | my-mig-vnet-01 |
+| 1 | **Name:** my-mig-subnet-01<br>**ID:** subnet-0b401ce3e440d6a88 | 10.0.1.0/24 | my-mig-vnet-01 |
 
 ### Source Network Information
 
@@ -5497,6 +5497,14 @@ Summary of key infrastructure resources created or configured in the target clou
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.30/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 #### 2. ip-10-0-1-221
 
@@ -5505,6 +5513,14 @@ Summary of key infrastructure resources created or configured in the target clou
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.221/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 #### 3. ip-10-0-1-138
 
@@ -5513,6 +5529,14 @@ Summary of key infrastructure resources created or configured in the target clou
 | Interface | IP Address | State |
 |-----------|------------|-------|
 | lo | 127.0.0.1/8 | up |
+| ens5 | 10.0.1.138/24 | up |
+
+**Main Routes:**
+
+| Destination | Gateway | Interface |
+|-------------|---------|-----------|
+| 0.0.0.0/0 | 10.0.1.1 | ens5 |
+| 10.0.1.0/24 | 10.0.1.1 | ens5 |
 
 ---
 
@@ -5524,7 +5548,7 @@ Summary of key infrastructure resources created or configured in the target clou
 
 | No. | SSH Key Name | CSP Key ID | Fingerprint | Usage |
 |-----|--------------|------------|-------------|-------|
-| 1 | my-mig-sshkey-01 | tbt1bt5hiiqoqi38lfv2 | 2a:61:89:ab:5d:44:cb:cf:66:1d:da:b7:30:d6:8f:2d:d7:8a:57:81 | Used by all 3 VMs |
+| 1 | my-mig-sshkey-01 | tbh9rdeut22if8j5cv6k | 27:de:16:94:80:a4:a8:73:30:d0:f3:da:83:37:7d:43:54:bd:7c:1e | Used by all 3 VMs |
 
 ---
 
@@ -5544,6 +5568,8 @@ Summary of key infrastructure resources created or configured in the target clou
 | Component | Spec | Monthly Cost | Percentage |
 |-----------|------|--------------|------------|
 | ip-10-0-1-30 (migrated) | t3a.small | $16.85 | 5.9% |
+| ip-10-0-1-221 (migrated) | t3a.xlarge | $134.78 | 47.1% |
+| ip-10-0-1-138 (migrated) | t3a.xlarge | $134.78 | 47.1% |
 
 ---
 

--- a/cmd/test-cli/infra-with-nlb/testresult/beetle-test-summary-all.md
+++ b/cmd/test-cli/infra-with-nlb/testresult/beetle-test-summary-all.md
@@ -5,32 +5,31 @@
 
 ## Execution details
 
-- **Test Date**: July 13, 2026
-- **Start Time**: 20:03:25 KST
-- **End Time**: 20:03:36 KST
-- **Total Execution Duration**: 10s
-- **CM-Beetle Version**: b418c24
-- **imdl Version**: unknown
-- **CB-Tumblebug Version**: Unknown (Fallback to Latest)
-- **CB-Spider Version**: Unknown (Fallback to Latest)
-- **CB-MapUI Version**: Unknown (Fallback to Latest)
+- **Test Date**: July 21, 2026
+- **Start Time**: 13:13:55 KST
+- **End Time**: 13:21:25 KST
+- **Total Execution Duration**: 8m7s
+- **CM-Beetle Version**: v0.5.5+ (726f2e8)
+- **imdl Version**: v0.1.10+ (726f2e8)
+- **CB-Tumblebug Version**: v0.12.25
+- **CB-Spider Version**: v0.12.35
+- **CB-MapUI Version**: v0.12.50
 
 ## High-level test status
 
 | Metric | Count | Description |
 |--------|-------|-------------|
 | **Total CSP Pairs** | **10** | Number of unique CSP-Region configurations evaluated |
-| Passed CSP Pairs | 0 | Pairs where all test steps succeeded |
-| Failed CSP Pairs | 1 | Pairs where at least one test step failed |
+| Passed CSP Pairs | 1 | Pairs where all test steps succeeded |
+| Failed CSP Pairs | 0 | Pairs where at least one test step failed |
 | Skipped CSP Pairs | 9 | Pairs that were disabled in config |
 | **Total Test Steps** | **130** | Total individual endpoint tests triggered |
-| Passed Steps | 0 | Individual tests that succeeded |
-| Failed Steps | 1 | Individual tests that failed |
-| Skipped Steps | 13 | Tests skipped due to pre-requisite step failure |
+| Passed Steps | 14 | Individual tests that succeeded |
+| Failed Steps | 0 | Individual tests that failed |
 
 ## Provider-specific summary
 
 | Provider-Region | Status | Duration | Steps Passed | Details |
 |-----------------|--------|----------|--------------|---------|
-| **Alibaba-Singapore** | ❌ **FAIL** | 5s | 0 / 14 | [View Report](beetle-test-results-alibaba.md) |
+| **AWS-Seoul** | ✅ **PASS** | 8m2s | 14 / 14 | [View Report](beetle-test-results-aws.md) |
 

--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -13,9 +13,9 @@ services:
   cm-beetle:
     image: cloudbaristaorg/cm-beetle:0.5.6
     container_name: cm-beetle
-    # build:
-    #   context: ${PROJECT_ROOT}
-    #   dockerfile: Dockerfile
+    build:
+      context: ${PROJECT_ROOT}
+      dockerfile: Dockerfile
     platform: linux/amd64
     networks:
       - cloud-barista

--- a/pkg/core/report/markdown.go
+++ b/pkg/core/report/markdown.go
@@ -16,6 +16,7 @@ package report
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/cloud-barista/cm-beetle/pkg/core/summary"
@@ -318,15 +319,19 @@ func writeVmMigrationStatus(md *strings.Builder, report *MigrationReport) {
 
 	if report.TargetDetails != nil && report.TargetDetails.ComputeResources.Vms != nil {
 		for i, vm := range report.TargetDetails.ComputeResources.Vms {
-			// Extract sourceMachineId from VM name
-			sourceMachineId := extractSourceMachineId(vm.Name)
+			// Resolve the source machine ID via the matched source node, rather
+			// than re-parsing it out of the VM name (see findSourceServer).
+			sourceMachineId := "N/A"
+			if node := findSourceServer(vm, report.SourceDetails); node != nil {
+				sourceMachineId = node.MachineId
+			}
 
 			// Format VM info
 			vmInfo := fmt.Sprintf("**VM Name:** %s<br>**VM ID:** %s<br>**Label(sourceMachineId):** %s",
 				vm.Name, vm.CspVmId, sourceMachineId)
 
 			// Get source node info
-			sourceInfo := extractSourceServerInfoDetailed(vm.Name, report.SourceDetails)
+			sourceInfo := extractSourceServerInfoDetailed(vm, report.SourceDetails)
 
 			md.WriteString(fmt.Sprintf("| %d | %s | %s |\n", i+1, vmInfo, sourceInfo))
 		}
@@ -357,8 +362,8 @@ func writeVmSpecStatus(md *strings.Builder, report *MigrationReport) {
 		for i, vm := range report.TargetDetails.ComputeResources.Vms {
 			vmName := vm.Name
 			specInfo := formatVmSpecInfo(vm)
-			sourceInfo := extractSourceServerInfoDetailed(vm.Name, report.SourceDetails)
-			sourceSpec := formatSourceServerSpecInfo(vm.Name, report.SourceDetails)
+			sourceInfo := extractSourceServerInfoDetailed(vm, report.SourceDetails)
+			sourceSpec := formatSourceServerSpecInfo(vm, report.SourceDetails)
 			md.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %s |\n", i+1, vmName, specInfo, sourceInfo, sourceSpec))
 		}
 	}
@@ -388,8 +393,8 @@ func writeVmImageStatus(md *strings.Builder, report *MigrationReport) {
 		for i, vm := range report.TargetDetails.ComputeResources.Vms {
 			vmName := vm.Name
 			imageInfo := fmt.Sprintf("**Image ID:** %s<br>**OS Type:** %s<br>**OS Distribution:** %s", vm.Image.Id, vm.Image.OsType, vm.Image.Distribution)
-			sourceInfo := extractSourceServerInfoDetailed(vm.Name, report.SourceDetails)
-			sourceOS := extractSourceOSInfoDetailed(vm.Name, report.SourceDetails)
+			sourceInfo := extractSourceServerInfoDetailed(vm, report.SourceDetails)
+			sourceOS := extractSourceOSInfoDetailed(vm, report.SourceDetails)
 			md.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %s |\n", i+1, vmName, imageInfo, sourceInfo, sourceOS))
 		}
 	}
@@ -423,7 +428,7 @@ func writeSecurityGroupStatus(md *strings.Builder, report *MigrationReport) {
 				md.WriteString("**Assigned VMs:**\n\n")
 				for _, vm := range assignedVMsList {
 					sourceInfo := extractSourceServerInfoDetailed(vm, report.SourceDetails)
-					md.WriteString(fmt.Sprintf("- **VM:** %s\n", vm))
+					md.WriteString(fmt.Sprintf("- **VM:** %s\n", vm.Name))
 					md.WriteString(fmt.Sprintf("  - **Source Server:** %s\n", strings.ReplaceAll(sourceInfo, "<br>", ", ")))
 				}
 				md.WriteString("\n")
@@ -557,7 +562,7 @@ func writeNetworkStatus(md *strings.Builder, report *MigrationReport) {
 				if len(mainRoutes) > 0 {
 					md.WriteString("**Main Routes:**\n\n")
 					md.WriteString("| Destination | Gateway | Interface |\n")
-					md.WriteString("|-------------|---------||-----------|\n")
+					md.WriteString("|-------------|---------|-----------|\n")
 
 					for _, route := range mainRoutes {
 						gateway := route.Gateway
@@ -605,112 +610,133 @@ func writeSshKeyStatus(md *strings.Builder, report *MigrationReport) {
 
 // Helper functions for extracting source information
 
-// extractSourceMachineId extracts machine ID from VM name
-func extractSourceMachineId(vmName string) string {
-	// VM name format: "migrated-{machineId}-..."
-	parts := strings.Split(vmName, "-")
-	if len(parts) >= 6 {
-		// Reconstruct full machine ID from parts (e.g., 0036e4b9-c8b4-e811-906e-000ffee02d5c)
-		return fmt.Sprintf("%s-%s-%s-%s-%s", parts[1], parts[2], parts[3], parts[4], parts[5])
+// sourceMachineIdsLabelKey is the NodeGroup creation-time label set by the
+// recommendation phase (see pkg/core/recommendation) recording which source
+// machine(s) a NodeGroup was recommended from.
+const sourceMachineIdsLabelKey = "sourceMachineIds"
+
+// resolveSourceMachineID resolves the exact source machine ID for a target VM
+// from its "sourceMachineIds" label, which is authoritative and set at
+// NodeGroup creation time — unlike inferring it from the VM name.
+//
+// For a 1:1 NodeGroup (NodeGroupSize == 1) the label holds exactly one machine
+// ID. For an N:1 NLB backend NodeGroup (NodeGroupSize > 1), CB-Tumblebug copies
+// the *same* CreateNodeGroupReq.Label verbatim onto every VM in the group, so
+// the label alone can't tell VMs in that group apart — it holds the full
+// comma-separated list of member machine IDs. To pick the right entry for this
+// specific VM, we use its 1-based index within the group: CB-Tumblebug names
+// NodeGroup members "<groupName>-1", "-2", ... in the same order it created
+// them, which is the same order cm-beetle used to build the label's list, so
+// the Nth VM corresponds to the Nth machine ID.
+func resolveSourceMachineID(vm summary.SummaryVmInfo) string {
+	ids := vm.Label[sourceMachineIdsLabelKey]
+	if ids == "" {
+		return ""
 	}
-	if len(parts) >= 2 {
-		return parts[1]
+
+	idList := strings.Split(ids, ",")
+	if len(idList) == 1 {
+		return strings.TrimSpace(idList[0])
 	}
-	return "N/A"
+
+	idx := vmGroupIndex(vm.Name)
+	if idx < 1 || idx > len(idList) {
+		return ""
+	}
+
+	return strings.TrimSpace(idList[idx-1])
+}
+
+// vmGroupIndex extracts the 1-based NodeGroup member index from a VM name's
+// trailing "-N" suffix. Returns 0 if the name has no such numeric suffix.
+func vmGroupIndex(vmName string) int {
+	i := strings.LastIndex(vmName, "-")
+	if i < 0 || i == len(vmName)-1 {
+		return 0
+	}
+
+	n, err := strconv.Atoi(vmName[i+1:])
+	if err != nil || n < 1 {
+		return 0
+	}
+
+	return n
+}
+
+// findSourceServer locates the source node a target VM was migrated from.
+// It first tries the authoritative "sourceMachineIds" label (see
+// resolveSourceMachineID); if the VM has no usable label — e.g. it was
+// manually registered rather than created through the recommendation flow —
+// it falls back to matching by substring containment of a known machine ID in
+// the VM name.
+func findSourceServer(vm summary.SummaryVmInfo, sourceDetails *summary.SourceInfraSummary) *summary.SourceServerInfo {
+	if sourceDetails == nil {
+		return nil
+	}
+
+	if machineID := resolveSourceMachineID(vm); machineID != "" {
+		for i, node := range sourceDetails.ComputeResources.Servers {
+			if node.MachineId == machineID {
+				return &sourceDetails.ComputeResources.Servers[i]
+			}
+		}
+	}
+
+	for i, node := range sourceDetails.ComputeResources.Servers {
+		if node.MachineId != "" && strings.Contains(vm.Name, node.MachineId) {
+			return &sourceDetails.ComputeResources.Servers[i]
+		}
+	}
+
+	return nil
 }
 
 // extractSourceServerInfoDetailed extracts detailed source node information
-func extractSourceServerInfoDetailed(vmName string, sourceDetails *summary.SourceInfraSummary) string {
-	if sourceDetails == nil || sourceDetails.ComputeResources.Servers == nil {
+func extractSourceServerInfoDetailed(vm summary.SummaryVmInfo, sourceDetails *summary.SourceInfraSummary) string {
+	node := findSourceServer(vm, sourceDetails)
+	if node == nil {
 		return "**Hostname:** N/A<br>**Machine ID:** N/A"
 	}
 
-	// Extract machine ID from VM name (format: "migrated-{MachineId}")
-	machineID := extractSourceMachineId(vmName)
-
-	// Match source node by machine ID field directly
-	for _, node := range sourceDetails.ComputeResources.Servers {
-		if node.MachineId == machineID {
-			return fmt.Sprintf("**Hostname:** %s<br>**Machine ID:** %s", node.Hostname, node.MachineId)
-		}
-	}
-
-	// If no match found, still show the machine ID extracted from VM name
-	return fmt.Sprintf("**Hostname:** N/A<br>**Machine ID:** %s", machineID)
+	return fmt.Sprintf("**Hostname:** %s<br>**Machine ID:** %s", node.Hostname, node.MachineId)
 }
 
-func extractSourceServerInfo(vmName string, sourceDetails *summary.SourceInfraSummary) string {
-	if sourceDetails == nil || sourceDetails.ComputeResources.Servers == nil {
+func extractSourceServerInfo(vm summary.SummaryVmInfo, sourceDetails *summary.SourceInfraSummary) string {
+	node := findSourceServer(vm, sourceDetails)
+	if node == nil {
 		return "N/A"
 	}
 
-	// Extract machine ID from VM name
-	machineID := extractSourceMachineId(vmName)
-
-	// Match by machine ID field
-	for _, node := range sourceDetails.ComputeResources.Servers {
-		if node.MachineId == machineID {
-			return fmt.Sprintf("%s<br>%s", node.Hostname, node.MachineId)
-		}
-	}
-
-	return fmt.Sprintf("Source node<br>%s", machineID)
+	return fmt.Sprintf("%s<br>%s", node.Hostname, node.MachineId)
 }
 
-func extractSourceSpecInfo(vmName string, sourceDetails *summary.SourceInfraSummary) string {
-	if sourceDetails == nil || sourceDetails.ComputeResources.Servers == nil {
+func extractSourceSpecInfo(vm summary.SummaryVmInfo, sourceDetails *summary.SourceInfraSummary) string {
+	node := findSourceServer(vm, sourceDetails)
+	if node == nil {
 		return "N/A"
 	}
 
-	// Extract machine ID from VM name
-	machineID := extractSourceMachineId(vmName)
-
-	// Match by machine ID field
-	for _, node := range sourceDetails.ComputeResources.Servers {
-		if node.MachineId == machineID {
-			return fmt.Sprintf("%d CPUs, %d Threads<br>%d GB RAM, %d GB Disk",
-				node.CPU.CPUs, node.CPU.Threads, node.Memory.TotalGB, node.Disk.TotalGB)
-		}
-	}
-
-	return "N/A"
+	return fmt.Sprintf("%d CPUs, %d Threads<br>%d GB RAM, %d GB Disk",
+		node.CPU.CPUs, node.CPU.Threads, node.Memory.TotalGB, node.Disk.TotalGB)
 }
 
-func extractSourceOSInfo(vmName string, sourceDetails *summary.SourceInfraSummary) string {
-	if sourceDetails == nil || sourceDetails.ComputeResources.Servers == nil {
+func extractSourceOSInfo(vm summary.SummaryVmInfo, sourceDetails *summary.SourceInfraSummary) string {
+	node := findSourceServer(vm, sourceDetails)
+	if node == nil {
 		return "N/A"
 	}
 
-	// Extract machine ID from VM name
-	machineID := extractSourceMachineId(vmName)
-
-	// Match by machine ID field
-	for _, node := range sourceDetails.ComputeResources.Servers {
-		if node.MachineId == machineID {
-			return fmt.Sprintf("%s %s", node.OS.Name, node.OS.Version)
-		}
-	}
-
-	return "N/A"
+	return fmt.Sprintf("%s %s", node.OS.Name, node.OS.Version)
 }
 
-func extractSourceOSInfoDetailed(vmName string, sourceDetails *summary.SourceInfraSummary) string {
-	if sourceDetails == nil || sourceDetails.ComputeResources.Servers == nil {
+func extractSourceOSInfoDetailed(vm summary.SummaryVmInfo, sourceDetails *summary.SourceInfraSummary) string {
+	node := findSourceServer(vm, sourceDetails)
+	if node == nil {
 		return "**PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A"
 	}
 
-	// Extract machine ID from VM name
-	machineID := extractSourceMachineId(vmName)
-
-	// Match by machine ID field
-	for _, node := range sourceDetails.ComputeResources.Servers {
-		if node.MachineId == machineID {
-			return fmt.Sprintf("**PrettyName:** %s<br>**Name:** %s<br>**Version:** %s",
-				node.OS.PrettyName, node.OS.Name, node.OS.Version)
-		}
-	}
-
-	return "**PrettyName:** N/A<br>**Name:** N/A<br>**Version:** N/A"
+	return fmt.Sprintf("**PrettyName:** %s<br>**Name:** %s<br>**Version:** %s",
+		node.OS.PrettyName, node.OS.Name, node.OS.Version)
 }
 
 // formatVmSpecInfo formats VM spec information for display
@@ -722,49 +748,18 @@ func formatVmSpecInfo(vm summary.SummaryVmInfo) string {
 }
 
 // formatSourceServerSpecInfo formats source node spec information for display
-func formatSourceServerSpecInfo(vmName string, sourceDetails *summary.SourceInfraSummary) string {
-	if sourceDetails == nil || sourceDetails.ComputeResources.Servers == nil {
+func formatSourceServerSpecInfo(vm summary.SummaryVmInfo, sourceDetails *summary.SourceInfraSummary) string {
+	node := findSourceServer(vm, sourceDetails)
+	if node == nil {
 		return "**CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A"
 	}
 
-	// Extract machine ID from VM name
-	machineID := extractSourceMachineId(vmName)
-
-	// Match by machine ID field
-	for _, node := range sourceDetails.ComputeResources.Servers {
-		if node.MachineId == machineID {
-			return fmt.Sprintf("**CPUs:** %d<br>**Threads:** %d<br>**Memory:** %d GB<br>**Root Disk:** %d GB",
-				node.CPU.CPUs, node.CPU.Threads, node.Memory.TotalGB, node.Disk.TotalGB)
-		}
-	}
-
-	return "**CPUs:** N/A<br>**Threads:** N/A<br>**Memory:** N/A<br>**Root Disk:** N/A"
+	return fmt.Sprintf("**CPUs:** %d<br>**Threads:** %d<br>**Memory:** %d GB<br>**Root Disk:** %d GB",
+		node.CPU.CPUs, node.CPU.Threads, node.Memory.TotalGB, node.Disk.TotalGB)
 }
 
-func getVMsUsingSecurityGroup(sgName string, targetDetails *summary.TargetInfraSummary) string {
-	if targetDetails == nil || targetDetails.ComputeResources.Vms == nil {
-		return "N/A"
-	}
-
-	vms := []string{}
-	for _, vm := range targetDetails.ComputeResources.Vms {
-		for _, sg := range vm.Misc.SecurityGroups {
-			if sg == sgName {
-				vms = append(vms, vm.Name)
-				break
-			}
-		}
-	}
-
-	if len(vms) == 0 {
-		return "N/A"
-	}
-
-	return strings.Join(vms, "<br>")
-}
-
-func getVMsUsingSecurityGroupList(sgName string, targetDetails *summary.TargetInfraSummary) []string {
-	vms := []string{}
+func getVMsUsingSecurityGroupList(sgName string, targetDetails *summary.TargetInfraSummary) []summary.SummaryVmInfo {
+	vms := []summary.SummaryVmInfo{}
 	if targetDetails == nil || targetDetails.ComputeResources.Vms == nil {
 		return vms
 	}
@@ -772,7 +767,7 @@ func getVMsUsingSecurityGroupList(sgName string, targetDetails *summary.TargetIn
 	for _, vm := range targetDetails.ComputeResources.Vms {
 		for _, sg := range vm.Misc.SecurityGroups {
 			if sg == sgName {
-				vms = append(vms, vm.Name)
+				vms = append(vms, vm)
 				break
 			}
 		}

--- a/pkg/core/report/markdown_test.go
+++ b/pkg/core/report/markdown_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"testing"
+
+	"github.com/cloud-barista/cm-beetle/pkg/core/summary"
+)
+
+func testSourceDetails() *summary.SourceInfraSummary {
+	return &summary.SourceInfraSummary{
+		ComputeResources: summary.SourceSummaryComputeResources{
+			Servers: []summary.SourceServerInfo{
+				{Hostname: "ip-10-0-1-30", MachineId: "ec268ed7-821e-9d73-e79f-961262161624"},
+				{Hostname: "ip-10-0-1-221", MachineId: "ec2d32b5-98fb-5a96-7913-d3db1ec18932"},
+				{Hostname: "ip-10-0-1-138", MachineId: "ec288dd0-c6fa-8a49-2f60-bc898311febf"},
+			},
+		},
+	}
+}
+
+func TestVmGroupIndex(t *testing.T) {
+	cases := []struct {
+		vmName string
+		want   int
+	}{
+		{"my-ng-influxdb-back-1", 1},
+		{"my-ng-influxdb-back-2", 2},
+		{"my-ng-influxdb-back-12", 12},
+		{"my-ng-ec268ed7-821e-9d73-e79f-961262161624-1", 1},
+		{"no-trailing-number", 0},
+		{"", 0},
+		{"trailing-dash-", 0},
+	}
+
+	for _, c := range cases {
+		if got := vmGroupIndex(c.vmName); got != c.want {
+			t.Errorf("vmGroupIndex(%q) = %d, want %d", c.vmName, got, c.want)
+		}
+	}
+}
+
+func TestResolveSourceMachineID(t *testing.T) {
+	cases := []struct {
+		name string
+		vm   summary.SummaryVmInfo
+		want string
+	}{
+		{
+			name: "1:1 NodeGroup - single machine ID in label",
+			vm: summary.SummaryVmInfo{
+				Name:  "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
+				Label: map[string]string{"sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624"},
+			},
+			want: "ec268ed7-821e-9d73-e79f-961262161624",
+		},
+		{
+			name: "NLB backend NodeGroup - 1st member picks 1st machine ID by position",
+			vm: summary.SummaryVmInfo{
+				Name:  "my-ng-influxdb-back-1",
+				Label: map[string]string{"sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf"},
+			},
+			want: "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+		},
+		{
+			name: "NLB backend NodeGroup - 2nd member picks 2nd machine ID by position",
+			vm: summary.SummaryVmInfo{
+				Name:  "my-ng-influxdb-back-2",
+				Label: map[string]string{"sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf"},
+			},
+			want: "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+		},
+		{
+			name: "no label",
+			vm:   summary.SummaryVmInfo{Name: "my-ng-influxdb-back-1"},
+			want: "",
+		},
+		{
+			name: "multi-value label but VM name has no group index",
+			vm: summary.SummaryVmInfo{
+				Name:  "my-ng-influxdb-back",
+				Label: map[string]string{"sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf"},
+			},
+			want: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolveSourceMachineID(c.vm); got != c.want {
+				t.Errorf("resolveSourceMachineID(%+v) = %q, want %q", c.vm, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFindSourceServer(t *testing.T) {
+	sourceDetails := testSourceDetails()
+
+	cases := []struct {
+		name         string
+		vm           summary.SummaryVmInfo
+		wantHostname string // "" means no match expected
+	}{
+		{
+			name: "resolved via label (1:1 NodeGroup)",
+			vm: summary.SummaryVmInfo{
+				Name:  "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
+				Label: map[string]string{"sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624"},
+			},
+			wantHostname: "ip-10-0-1-30",
+		},
+		{
+			name: "resolved via label (NLB backend NodeGroup, 2nd member)",
+			vm: summary.SummaryVmInfo{
+				Name:  "my-ng-influxdb-back-2",
+				Label: map[string]string{"sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf"},
+			},
+			wantHostname: "ip-10-0-1-138",
+		},
+		{
+			name:         "no label - falls back to substring match (infra-with-nlb naming)",
+			vm:           summary.SummaryVmInfo{Name: "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1"},
+			wantHostname: "ip-10-0-1-30",
+		},
+		{
+			name:         "no label - falls back to substring match (infra naming)",
+			vm:           summary.SummaryVmInfo{Name: "my01-vm-ec288dd0-c6fa-8a49-2f60-bc898311febf-1"},
+			wantHostname: "ip-10-0-1-138",
+		},
+		{
+			name:         "role-named VM with no label and no embedded machine ID",
+			vm:           summary.SummaryVmInfo{Name: "my-ng-influxdb-back-1"},
+			wantHostname: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			node := findSourceServer(c.vm, sourceDetails)
+			if c.wantHostname == "" {
+				if node != nil {
+					t.Errorf("findSourceServer(%+v) = %+v, want no match", c.vm, node)
+				}
+				return
+			}
+
+			if node == nil {
+				t.Fatalf("findSourceServer(%+v) = nil, want hostname %q", c.vm, c.wantHostname)
+			}
+			if node.Hostname != c.wantHostname {
+				t.Errorf("findSourceServer(%+v).Hostname = %q, want %q", c.vm, node.Hostname, c.wantHostname)
+			}
+		})
+	}
+}
+
+func TestFindSourceServerNilDetails(t *testing.T) {
+	vm := summary.SummaryVmInfo{Name: "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1"}
+	if node := findSourceServer(vm, nil); node != nil {
+		t.Errorf("findSourceServer with nil sourceDetails = %+v, want nil", node)
+	}
+}

--- a/pkg/core/report/migration-report.go
+++ b/pkg/core/report/migration-report.go
@@ -16,7 +16,6 @@ package report
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -120,25 +119,35 @@ func buildExecutiveSummary(sourceSummary *summary.SourceInfraSummary, targetSumm
 func buildMigrationMappings(sourceSummary *summary.SourceInfraSummary, targetSummary *summary.TargetInfraSummary) []SourceTargetMapping {
 	var mappings []SourceTargetMapping
 
-	// Create a map of machine IDs from target VMs
-	vmByMachineID := make(map[string]summary.SummaryVmInfo)
-	for _, vm := range targetSummary.ComputeResources.Vms {
-		// Extract sourceMachineId from VM name or labels
-		machineID := extractSourceMachineID(vm.Name)
-		if machineID != "" {
-			vmByMachineID[machineID] = vm
+	// Build a source-machine-ID -> target VM index, preferring the
+	// authoritative "sourceMachineIds" label set at NodeGroup creation time
+	// (see resolveSourceMachineID) over any inference from the VM name.
+	vmByMachineID := make(map[string]*summary.SummaryVmInfo)
+	for i, vm := range targetSummary.ComputeResources.Vms {
+		if machineID := resolveSourceMachineID(vm); machineID != "" {
+			vmByMachineID[machineID] = &targetSummary.ComputeResources.Vms[i]
 		}
 	}
 
 	// Match source servers to target VMs
 	mappingID := 1
 	for _, sourceNode := range sourceSummary.ComputeResources.Servers {
-		// Try to find matching VM by machine ID (now directly from source node data)
 		machineID := sourceNode.MachineId
-		targetVM, found := vmByMachineID[machineID]
+		targetVM := vmByMachineID[machineID]
 
-		if !found {
-			// Try alternative matching strategies
+		if targetVM == nil && machineID != "" {
+			// Fallback for VMs without a usable label (e.g. manually
+			// registered nodes): match by substring containment of the
+			// machine ID in the VM name.
+			for i, vm := range targetSummary.ComputeResources.Vms {
+				if strings.Contains(vm.Name, machineID) {
+					targetVM = &targetSummary.ComputeResources.Vms[i]
+					break
+				}
+			}
+		}
+
+		if targetVM == nil {
 			log.Warn().Msgf("No matching target VM found for source node: %s (MachineId: %s)", sourceNode.Hostname, machineID)
 			continue
 		}
@@ -183,7 +192,7 @@ func buildMigrationMappings(sourceSummary *summary.SourceInfraSummary, targetSum
 		}
 
 		// Analyze resource changes
-		resourceChanges := analyzeResourceChanges(sourceNode, targetVM)
+		resourceChanges := analyzeResourceChanges(sourceNode, *targetVM)
 
 		// Calculate cost for this VM
 		costPerMonth := 0.0
@@ -496,44 +505,4 @@ func generateRecommendations(sourceSummary *summary.SourceInfraSummary, targetSu
 	})
 
 	return recommendations
-}
-
-// Helper functions
-
-// extractSourceMachineID extracts machine ID from VM name
-// Example: "migrated-0036e4b9-c8b4-e811-906e-000ffee02d5c-1" -> "0036e4b9-c8b4-e811-906e-000ffee02d5c"
-func extractSourceMachineID(vmName string) string {
-	// A UUID pattern: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-	re := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
-	match := re.FindString(vmName)
-	if match != "" {
-		return match
-	}
-
-	// Fallback to legacy logic if regex fails (though unlikely for UUIDs)
-	// Remove prefixes
-	name := vmName
-	if strings.Contains(name, "migrated-") {
-		name = name[strings.Index(name, "migrated-")+len("migrated-"):]
-	} else if strings.Contains(name, "vm-") {
-		name = name[strings.Index(name, "vm-")+len("vm-"):]
-	}
-
-	parts := strings.Split(name, "-")
-	if len(parts) >= 5 {
-		// Reconstruct the GUID format
-		return strings.Join(parts[:5], "-")
-	}
-	return ""
-}
-
-// extractMachineIDFromHostname attempts to extract machine ID from source node
-// This is a placeholder - actual implementation depends on source data structure
-func extractMachineIDFromHostname(hostname string) string {
-	// In real implementation, this would look up machine ID from source data
-	// For now, we'll use a placeholder that matches the VM naming pattern
-
-	// This is a simplified approach - in production, you'd need actual machine IDs
-	// from the source infrastructure data
-	return "" // Will be populated from actual source data
 }

--- a/pkg/core/report/migration-report_test.go
+++ b/pkg/core/report/migration-report_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"testing"
+
+	"github.com/cloud-barista/cm-beetle/pkg/core/summary"
+)
+
+// TestBuildMigrationMappingsNlbGroup reproduces the 3-server sample used across
+// the test-cli reports: one solo node whose NodeGroup has its own machine ID
+// label, plus two NLB backend nodes sharing a single NodeGroup (and therefore
+// the same comma-separated "sourceMachineIds" label). All three must resolve
+// to a mapping — previously the two NLB-group members were silently dropped,
+// which is what caused the Cost Breakdown table to only show 1 of 3 VMs.
+func TestBuildMigrationMappingsNlbGroup(t *testing.T) {
+	sourceSummary := &summary.SourceInfraSummary{
+		ComputeResources: summary.SourceSummaryComputeResources{
+			Servers: []summary.SourceServerInfo{
+				{Hostname: "ip-10-0-1-30", MachineId: "ec268ed7-821e-9d73-e79f-961262161624", CPU: summary.SourceCPUInfo{Cores: 1}, Memory: summary.SourceMemoryInfo{TotalGB: 2}, Disk: summary.SourceDiskInfo{TotalGB: 30}},
+				{Hostname: "ip-10-0-1-221", MachineId: "ec2d32b5-98fb-5a96-7913-d3db1ec18932", CPU: summary.SourceCPUInfo{Cores: 1}, Memory: summary.SourceMemoryInfo{TotalGB: 8}, Disk: summary.SourceDiskInfo{TotalGB: 30}},
+				{Hostname: "ip-10-0-1-138", MachineId: "ec288dd0-c6fa-8a49-2f60-bc898311febf", CPU: summary.SourceCPUInfo{Cores: 2}, Memory: summary.SourceMemoryInfo{TotalGB: 8}, Disk: summary.SourceDiskInfo{TotalGB: 30}},
+			},
+		},
+	}
+
+	nlbLabel := map[string]string{
+		"sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf",
+	}
+	targetSummary := &summary.TargetInfraSummary{
+		ComputeResources: summary.SummaryComputeResources{
+			Vms: []summary.SummaryVmInfo{
+				{
+					Name:   "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1",
+					Status: "Running",
+					Spec:   summary.SummaryVmSpecInfo{Name: "t3a.small", VCpus: 2, MemoryGiB: 2},
+					Label:  map[string]string{"sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624"},
+				},
+				{
+					Name:   "my-ng-influxdb-back-1",
+					Status: "Running",
+					Spec:   summary.SummaryVmSpecInfo{Name: "t3a.xlarge", VCpus: 4, MemoryGiB: 16},
+					Label:  nlbLabel,
+				},
+				{
+					Name:   "my-ng-influxdb-back-2",
+					Status: "Running",
+					Spec:   summary.SummaryVmSpecInfo{Name: "t3a.xlarge", VCpus: 4, MemoryGiB: 16},
+					Label:  nlbLabel,
+				},
+			},
+		},
+		CostEstimation: summary.SummaryCostEstimation{
+			ByVm: []summary.SummaryCostByVm{
+				{VmName: "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1", CostPerMonth: 16.85},
+				{VmName: "my-ng-influxdb-back-1", CostPerMonth: 134.78},
+				{VmName: "my-ng-influxdb-back-2", CostPerMonth: 134.78},
+			},
+		},
+	}
+
+	mappings := buildMigrationMappings(sourceSummary, targetSummary)
+
+	if len(mappings) != 3 {
+		t.Fatalf("buildMigrationMappings() returned %d mappings, want 3 (got: %+v)", len(mappings), mappings)
+	}
+
+	byHostname := make(map[string]SourceTargetMapping)
+	for _, m := range mappings {
+		byHostname[m.SourceServer.Hostname] = m
+	}
+
+	cases := []struct {
+		hostname   string
+		wantVmName string
+		wantCost   float64
+	}{
+		{"ip-10-0-1-30", "my-ng-ec268ed7-821e-9d73-e79f-961262161624-1", 16.85},
+		{"ip-10-0-1-221", "my-ng-influxdb-back-1", 134.78},
+		{"ip-10-0-1-138", "my-ng-influxdb-back-2", 134.78},
+	}
+
+	for _, c := range cases {
+		m, ok := byHostname[c.hostname]
+		if !ok {
+			t.Errorf("no mapping found for source hostname %q", c.hostname)
+			continue
+		}
+		if m.TargetVM.InstanceName != c.wantVmName {
+			t.Errorf("hostname %q mapped to VM %q, want %q", c.hostname, m.TargetVM.InstanceName, c.wantVmName)
+		}
+		// CostPerMonth passes through a float32 (SummaryCostByVm) on its way to
+		// this float64 field, so compare at float32 precision.
+		if float32(m.CostPerMonth) != float32(c.wantCost) {
+			t.Errorf("hostname %q CostPerMonth = %v, want %v", c.hostname, m.CostPerMonth, c.wantCost)
+		}
+	}
+}

--- a/pkg/core/summary/model-target.go
+++ b/pkg/core/summary/model-target.go
@@ -140,6 +140,14 @@ type SummaryVmInfo struct {
 	Misc    SummaryVmMiscInfo  `json:"misc"`
 	Region  string             `json:"region" example:"ap-northeast-2"`
 	Zone    string             `json:"zone,omitempty" example:"ap-northeast-2a"`
+	// Label carries the node's labels as set at NodeGroup creation time, e.g.
+	// {"sourceMachineIds": "<id1>,<id2>,..."} recording which source machine(s)
+	// this VM's NodeGroup was recommended from. For an NLB backend NodeGroup
+	// (NodeGroupSize > 1) this same label is shared verbatim by every VM in the
+	// group, so resolving the single machine ID for one specific VM additionally
+	// requires its 1-based index within the group (see the VM name's trailing
+	// "-N" suffix, which CB-Tumblebug assigns in the same order as this list).
+	Label map[string]string `json:"label,omitempty" example:"{\"sourceMachineIds\":\"0036e4b9-c8b4-e811-906e-000ffee02d5c\"}"`
 }
 
 // SummaryVmSpecInfo represents VM Spec summary embedded in VM info

--- a/pkg/core/summary/summary-source.go
+++ b/pkg/core/summary/summary-source.go
@@ -214,13 +214,14 @@ func collectSourceComputeResources(infraData *onpremmodel.OnpremInfra) SourceSum
 
 // isMainInterface checks if the interface is a main/primary interface
 func isMainInterface(name string) bool {
-	// Main interfaces typically include: lo, eth*, eno*, enp*, br-ex, etc.
+	// Main interfaces typically include: lo, eth*, and the systemd predictable
+	// network interface naming scheme variants eno*/ens*/enp*/enx*, br-ex, etc.
 	// Exclude tap*, veth*, and other virtual interfaces
 	if name == "" {
 		return false
 	}
 
-	mainPrefixes := []string{"lo", "eth", "eno", "enp", "br-"}
+	mainPrefixes := []string{"lo", "eth", "eno", "ens", "enp", "enx", "br-"}
 	for _, prefix := range mainPrefixes {
 		if strings.HasPrefix(name, prefix) {
 			return true

--- a/pkg/core/summary/summary-source_test.go
+++ b/pkg/core/summary/summary-source_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package summary
+
+import "testing"
+
+func TestIsMainInterface(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"lo", true},
+		{"eth0", true},
+		{"eno1", true},
+		{"ens5", true},   // systemd PCI-slot predictable name (e.g. AWS/KVM guests)
+		{"enp0s3", true}, // systemd PCI-ID predictable name
+		{"enx001122334455", true},
+		{"br-ex", true},
+		{"tap0", false},
+		{"veth1234", false},
+		{"docker0", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		if got := isMainInterface(c.name); got != c.want {
+			t.Errorf("isMainInterface(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/pkg/core/summary/summary-target.go
+++ b/pkg/core/summary/summary-target.go
@@ -375,6 +375,7 @@ func collectComputeResources(nsId string, infraInfo *tbmodel.InfraInfo, specIds,
 			},
 			Region: node.Region.Region,
 			Zone:   node.Region.Zone,
+			Label:  node.Label,
 		}
 
 		resources.Vms = append(resources.Vms, reportVm)
@@ -404,16 +405,16 @@ func buildInfraOverview(infraInfo *tbmodel.InfraInfo) TargetInfraOverview {
 	}
 
 	return TargetInfraOverview{
-		InfraName:       infraInfo.Name,
+		InfraName:        infraInfo.Name,
 		InfraDescription: infraInfo.Description,
-		Status:          infraInfo.Status,
-		TargetCloud:     targetCloud,
-		TargetRegion:    targetRegion,
-		TotalVmCount:    len(infraInfo.Node),
-		RunningVmCount:  runningCount,
-		StoppedVmCount:  stoppedCount,
-		Label:           infraInfo.Label,
-		InstallMonAgent: infraInfo.InstallMonAgent,
+		Status:           infraInfo.Status,
+		TargetCloud:      targetCloud,
+		TargetRegion:     targetRegion,
+		TotalVmCount:     len(infraInfo.Node),
+		RunningVmCount:   runningCount,
+		StoppedVmCount:   stoppedCount,
+		Label:            infraInfo.Label,
+		InstallMonAgent:  infraInfo.InstallMonAgent,
 	}
 }
 


### PR DESCRIPTION
- Resolve source machines via labels
- Add fallback to substring matching for legacy nodes
- Fix table formatting in network routes section
- Improve test-cli version detection logic