### PR TITLE
feat(api): add optional async responses to migration/recommendation APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ cmd/test-cli/data/log/
 cmd/test-cli/data/test-result/
 cmd/test-cli/data/testconf/auth-config.json
 cmd/test-cli/data/testconf/test-config.yaml
+cmd/test-cli/async/test-async
+cmd/test-cli/async/testconf/auth-config.json
+cmd/test-cli/async/testconf/test-config.yaml
 pkg/testclient/scripts/sequentialFullTest/executionStatus*
 pkg/testclient/scripts/sequentialFullTest/ansibleAutoConf/*
 pkg/testclient/scripts/credentials*

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ clean: ## Remove previous build
 	@cd cmd/test-cli/infra-with-nlb && $(GO) clean
 	@cd cmd/test-cli/object-storage && $(GO) clean
 	@cd cmd/test-cli/data && $(GO) clean
+	@cd cmd/test-cli/async && $(GO) clean
 	@echo "Cleaned!"
 
 test-infra: ## Run the infra migration test CLI for all CSP-Region pairs
@@ -135,6 +136,14 @@ test-data: ## Run the data migration test CLI for all CSP-Region pairs
 		echo "Created testconf/test-config.yaml from template. Edit it before running."; \
 	fi
 	@cd cmd/test-cli/data && $(GO) run main.go -config testconf/test-config.yaml
+
+test-async: ## Run the async response test CLI (recommend -> poll -> get -> migrate -> poll -> get -> delete -> poll -> get)
+	@echo "Running async response test CLI..."
+	@if [ ! -f cmd/test-cli/async/testconf/test-config.yaml ]; then \
+		cp cmd/test-cli/async/testconf/template-test-config.yaml cmd/test-cli/async/testconf/test-config.yaml; \
+		echo "Created testconf/test-config.yaml from template. Edit it before running."; \
+	fi
+	@cd cmd/test-cli/async && $(GO) run main.go -config testconf/test-config.yaml
 
 test-data-clean: ## Clean up data migration test artifacts
 	@echo "Cleaning data migration test artifacts..."

--- a/api/docs.go
+++ b/api/docs.go
@@ -62,7 +62,7 @@ const docTemplate = `{
         },
         "/migration/data": {
             "post": {
-                "description": "**Asynchronous Operation**: This API returns immediately with a request ID. The actual migration runs in the background.\n\n[How to Use]\n1. Call this API → Receive 202 Accepted with reqId\n2. Poll GET /request/{reqId} to check status\n3. Status flow: Handling → Success / Error\n\n[Endpoint Requirements]\n* Both source and destination must be remote endpoints (SSH or object storage)\n* Local filesystem access is not allowed for security reasons\n\n[Transfer Options]\n* Strategy: auto (default), direct, relay\n* SSH: Supports PrivateKey content or PrivateKeyPath\n\n[Encryption Support]\n* To encrypt sensitive fields, first call GET /migration/data/encryptionKey\n* Encrypted requests include ` + "`" + `encryptionKeyId` + "`" + ` field\n* Server automatically detects and decrypts encrypted requests\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
+                "description": "By default this API runs synchronously and returns the migration result directly.\n\n[Async Operation (opt-in)]\n1. Send header ` + "`" + `Prefer: respond-async` + "`" + ` → Receive 202 Accepted with reqId\n2. Poll GET /request/{reqId} to check status\n3. Status flow: Handling → Success / Error\n* Only the \"respond-async\" preference token is recognized; other tokens (e.g. wait=N) are ignored.\n* If too many async jobs are already running, this returns 503 instead of 202; retry after the ` + "`" + `Retry-After` + "`" + ` seconds.\n\n[Endpoint Requirements]\n* Both source and destination must be remote endpoints (SSH or object storage)\n* Local filesystem access is not allowed for security reasons\n\n[Transfer Options]\n* Strategy: auto (default), direct, relay\n* SSH: Supports PrivateKey content or PrivateKeyPath\n\n[Encryption Support]\n* To encrypt sensitive fields, first call GET /migration/data/encryptionKey\n* Encrypted requests include ` + "`" + `encryptionKeyId` + "`" + ` field\n* Server automatically detects and decrypts encrypted requests\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -72,13 +72,22 @@ const docTemplate = `{
                 "tags": [
                     "[Migration] Data (incubating)"
                 ],
-                "summary": "[Async] Migrate data from source to target",
+                "summary": "Migrate data from source to target (sync by default; async via Prefer: respond-async)",
                 "operationId": "MigrateData",
                 "parameters": [
                     {
                         "type": "string",
                         "description": "Unique request ID (auto-generated if not provided). Used as reqId for tracking migration status.",
                         "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
                         "in": "header"
                     },
                     {
@@ -92,14 +101,32 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "Migration completed synchronously",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
                     "202": {
-                        "description": "Migration started - use GET /request/{reqId} to check status",
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request parameters or decryption failed",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Migration failed",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -304,7 +331,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Migrate NLBs to the target cloud infra based on recommendation results.\n\n[Prerequisites]\n- The target Namespace (nsId) must exist.\n- The target Infra (infraId) must exist and have at least one NodeGroup in Running state.\n- Each ` + "`" + `targetNlbList[].targetGroup.nodeGroupId` + "`" + ` must reference an existing NodeGroup in the Infra.\n\n[Note] Input should be the ` + "`" + `targetNlbList` + "`" + ` field from the POST /recommendation/infraWithNlb response.\nEnsure ` + "`" + `targetGroup.nodeGroupId` + "`" + ` matches the NodeGroup IDs created during infra migration.\n\n[Note] All NLBs are attempted independently. Partial success is possible.",
+                "description": "Migrate NLBs to the target cloud infra based on recommendation results.\n\n[Prerequisites]\n- The target Namespace (nsId) must exist.\n- The target Infra (infraId) must exist and have at least one NodeGroup in Running state.\n- Each ` + "`" + `targetNlbList[].targetGroup.nodeGroupId` + "`" + ` must reference an existing NodeGroup in the Infra.\n\n[Note] Input should be the ` + "`" + `targetNlbList` + "`" + ` field from the POST /recommendation/infraWithNlb response.\nEnsure ` + "`" + `targetGroup.nodeGroupId` + "`" + ` matches the NodeGroup IDs created during infra migration.\n\n[Note] All NLBs are attempted independently. Partial success is possible.\n\nBy default this API runs synchronously. Send header ` + "`" + `Prefer: respond-async` + "`" + ` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -352,6 +379,15 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided)",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -359,6 +395,12 @@ const docTemplate = `{
                         "description": "NLBs created successfully",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-cloudmodel_MigratedNlbResult"
+                        }
+                    },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
@@ -369,6 +411,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error during NLB creation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -448,7 +496,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.",
+                "description": "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.\n\nBy default this API runs synchronously (always includes the 15s settle wait). Send header\n` + "`" + `Prefer: respond-async` + "`" + ` to run it asynchronously instead: receive 202 Accepted with a reqId,\nthen poll GET /request/{reqId} (status flow: Handling → Success / Error).",
                 "consumes": [
                     "application/json"
                 ],
@@ -488,9 +536,24 @@ const docTemplate = `{
                         "description": "Unique request ID",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this deletion asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
+                    "202": {
+                        "description": "Deletion started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
                     "204": {
                         "description": "NLB deleted (includes 15s settle wait for CSP async cleanup)"
                     },
@@ -502,6 +565,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -633,7 +702,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note]\n- This API creates object storages (buckets) in the target cloud within the specified namespace\n- Input should be the output from RecommendObjectStorage API\n- Connection name is automatically generated from CSP and region in the request body\n\n[Note] ` + "`" + `nameSeed` + "`" + ` enables dynamic naming via **Late Binding**.\n- If ` + "`" + `nameSeed` + "`" + ` query param is set (e.g., ` + "`" + `?nameSeed=my` + "`" + `), bucket names are prefixed at migration time: ` + "`" + `my-os-01` + "`" + `.\n- If ` + "`" + `nameSeed` + "`" + ` is omitted, bucket names are used as-is from the recommendation result.\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
+                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note]\n- This API creates object storages (buckets) in the target cloud within the specified namespace\n- Input should be the output from RecommendObjectStorage API\n- Connection name is automatically generated from CSP and region in the request body\n\n[Note] ` + "`" + `nameSeed` + "`" + ` enables dynamic naming via **Late Binding**.\n- If ` + "`" + `nameSeed` + "`" + ` query param is set (e.g., ` + "`" + `?nameSeed=my` + "`" + `), bucket names are prefixed at migration time: ` + "`" + `my-os-01` + "`" + `.\n- If ` + "`" + `nameSeed` + "`" + ` is omitted, bucket names are used as-is from the recommendation result.\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n\nBy default this API runs synchronously. Send header ` + "`" + `Prefer: respond-async` + "`" + ` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -674,11 +743,26 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
                     "201": {
                         "description": "Created - Object storages created successfully"
+                    },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
                     },
                     "400": {
                         "description": "Invalid request parameters",
@@ -688,6 +772,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error during object storage creation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -1156,7 +1246,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\n**[Request Field: ` + "`" + `nodeGroups[].cspImageName` + "`" + `]** Optional CSP-native image identifier.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses ` + "`" + `imageId` + "`" + ` for the standard DB lookup (may encounter stale images for some CSPs).\n- Recommended: pass the recommendation API response as-is to use the latest resolved image.",
+                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\n**[Request Field: ` + "`" + `nodeGroups[].cspImageName` + "`" + `]** Optional CSP-native image identifier.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses ` + "`" + `imageId` + "`" + ` for the standard DB lookup (may encounter stale images for some CSPs).\n- Recommended: pass the recommendation API response as-is to use the latest resolved image.\n\nBy default this API runs synchronously. Send header ` + "`" + `Prefer: respond-async` + "`" + ` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1166,7 +1256,7 @@ const docTemplate = `{
                 "tags": [
                     "[Migration] Infrastructure"
                 ],
-                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults",
+                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults (sync by default; async via Prefer: respond-async)",
                 "operationId": "MigrateInfra",
                 "parameters": [
                     {
@@ -1203,6 +1293,15 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -1210,6 +1309,12 @@ const docTemplate = `{
                         "description": "Successfully migrated to the multi-cloud infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-controller_MigrateInfraResponse"
+                        }
+                    },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "404": {
@@ -1220,6 +1325,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -1287,7 +1398,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Delete the migrated mult-cloud infrastructure (MCI)",
+                "description": "Delete the migrated mult-cloud infrastructure (MCI).\n\nThis operation can take a long time (multiple settle-time waits and vNet-deletion\nretries). By default it runs synchronously. Send header ` + "`" + `Prefer: respond-async` + "`" + ` to run\nit asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1297,7 +1408,7 @@ const docTemplate = `{
                 "tags": [
                     "[Migration] Infrastructure"
                 ],
-                "summary": "Delete the migrated mult-cloud infrastructure (MCI)",
+                "summary": "Delete the migrated mult-cloud infrastructure (MCI) (sync by default; async via Prefer: respond-async)",
                 "operationId": "DeleteInfra",
                 "parameters": [
                     {
@@ -1332,6 +1443,15 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this deletion asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -1339,6 +1459,12 @@ const docTemplate = `{
                         "description": "The result of deleting the migrated multi-cloud infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "202": {
+                        "description": "Deletion started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "404": {
@@ -1352,13 +1478,19 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
                     }
                 }
             }
         },
         "/migration/ns/{nsId}/infraWithDefaults": {
             "post": {
-                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.",
+                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\nBy default this API runs synchronously. Send header ` + "`" + `Prefer: respond-async` + "`" + ` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1368,7 +1500,7 @@ const docTemplate = `{
                 "tags": [
                     "[Migration] Infrastructure"
                 ],
-                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults",
+                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults (sync by default; async via Prefer: respond-async)",
                 "operationId": "MigrateInfraWithDefaults",
                 "parameters": [
                     {
@@ -1393,6 +1525,15 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -1402,8 +1543,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/model.ApiResponse-controller_MigrateInfraWithDefaultsResponse"
                         }
                     },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -2748,6 +2901,15 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2755,6 +2917,12 @@ const docTemplate = `{
                         "description": "Successfully recommended infrastructure candidates",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
@@ -2765,6 +2933,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -2822,6 +2996,15 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2829,6 +3012,12 @@ const docTemplate = `{
                         "description": "The result of recommended infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-controller_RecommendInfraWithDefaultsResponse"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "404": {
@@ -2839,6 +3028,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -2910,6 +3105,15 @@ const docTemplate = `{
                         "description": "Unique request ID (auto-generated if not provided)",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2917,6 +3121,12 @@ const docTemplate = `{
                         "description": "NLB-aware recommendation candidates",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
@@ -2927,6 +3137,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -56,7 +56,7 @@
         },
         "/migration/data": {
             "post": {
-                "description": "**Asynchronous Operation**: This API returns immediately with a request ID. The actual migration runs in the background.\n\n[How to Use]\n1. Call this API → Receive 202 Accepted with reqId\n2. Poll GET /request/{reqId} to check status\n3. Status flow: Handling → Success / Error\n\n[Endpoint Requirements]\n* Both source and destination must be remote endpoints (SSH or object storage)\n* Local filesystem access is not allowed for security reasons\n\n[Transfer Options]\n* Strategy: auto (default), direct, relay\n* SSH: Supports PrivateKey content or PrivateKeyPath\n\n[Encryption Support]\n* To encrypt sensitive fields, first call GET /migration/data/encryptionKey\n* Encrypted requests include `encryptionKeyId` field\n* Server automatically detects and decrypts encrypted requests\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
+                "description": "By default this API runs synchronously and returns the migration result directly.\n\n[Async Operation (opt-in)]\n1. Send header `Prefer: respond-async` → Receive 202 Accepted with reqId\n2. Poll GET /request/{reqId} to check status\n3. Status flow: Handling → Success / Error\n* Only the \"respond-async\" preference token is recognized; other tokens (e.g. wait=N) are ignored.\n* If too many async jobs are already running, this returns 503 instead of 202; retry after the `Retry-After` seconds.\n\n[Endpoint Requirements]\n* Both source and destination must be remote endpoints (SSH or object storage)\n* Local filesystem access is not allowed for security reasons\n\n[Transfer Options]\n* Strategy: auto (default), direct, relay\n* SSH: Supports PrivateKey content or PrivateKeyPath\n\n[Encryption Support]\n* To encrypt sensitive fields, first call GET /migration/data/encryptionKey\n* Encrypted requests include `encryptionKeyId` field\n* Server automatically detects and decrypts encrypted requests\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
                 "consumes": [
                     "application/json"
                 ],
@@ -66,13 +66,22 @@
                 "tags": [
                     "[Migration] Data (incubating)"
                 ],
-                "summary": "[Async] Migrate data from source to target",
+                "summary": "Migrate data from source to target (sync by default; async via Prefer: respond-async)",
                 "operationId": "MigrateData",
                 "parameters": [
                     {
                         "type": "string",
                         "description": "Unique request ID (auto-generated if not provided). Used as reqId for tracking migration status.",
                         "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
                         "in": "header"
                     },
                     {
@@ -86,14 +95,32 @@
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "Migration completed synchronously",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
                     "202": {
-                        "description": "Migration started - use GET /request/{reqId} to check status",
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request parameters or decryption failed",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Migration failed",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -298,7 +325,7 @@
                 }
             },
             "post": {
-                "description": "Migrate NLBs to the target cloud infra based on recommendation results.\n\n[Prerequisites]\n- The target Namespace (nsId) must exist.\n- The target Infra (infraId) must exist and have at least one NodeGroup in Running state.\n- Each `targetNlbList[].targetGroup.nodeGroupId` must reference an existing NodeGroup in the Infra.\n\n[Note] Input should be the `targetNlbList` field from the POST /recommendation/infraWithNlb response.\nEnsure `targetGroup.nodeGroupId` matches the NodeGroup IDs created during infra migration.\n\n[Note] All NLBs are attempted independently. Partial success is possible.",
+                "description": "Migrate NLBs to the target cloud infra based on recommendation results.\n\n[Prerequisites]\n- The target Namespace (nsId) must exist.\n- The target Infra (infraId) must exist and have at least one NodeGroup in Running state.\n- Each `targetNlbList[].targetGroup.nodeGroupId` must reference an existing NodeGroup in the Infra.\n\n[Note] Input should be the `targetNlbList` field from the POST /recommendation/infraWithNlb response.\nEnsure `targetGroup.nodeGroupId` matches the NodeGroup IDs created during infra migration.\n\n[Note] All NLBs are attempted independently. Partial success is possible.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -346,6 +373,15 @@
                         "description": "Unique request ID (auto-generated if not provided)",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -353,6 +389,12 @@
                         "description": "NLBs created successfully",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-cloudmodel_MigratedNlbResult"
+                        }
+                    },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
@@ -363,6 +405,12 @@
                     },
                     "500": {
                         "description": "Internal server error during NLB creation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -442,7 +490,7 @@
                 }
             },
             "delete": {
-                "description": "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.",
+                "description": "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.\n\nBy default this API runs synchronously (always includes the 15s settle wait). Send header\n`Prefer: respond-async` to run it asynchronously instead: receive 202 Accepted with a reqId,\nthen poll GET /request/{reqId} (status flow: Handling → Success / Error).",
                 "consumes": [
                     "application/json"
                 ],
@@ -482,9 +530,24 @@
                         "description": "Unique request ID",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this deletion asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
+                    "202": {
+                        "description": "Deletion started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
                     "204": {
                         "description": "NLB deleted (includes 15s settle wait for CSP async cleanup)"
                     },
@@ -496,6 +559,12 @@
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -627,7 +696,7 @@
                 }
             },
             "post": {
-                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note]\n- This API creates object storages (buckets) in the target cloud within the specified namespace\n- Input should be the output from RecommendObjectStorage API\n- Connection name is automatically generated from CSP and region in the request body\n\n[Note] `nameSeed` enables dynamic naming via **Late Binding**.\n- If `nameSeed` query param is set (e.g., `?nameSeed=my`), bucket names are prefixed at migration time: `my-os-01`.\n- If `nameSeed` is omitted, bucket names are used as-is from the recommendation result.\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n",
+                "description": "Migrate object storages to cloud based on recommendation results\n\n[Note]\n- This API creates object storages (buckets) in the target cloud within the specified namespace\n- Input should be the output from RecommendObjectStorage API\n- Connection name is automatically generated from CSP and region in the request body\n\n[Note] `nameSeed` enables dynamic naming via **Late Binding**.\n- If `nameSeed` query param is set (e.g., `?nameSeed=my`), bucket names are prefixed at migration time: `my-os-01`.\n- If `nameSeed` is omitted, bucket names are used as-is from the recommendation result.\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -668,11 +737,26 @@
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
                     "201": {
                         "description": "Created - Object storages created successfully"
+                    },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
                     },
                     "400": {
                         "description": "Invalid request parameters",
@@ -682,6 +766,12 @@
                     },
                     "500": {
                         "description": "Internal server error during object storage creation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -1150,7 +1240,7 @@
                 }
             },
             "post": {
-                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\n**[Request Field: `nodeGroups[].cspImageName`]** Optional CSP-native image identifier.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup (may encounter stale images for some CSPs).\n- Recommended: pass the recommendation API response as-is to use the latest resolved image.",
+                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\n**[Request Field: `nodeGroups[].cspImageName`]** Optional CSP-native image identifier.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup (may encounter stale images for some CSPs).\n- Recommended: pass the recommendation API response as-is to use the latest resolved image.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1160,7 +1250,7 @@
                 "tags": [
                     "[Migration] Infrastructure"
                 ],
-                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults",
+                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults (sync by default; async via Prefer: respond-async)",
                 "operationId": "MigrateInfra",
                 "parameters": [
                     {
@@ -1197,6 +1287,15 @@
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -1204,6 +1303,12 @@
                         "description": "Successfully migrated to the multi-cloud infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-controller_MigrateInfraResponse"
+                        }
+                    },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "404": {
@@ -1214,6 +1319,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -1281,7 +1392,7 @@
                 }
             },
             "delete": {
-                "description": "Delete the migrated mult-cloud infrastructure (MCI)",
+                "description": "Delete the migrated mult-cloud infrastructure (MCI).\n\nThis operation can take a long time (multiple settle-time waits and vNet-deletion\nretries). By default it runs synchronously. Send header `Prefer: respond-async` to run\nit asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1291,7 +1402,7 @@
                 "tags": [
                     "[Migration] Infrastructure"
                 ],
-                "summary": "Delete the migrated mult-cloud infrastructure (MCI)",
+                "summary": "Delete the migrated mult-cloud infrastructure (MCI) (sync by default; async via Prefer: respond-async)",
                 "operationId": "DeleteInfra",
                 "parameters": [
                     {
@@ -1326,6 +1437,15 @@
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this deletion asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -1333,6 +1453,12 @@
                         "description": "The result of deleting the migrated multi-cloud infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "202": {
+                        "description": "Deletion started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "404": {
@@ -1346,13 +1472,19 @@
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
                     }
                 }
             }
         },
         "/migration/ns/{nsId}/infraWithDefaults": {
             "post": {
-                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.",
+                "description": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1362,7 +1494,7 @@
                 "tags": [
                     "[Migration] Infrastructure"
                 ],
-                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults",
+                "summary": "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults (sync by default; async via Prefer: respond-async)",
                 "operationId": "MigrateInfraWithDefaults",
                 "parameters": [
                     {
@@ -1387,6 +1519,15 @@
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this migration asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -1396,8 +1537,20 @@
                             "$ref": "#/definitions/model.ApiResponse-controller_MigrateInfraWithDefaultsResponse"
                         }
                     },
+                    "202": {
+                        "description": "Migration started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -2742,6 +2895,15 @@
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2749,6 +2911,12 @@
                         "description": "Successfully recommended infrastructure candidates",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
@@ -2759,6 +2927,12 @@
                     },
                     "500": {
                         "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -2816,6 +2990,15 @@
                         "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2823,6 +3006,12 @@
                         "description": "The result of recommended infrastructure",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-controller_RecommendInfraWithDefaultsResponse"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "404": {
@@ -2833,6 +3022,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }
@@ -2904,6 +3099,15 @@
                         "description": "Unique request ID (auto-generated if not provided)",
                         "name": "X-Request-Id",
                         "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2911,6 +3115,12 @@
                         "description": "NLB-aware recommendation candidates",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
                         }
                     },
                     "400": {
@@ -2921,6 +3131,12 @@
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
                         "schema": {
                             "$ref": "#/definitions/model.ApiResponse-any"
                         }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5316,12 +5316,14 @@ paths:
       consumes:
       - application/json
       description: |
-        **Asynchronous Operation**: This API returns immediately with a request ID. The actual migration runs in the background.
+        By default this API runs synchronously and returns the migration result directly.
 
-        [How to Use]
-        1. Call this API → Receive 202 Accepted with reqId
+        [Async Operation (opt-in)]
+        1. Send header `Prefer: respond-async` → Receive 202 Accepted with reqId
         2. Poll GET /request/{reqId} to check status
         3. Status flow: Handling → Success / Error
+        * Only the "respond-async" preference token is recognized; other tokens (e.g. wait=N) are ignored.
+        * If too many async jobs are already running, this returns 503 instead of 202; retry after the `Retry-After` seconds.
 
         [Endpoint Requirements]
         * Both source and destination must be remote endpoints (SSH or object storage)
@@ -5345,6 +5347,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this migration asynchronously (RFC
+          7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       - description: Data migration request (supports plaintext or encrypted with
           encryptionKeyId)
         in: body
@@ -5355,15 +5364,30 @@ paths:
       produces:
       - application/json
       responses:
+        "200":
+          description: Migration completed synchronously
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
         "202":
-          description: Migration started - use GET /request/{reqId} to check status
+          description: Migration started asynchronously - use GET /request/{reqId}
+            to check status
           schema:
             $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "400":
           description: Invalid request parameters or decryption failed
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
-      summary: '[Async] Migrate data from source to target'
+        "500":
+          description: Migration failed
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: 'Migrate data from source to target (sync by default; async via Prefer:
+        respond-async)'
       tags:
       - '[Migration] Data (incubating)'
   /migration/data/encryptionKey:
@@ -5561,6 +5585,10 @@ paths:
         Ensure `targetGroup.nodeGroupId` matches the NodeGroup IDs created during infra migration.
 
         [Note] All NLBs are attempted independently. Partial success is possible.
+
+        By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+        asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+        (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
       operationId: MigrateNlbs
       parameters:
       - default: mig01
@@ -5589,6 +5617,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this migration asynchronously (RFC
+          7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
@@ -5596,12 +5631,22 @@ paths:
           description: NLBs created successfully
           schema:
             $ref: '#/definitions/model.ApiResponse-cloudmodel_MigratedNlbResult'
+        "202":
+          description: Migration started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "400":
           description: Invalid request parameters
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
         "500":
           description: Internal server error during NLB creation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
       summary: (Preview) Migrate NLBs to a cloud infra
@@ -5617,6 +5662,10 @@ paths:
         [Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.
         Deleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).
         CM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.
+
+        By default this API runs synchronously (always includes the 15s settle wait). Send header
+        `Prefer: respond-async` to run it asynchronously instead: receive 202 Accepted with a reqId,
+        then poll GET /request/{reqId} (status flow: Handling → Success / Error).
       operationId: DeleteNlb
       parameters:
       - default: mig01
@@ -5639,9 +5688,21 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this deletion asynchronously (RFC
+          7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
+        "202":
+          description: Deletion started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "204":
           description: NLB deleted (includes 15s settle wait for CSP async cleanup)
         "400":
@@ -5650,6 +5711,11 @@ paths:
             $ref: '#/definitions/model.ApiResponse-any'
         "500":
           description: Internal server error
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
       summary: Delete an NLB
@@ -5794,7 +5860,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: |
+      description: |-
         Migrate object storages to cloud based on recommendation results
 
         [Note]
@@ -5808,6 +5874,10 @@ paths:
 
         [Examples]
         * Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md
+
+        By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+        asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+        (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
       operationId: MigrateObjectStorage
       parameters:
       - default: mig01
@@ -5833,17 +5903,34 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this migration asynchronously (RFC
+          7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
         "201":
           description: Created - Object storages created successfully
+        "202":
+          description: Migration started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "400":
           description: Invalid request parameters
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
         "500":
           description: Internal server error during object storage creation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
       summary: Migrate object storages to cloud
@@ -6198,6 +6285,10 @@ paths:
         - **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).
         - **Empty**: TumbleBug uses `imageId` for the standard DB lookup (may encounter stale images for some CSPs).
         - Recommended: pass the recommendation API response as-is to use the latest resolved image.
+
+        By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+        asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+        (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
       operationId: MigrateInfra
       parameters:
       - default: mig01
@@ -6227,6 +6318,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this migration asynchronously (RFC
+          7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
@@ -6234,6 +6332,11 @@ paths:
           description: Successfully migrated to the multi-cloud infrastructure
           schema:
             $ref: '#/definitions/model.ApiResponse-controller_MigrateInfraResponse'
+        "202":
+          description: Migration started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "404":
           description: Not Found
           schema:
@@ -6242,15 +6345,26 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
-      summary: Migrate an infrastructure to the multi-cloud infrastructure (MCI) with
-        defaults
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: 'Migrate an infrastructure to the multi-cloud infrastructure (MCI)
+        with defaults (sync by default; async via Prefer: respond-async)'
       tags:
       - '[Migration] Infrastructure'
   /migration/ns/{nsId}/infra/{infraId}:
     delete:
       consumes:
       - application/json
-      description: Delete the migrated mult-cloud infrastructure (MCI)
+      description: |-
+        Delete the migrated mult-cloud infrastructure (MCI).
+
+        This operation can take a long time (multiple settle-time waits and vNet-deletion
+        retries). By default it runs synchronously. Send header `Prefer: respond-async` to run
+        it asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+        (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
       operationId: DeleteInfra
       parameters:
       - default: mig01
@@ -6279,6 +6393,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this deletion asynchronously (RFC
+          7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
@@ -6286,6 +6407,11 @@ paths:
           description: The result of deleting the migrated multi-cloud infrastructure
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
+        "202":
+          description: Deletion started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "404":
           description: Not Found
           schema:
@@ -6294,7 +6420,13 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
-      summary: Delete the migrated mult-cloud infrastructure (MCI)
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: 'Delete the migrated mult-cloud infrastructure (MCI) (sync by default;
+        async via Prefer: respond-async)'
       tags:
       - '[Migration] Infrastructure'
     get:
@@ -6343,8 +6475,12 @@ paths:
     post:
       consumes:
       - application/json
-      description: Migrate an infrastructure to the multi-cloud infrastructure (MCI)
-        with defaults.
+      description: |-
+        Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.
+
+        By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+        asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+        (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
       operationId: MigrateInfraWithDefaults
       parameters:
       - default: mig01
@@ -6365,6 +6501,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this migration asynchronously (RFC
+          7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
@@ -6372,12 +6515,22 @@ paths:
           description: Successfully migrated to the multi-cloud infrastructure
           schema:
             $ref: '#/definitions/model.ApiResponse-controller_MigrateInfraWithDefaultsResponse'
+        "202":
+          description: Migration started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
-      summary: Migrate an infrastructure to the multi-cloud infrastructure (MCI) with
-        defaults
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: 'Migrate an infrastructure to the multi-cloud infrastructure (MCI)
+        with defaults (sync by default; async via Prefer: respond-async)'
       tags:
       - '[Migration] Infrastructure'
   /migration/ns/{nsId}/resources/securityGroup:
@@ -7342,6 +7495,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this recommendation asynchronously
+          (RFC 7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
@@ -7349,12 +7509,22 @@ paths:
           description: Successfully recommended infrastructure candidates
           schema:
             $ref: '#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra'
+        "202":
+          description: Recommendation started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "400":
           description: Invalid request parameters
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
         "500":
           description: Internal server error during recommendation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
       summary: Recommend multiple VM infrastructure candidates for cloud migration
@@ -7404,6 +7574,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this recommendation asynchronously
+          (RFC 7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
@@ -7411,12 +7588,22 @@ paths:
           description: The result of recommended infrastructure
           schema:
             $ref: '#/definitions/model.ApiResponse-controller_RecommendInfraWithDefaultsResponse'
+        "202":
+          description: Recommendation started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "404":
           description: Not Found
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
       summary: (To be updated) Recommend an appropriate VM infrastructure (i.e., MCI,
@@ -7503,6 +7690,13 @@ paths:
         in: header
         name: X-Request-Id
         type: string
+      - description: Set to 'respond-async' to run this recommendation asynchronously
+          (RFC 7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
       produces:
       - application/json
       responses:
@@ -7510,12 +7704,22 @@ paths:
           description: NLB-aware recommendation candidates
           schema:
             $ref: '#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra'
+        "202":
+          description: Recommendation started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
         "400":
           description: Invalid request
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
         "500":
           description: Internal server error
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
           schema:
             $ref: '#/definitions/model.ApiResponse-any'
       summary: (Preview) Recommend infrastructure candidates with NLB for cloud migration

--- a/cmd/test-cli/async/main.go
+++ b/cmd/test-cli/async/main.go
@@ -1,0 +1,338 @@
+// Package main is the starting point of CM-Beetle Async Response Test CLI.
+//
+// Exercises the core async flow (Prefer: respond-async -> 202 -> poll GET /request/{reqId})
+// end to end: Recommend -> Poll -> Get -> Migrate -> Poll -> Get -> Delete -> Poll -> Get.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cloud-barista/cm-beetle/pkg/config"
+	"github.com/cloud-barista/cm-beetle/pkg/logger"
+)
+
+// restyNoopLogger silences all Resty log output (e.g. "Basic Auth in HTTP mode" warnings).
+type restyNoopLogger struct{}
+
+func (restyNoopLogger) Errorf(_ string, _ ...interface{}) {}
+func (restyNoopLogger) Warnf(_ string, _ ...interface{})  {}
+func (restyNoopLogger) Debugf(_ string, _ ...interface{}) {}
+
+// TestConfig holds the test configuration from test-config.yaml.
+type TestConfig struct {
+	Beetle struct {
+		Endpoint        string `yaml:"endpoint"`
+		NamespaceID     string `yaml:"namespaceId"`
+		RequestBodyFile string `yaml:"requestBodyFile"`
+		AuthConfigFile  string `yaml:"authConfigFile"`
+	} `yaml:"beetle"`
+	Poll struct {
+		IntervalSec int `yaml:"intervalSec"` // fixed poll interval
+		TimeoutSec  int `yaml:"timeoutSec"`
+	} `yaml:"poll"`
+}
+
+// AuthConfig holds Beetle API credentials.
+type AuthConfig struct {
+	BeetleApiUsername string `json:"beetleApiUsername"`
+	BeetleApiPassword string `json:"beetleApiPassword"`
+}
+
+// ApiResponse mirrors model.ApiResponse[T] — only the fields this CLI needs.
+type ApiResponse struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data"`
+	Message string          `json:"message,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+// AsyncJobData mirrors model.AsyncJobResponse.
+type AsyncJobData struct {
+	ReqID     string `json:"reqId"`
+	Status    string `json:"status"`
+	StatusURL string `json:"statusUrl"`
+}
+
+// RequestDetails mirrors the fields of common.RequestDetails this CLI reads.
+type RequestDetails struct {
+	Status        string          `json:"status"`
+	ResponseData  json.RawMessage `json:"responseData"`
+	ErrorResponse string          `json:"errorResponse"`
+}
+
+var configFile = flag.String("config", "testconf/test-config.yaml", "Path to config file")
+
+func init() {
+	config.Init()
+	l := logger.NewLogger(logger.Config{
+		LogLevel:    config.Beetle.LogLevel,
+		LogWriter:   config.Beetle.LogWriter,
+		LogFilePath: config.Beetle.LogFile.Path,
+		MaxSize:     config.Beetle.LogFile.MaxSize,
+		MaxBackups:  config.Beetle.LogFile.MaxBackups,
+		MaxAge:      config.Beetle.LogFile.MaxAge,
+		Compress:    config.Beetle.LogFile.Compress,
+	})
+	log.Logger = *l
+}
+
+func main() {
+	flag.Parse()
+
+	cfg, err := loadConfig(*configFile)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to load config")
+	}
+
+	auth, err := loadAuthConfig(cfg.Beetle.AuthConfigFile)
+	if err != nil {
+		fmt.Printf("(no auth config loaded: %v — proceeding without auth)\n", err)
+	}
+
+	client := resty.New().SetTimeout(30 * time.Second).SetLogger(restyNoopLogger{})
+	if auth.BeetleApiUsername != "" {
+		client.SetBasicAuth(auth.BeetleApiUsername, auth.BeetleApiPassword)
+	}
+
+	intervalSec := cfg.Poll.IntervalSec
+	if intervalSec <= 0 {
+		intervalSec = 10
+	}
+	timeoutSec := cfg.Poll.TimeoutSec
+	if timeoutSec <= 0 {
+		timeoutSec = 300
+	}
+
+	endpoint := cfg.Beetle.Endpoint
+	nsId := cfg.Beetle.NamespaceID
+
+	fmt.Println("=========================================================")
+	fmt.Println(" CM-Beetle Async Response Test CLI")
+	fmt.Println(" Recommend -> Poll -> Get -> Migrate -> Poll -> Get -> Delete -> Poll -> Get")
+	fmt.Println("=========================================================")
+
+	// [1/9] Recommend (async)
+	fmt.Println("\n[1/9] POST /recommendation/infra (Prefer: respond-async)")
+	reqBody, err := os.ReadFile(cfg.Beetle.RequestBodyFile)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to read request body file")
+	}
+	recReqID := postAsync(client, endpoint+"/recommendation/infra", reqBody)
+	fmt.Printf("      -> 202 Accepted, reqId=%s\n", recReqID)
+
+	// [2/9] Poll
+	fmt.Println("\n[2/9] Poll GET /request/{reqId} (recommendation)")
+	recDetails := pollUntilDone(client, endpoint, recReqID, intervalSec, timeoutSec)
+	if recDetails.Status != "Success" {
+		log.Fatal().Str("status", recDetails.Status).Str("error", recDetails.ErrorResponse).Msg("recommendation did not succeed")
+	}
+	fmt.Printf("      -> status: %s\n", recDetails.Status)
+
+	// [3/9] "Get" — recommendation results only exist inside the polled response; inspect them here.
+	fmt.Println("\n[3/9] Inspect recommendation result")
+	var candidates []json.RawMessage
+	if err := json.Unmarshal(recDetails.ResponseData, &candidates); err != nil {
+		log.Fatal().Err(err).Msg("failed to parse recommendation candidates")
+	}
+	if len(candidates) == 0 {
+		log.Fatal().Msg("no recommendation candidates returned")
+	}
+	candidate := candidates[0]
+	fmt.Printf("      -> %d candidate(s) recommended; using candidate #1 for migration\n", len(candidates))
+
+	// [4/9] Migrate (async) — the recommended candidate JSON is posted as-is (RecommendedInfra shape).
+	fmt.Println("\n[4/9] POST /migration/ns/{nsId}/infra (Prefer: respond-async)")
+	migrateURL := fmt.Sprintf("%s/migration/ns/%s/infra", endpoint, nsId)
+	migReqID := postAsync(client, migrateURL, candidate)
+	fmt.Printf("      -> 202 Accepted, reqId=%s\n", migReqID)
+
+	// [5/9] Poll
+	fmt.Println("\n[5/9] Poll GET /request/{reqId} (migration)")
+	migDetails := pollUntilDone(client, endpoint, migReqID, intervalSec, timeoutSec)
+	if migDetails.Status != "Success" {
+		log.Fatal().Str("status", migDetails.Status).Str("error", migDetails.ErrorResponse).Msg("migration did not succeed")
+	}
+	fmt.Printf("      -> status: %s\n", migDetails.Status)
+
+	var infraInfo struct {
+		Id string `json:"id"`
+	}
+	if err := json.Unmarshal(migDetails.ResponseData, &infraInfo); err != nil {
+		log.Fatal().Err(err).Msg("failed to parse migrated infra info")
+	}
+	infraId := infraInfo.Id
+	if infraId == "" {
+		log.Fatal().Msg("migrated infra has no id")
+	}
+	fmt.Printf("      -> infraId: %s\n", infraId)
+
+	// [6/9] Get
+	fmt.Println("\n[6/9] GET /migration/ns/{nsId}/infra/{infraId}")
+	getURL := fmt.Sprintf("%s/migration/ns/%s/infra/%s", endpoint, nsId, infraId)
+	getResp, err := client.R().Get(getURL)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to get migrated infra")
+	}
+	fmt.Printf("      -> HTTP %d: %s\n", getResp.StatusCode(), truncate(string(getResp.Body()), 300))
+
+	// [7/9] Delete (async)
+	fmt.Println("\n[7/9] DELETE /migration/ns/{nsId}/infra/{infraId} (Prefer: respond-async)")
+	delReqID := deleteAsync(client, getURL+"?option=terminate")
+	fmt.Printf("      -> 202 Accepted, reqId=%s\n", delReqID)
+
+	// [8/9] Poll
+	fmt.Println("\n[8/9] Poll GET /request/{reqId} (deletion)")
+	delDetails := pollUntilDone(client, endpoint, delReqID, intervalSec, timeoutSec)
+	if delDetails.Status != "Success" {
+		log.Fatal().Str("status", delDetails.Status).Str("error", delDetails.ErrorResponse).Msg("deletion did not succeed")
+	}
+	fmt.Printf("      -> status: %s\n", delDetails.Status)
+
+	// [9/9] Get again — expect 404, confirming the infra is gone.
+	fmt.Println("\n[9/9] GET /migration/ns/{nsId}/infra/{infraId} (expect 404)")
+	confirmResp, err := client.R().Get(getURL)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to confirm deletion")
+	}
+	if confirmResp.StatusCode() == http.StatusNotFound {
+		fmt.Println("      -> HTTP 404: deletion confirmed")
+	} else {
+		fmt.Printf("      -> HTTP %d (expected 404): %s\n", confirmResp.StatusCode(), truncate(string(confirmResp.Body()), 300))
+	}
+
+	fmt.Println("\n=========================================================")
+	fmt.Println(" Done.")
+	fmt.Println("=========================================================")
+}
+
+// postAsync sends req body as a POST with Prefer: respond-async and returns the reqId from a 202 response.
+func postAsync(client *resty.Client, url string, body []byte) string {
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Prefer", "respond-async").
+		SetBody(body).
+		Post(url)
+	if err != nil {
+		log.Fatal().Err(err).Str("url", url).Msg("async request failed")
+	}
+	if resp.StatusCode() != http.StatusAccepted {
+		log.Fatal().Int("status", resp.StatusCode()).Str("body", string(resp.Body())).Msg("expected 202 Accepted")
+	}
+	return extractReqID(resp)
+}
+
+// deleteAsync sends a DELETE with Prefer: respond-async and returns the reqId from a 202 response.
+func deleteAsync(client *resty.Client, url string) string {
+	resp, err := client.R().
+		SetHeader("Prefer", "respond-async").
+		Delete(url)
+	if err != nil {
+		log.Fatal().Err(err).Str("url", url).Msg("async request failed")
+	}
+	if resp.StatusCode() != http.StatusAccepted {
+		log.Fatal().Int("status", resp.StatusCode()).Str("body", string(resp.Body())).Msg("expected 202 Accepted")
+	}
+	return extractReqID(resp)
+}
+
+func extractReqID(resp *resty.Response) string {
+	var apiResp ApiResponse
+	if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+		log.Fatal().Err(err).Msg("failed to parse async job response")
+	}
+	var job AsyncJobData
+	if err := json.Unmarshal(apiResp.Data, &job); err != nil {
+		log.Fatal().Err(err).Msg("failed to parse async job data")
+	}
+	if job.ReqID == "" {
+		job.ReqID = resp.Header().Get("X-Request-Id")
+	}
+	if job.ReqID == "" {
+		log.Fatal().Msg("no reqId in async job response")
+	}
+	return job.ReqID
+}
+
+// pollUntilDone polls GET /request/{reqId} on a fixed interval until status is Success or
+// Error, or timeoutSec elapses.
+func pollUntilDone(client *resty.Client, endpoint, reqID string, intervalSec, timeoutSec int) RequestDetails {
+	statusURL := fmt.Sprintf("%s/request/%s", endpoint, reqID)
+	start := time.Now()
+	deadline := start.Add(time.Duration(timeoutSec) * time.Second)
+	attempt := 0
+	interval := time.Duration(intervalSec) * time.Second
+
+	for time.Now().Before(deadline) {
+		time.Sleep(interval)
+		attempt++
+		elapsed := time.Since(start).Round(time.Second)
+
+		resp, err := client.R().Get(statusURL)
+		if err != nil {
+			fmt.Printf("      ... [%s elapsed, poll #%d] request error: %v\n", elapsed, attempt, err)
+			continue
+		}
+
+		var apiResp ApiResponse
+		if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+			fmt.Printf("      ... [%s elapsed, poll #%d] parse error: %v\n", elapsed, attempt, err)
+			continue
+		}
+		var details RequestDetails
+		if err := json.Unmarshal(apiResp.Data, &details); err != nil {
+			fmt.Printf("      ... [%s elapsed, poll #%d] parse error: %v\n", elapsed, attempt, err)
+			continue
+		}
+
+		fmt.Printf("      ... [%s elapsed, poll #%d] status: %s\n", elapsed, attempt, details.Status)
+		if details.Status == "Success" || details.Status == "Error" {
+			return details
+		}
+	}
+
+	log.Fatal().Str("reqId", reqID).Msg("polling timed out")
+	return RequestDetails{}
+}
+
+func loadConfig(path string) (TestConfig, error) {
+	var cfg TestConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, err
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func loadAuthConfig(path string) (AuthConfig, error) {
+	var auth AuthConfig
+	if path == "" {
+		return auth, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return auth, err
+	}
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return auth, err
+	}
+	return auth, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/cmd/test-cli/async/testconf/recommendation-request.json
+++ b/cmd/test-cli/async/testconf/recommendation-request.json
@@ -1,0 +1,1848 @@
+{
+  "desiredCspAndRegionPair": {
+    "csp": "aws",
+    "region": "ap-northeast-2"
+  },
+  "nameSeed": "my",
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "defaultGateways": [
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec268ed7-821e-9d73-e79f-961262161624"
+          },
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932"
+          },
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 1,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+          "threads": 2,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "5432",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9113",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9113",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "5432",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-30",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.30/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::6f:deff:fefc:71b1/64"
+            ],
+            "macAddress": "02:6f:de:fc:71:b1",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec268ed7-821e-9d73-e79f-961262161624",
+        "memory": {
+          "available": 1,
+          "totalSize": 2,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 0,
+          "type": ""
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::6f:deff:fefc:71b1/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      },
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 2,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
+          "threads": 4,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "2049",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "2049",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "111",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "111",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "20048",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "20048",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "32803",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "32803",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9100",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9100",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "2049",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "2049",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "111",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "111",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-221",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.221/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::8:96ff:fe7d:f417/64"
+            ],
+            "macAddress": "02:08:96:7d:f4:17",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+        "memory": {
+          "available": 15,
+          "totalSize": 16,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 0,
+          "type": ""
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::8:96ff:fe7d:f417/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      },
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 1,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+          "threads": 2,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4567",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4567",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4568",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4568",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4444",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4444",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9104",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9104",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-138",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.138/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::bf:6eff:fe6c:6e31/64"
+            ],
+            "macAddress": "02:bf:6e:6c:6e:31",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+        "memory": {
+          "available": 7,
+          "totalSize": 8,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 0,
+          "type": ""
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::bf:6eff:fe6c:6e31/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cmd/test-cli/async/testconf/template-auth-config.json
+++ b/cmd/test-cli/async/testconf/template-auth-config.json
@@ -1,0 +1,4 @@
+{
+  "beetleApiUsername": "default",
+  "beetleApiPassword": "default"
+}

--- a/cmd/test-cli/async/testconf/template-test-config.yaml
+++ b/cmd/test-cli/async/testconf/template-test-config.yaml
@@ -1,0 +1,9 @@
+beetle:
+  endpoint: http://localhost:8056/beetle
+  namespaceId: mig01
+  requestBodyFile: testconf/recommendation-request.json
+  authConfigFile: testconf/auth-config.json
+
+poll:
+  intervalSec: 10  # fixed poll interval
+  timeoutSec: 300

--- a/cmd/test-cli/data/main.go
+++ b/cmd/test-cli/data/main.go
@@ -869,6 +869,7 @@ func runMigrateDataStep(
 
 	var asyncResp AsyncJobResponseWrapper
 	resp, err := client.R().
+		SetHeader("Prefer", "respond-async").
 		SetBody(encModel).
 		SetResult(&asyncResp).
 		Post(url)

--- a/docs/api-response-policy.md
+++ b/docs/api-response-policy.md
@@ -8,9 +8,11 @@ This document outlines the policies for API response codes, success messages, an
 | :--- | :--- | :--- |
 | **200 OK** | Success | Standard response for successful GET, PUT, DELETE operations. |
 | **201 Created** | Created | Standard response for successful POST operations resulting in resource creation. |
+| **202 Accepted** | Async job accepted | Reserved repo-wide for async responses (see [Async Responses](#async-responses)). Never return 202 for any other reason. |
 | **400 Bad Request** | Bad Request | Invalid input parameters or request body. |
 | **404 Not Found** | Not Found | Resource does not exist. Used for GET, DELETE, etc., when the target ID is invalid. |
 | **500 Internal Server Error** | Server Error | Unexpected server-side errors. |
+| **503 Service Unavailable** | At capacity | Returned by async-capable endpoints when too many async jobs are already running (see [Async Responses](#async-responses)). |
 
 ## Response Body
 
@@ -27,3 +29,17 @@ This document outlines the policies for API response codes, success messages, an
 ## Proxy Behavior
 - **Status Code Preservation**: When proxying requests to Tumblebug or other services, the proxy **must** preserve the upstream HTTP status code.
 - **Transparency**: Do not override specific upstream codes (like `404`) with generic codes (like `500`) unless it is a true internal proxy error.
+
+## Async Responses
+
+Some long-running APIs (data/infra migration, recommendation) support an optional asynchronous mode.
+
+- **Opt-in**: send header `Prefer: respond-async`. Without it, the API responds synchronously as usual.
+  Only the `respond-async` token is recognized; other `Prefer` tokens (e.g. `wait=N`) are ignored.
+- **Accepted**: `202` with `{reqId, status: "Handling", statusUrl}` and header `Preference-Applied: respond-async`.
+- **Poll**: `GET /request/{reqId}` until `status` is `Success` or `Error`.
+- **At capacity**: `503` if too many async jobs are already running (process-wide limit, currently 20),
+  with a `Retry-After` header. The sync path is never affected by this limit.
+- **Implementation**: handlers use `common.RunAsync` (`pkg/core/common/request-manager.go`), which finalizes
+  the request record itself. Middleware skips status finalization for any `202` response — this is why
+  `202` must never be returned for a non-async reason.

--- a/docs/feature-guide/async-responses.md
+++ b/docs/feature-guide/async-responses.md
@@ -1,0 +1,63 @@
+# Async Responses
+
+## What is it?
+
+Long-running migration and recommendation APIs support an optional asynchronous mode. By default they
+respond synchronously, exactly as before. Send `Prefer: respond-async` to get an immediate `202
+Accepted` instead, then poll for completion.
+
+## How to Use It
+
+```
+POST /beetle/recommendation/infra
+Prefer: respond-async
+
+→ 202 Accepted
+  Preference-Applied: respond-async
+  { "reqId": "...", "status": "Handling", "statusUrl": "/beetle/request/{reqId}" }
+```
+
+```
+GET /beetle/request/{reqId}
+
+→ { "status": "Success" | "Error" | "Handling", ... }
+```
+
+Poll `GET /request/{reqId}` until `status` is `Success` or `Error`. Omit the `Prefer` header (or send
+any other value) to get the original synchronous response — nothing changes for existing callers.
+
+## Supported Endpoints
+
+| Endpoint | Notes |
+| --- | --- |
+| `POST /migration/data` | Sync by default (breaking change from earlier versions, which were always async) |
+| `POST /migration/ns/{nsId}/infra` | |
+| `POST /migration/ns/{nsId}/infraWithDefaults` | |
+| `DELETE /migration/ns/{nsId}/infra/{infraId}` | Worth using async — deletion includes several settle waits |
+| `POST /recommendation/infraWithNlb` | |
+| `POST /recommendation/infra` | |
+| `POST /recommendation/infraWithDefaults` | |
+| `POST /migration/middleware/ns/{nsId}/infra/{infraId}/nlb` | |
+| `DELETE /migration/middleware/ns/{nsId}/infra/{infraId}/nlb/{nlbId}` | Worth using async — includes a fixed 15s settle wait |
+| `POST /migration/middleware/ns/{nsId}/objectStorage` | |
+
+## Status Values
+
+| Status | Meaning |
+| --- | --- |
+| `Handling` | Still running |
+| `Success` | Completed; result in `responseData` |
+| `Error` | Failed; message in `errorResponse` |
+
+## Limits
+
+- At most 20 async jobs run concurrently (shared across all endpoints above). Beyond that, a request
+  returns `503` with a `Retry-After` header instead of `202` — retry after that delay, or retry without
+  `Prefer: respond-async` to run synchronously.
+- Only the `respond-async` preference token is recognized. Other `Prefer` tokens (e.g. `wait=N`) are
+  ignored — there is no time-bounded hybrid mode.
+
+## Related
+
+- [API Response Policy](../api-response-policy.md) — the underlying status-code and middleware contract
+- [Async Support Plan](../plan/async-support-plan-for-recommendation-migration-apis.md) — design background and implementation notes

--- a/docs/plan/async-support-plan-for-recommendation-migration-apis.md
+++ b/docs/plan/async-support-plan-for-recommendation-migration-apis.md
@@ -1,0 +1,529 @@
+# Plan: Optional Async Responses for Recommendation & Migration APIs
+
+## Overview
+
+Users need async responses for CM-Beetle APIs that take a long time to complete (VM provisioning,
+multi-region/multi-CSP recommendation lookups). CM-Beetle already has a working async pattern
+(`POST /migration/data`) and a request-tracking infrastructure (`GET /request/{reqId}`). This plan
+extends that same pattern to the recommendation and migration-infra APIs, **without breaking existing
+synchronous callers**.
+
+Status: All phases implemented — Phase 0 (Data), Phase 1 (migration infra, including DeleteInfra), Phase 2 (infraWithNlb), and Phase 3 (recommendation infra / infraWithDefaults). Extended beyond the original scope to `MigrateNlbs`, `DeleteNlb` (fixed 15s settle wait, [nlb.go:197-199](../../pkg/core/migration/nlb.go#L197-L199)), and `MigrateObjectStorage` (N buckets processed sequentially) after a latency review of Object Storage/NLB/individual-resource APIs — see [Extended Scope](#extended-scope-object-storage--nlb) below. `RecommendVmSpecs`/`RecommendVmOsImages` were reviewed and intentionally left synchronous. `docs/feature-guide/async-responses.md` (63 lines) has been written, completing the plan.
+
+---
+
+## Breaking-Change Policy (Platform Integration in Progress)
+
+A platform-wide integration effort is currently underway, so **the recommendation and migration-infra
+APIs (Phases 1-3 below) must have zero breaking change** — any client that never sends the new opt-in
+signal must see byte-for-byte identical behavior to today.
+
+**`POST /migration/data` (Data) is explicitly excluded from this constraint.** It is not part of the
+current integration effort, so — in the interest of making the _whole_ API surface consistent — it is
+deliberately being changed to follow the same `Prefer: respond-async` opt-in convention as every other
+endpoint, even though this changes its current (always-202) behavior. See [Phase 0](#target-apis-and-rollout-order).
+
+| Target endpoint                                                     | Default (no `Prefer` header) behavior after the change                              | Verified by                                                                              |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `POST /migration/ns/{nsId}/infra`, `/infraWithDefaults`             | Identical 201 + `MigrateInfraResponse`                                              | `preferRespondAsync(c) == false` → falls straight into the existing, untouched code path |
+| `POST /recommendation/infra`, `/infraWithDefaults`, `/infraWithNlb` | Identical 200 response                                                              | Same                                                                                     |
+| `POST /migration/data`                                              | **Changes** — now returns 200 synchronously by default instead of unconditional 202 | Intentional, out of scope for this constraint                                            |
+
+**Implementation discipline required for Phases 1-3** (design safety is not the same as implementation safety):
+
+1. **Insert, never restructure.** The async branch must be added as a pure early-return block right after
+   existing input validation. The pre-existing synchronous code must not be reordered, reindented, or
+   extracted into a shared function in the same change — a reviewer should be able to confirm safety just
+   by checking that the diff is addition-only with zero lines touched in the sync path.
+2. **Malformed/absent `Prefer` header must default to sync.** `preferRespondAsync` returns `false` unless
+   the exact `respond-async` token is present — already designed this way, re-confirmed here as a hard
+   requirement, not just an implementation detail.
+3. **Swagger changes are additive and have an in-repo precedent.** Declaring more than one possible
+   response for the same endpoint is not new to this codebase: `ListInfra` already declares two distinct
+   `@Success 200` responses depending on the `option` query param
+   ([migration.go:195-196](../../pkg/api/rest/controller/migration.go#L195-L196)). Adding
+   `@Success 202 {object} model.ApiResponse[model.AsyncJobResponse]` alongside the existing `@Success 200/201`
+   follows the same established pattern.
+
+---
+
+## Existing Infrastructure (reused, not modified)
+
+| Component                      | Location                                                                                                                        | Role                                                                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RequestDetails` / `lkvstore`  | [pkg/core/common/request-manager.go](../../pkg/core/common/request-manager.go)                                                  | Persists per-request status (`sync.Map` + file-backed)                                                                                        |
+| Status enum                    | `common.RequestStatusHandling / Success / Error` (request-manager.go:74-87)                                                     | Deliberately kept to 3 values — see [Status Values](#2-status-values-no-changes)                                                                |
+| `model.AsyncJobResponse`       | [pkg/api/rest/model/async.go](../../pkg/api/rest/model/async.go)                                                                | `{reqId, status, statusUrl}` — the 202 response body                                                                                          |
+| `RequestIdAndDetailsIssuer`    | [pkg/api/rest/middlewares/request-id.go](../../pkg/api/rest/middlewares/request-id.go)                                          | Issues/validates `X-Request-Id`, sets initial `Handling` status before the handler runs                                                       |
+| `ResponseBodyDump`             | [pkg/api/rest/middlewares/response-dump.go](../../pkg/api/rest/middlewares/response-dump.go)                                    | Finalizes status to `Success`/`Error` after the handler returns — **skips this entirely if the response status is 202** (response-dump.go:47) |
+| Reference implementation       | `MigrateData` / `executeMigrationAsync` in [migration-data.go](../../pkg/api/rest/controller/migration-data.go) (lines 119-230) | The only existing async handler; the pattern to replicate                                                                                     |
+| `common.UpdateRequestProgress` | request-manager.go:330                                                                                                          | Appends incremental progress entries to `ResponseData` — implemented but currently unused anywhere                                            |
+
+**No changes to middleware _logic_ are required.** HTTP 202 is already a reserved, codebase-wide signal
+meaning "async job accepted; a background goroutine will finalize the status." Grep confirms
+`StatusAccepted` is used in exactly two places today (the handler that sets it, and the middleware guard
+that skips it). The one exception is a one-line, additive change to `RequestIdAndDetailsIssuer`'s CORS
+header list — see [CORS Header Exposure](#4-cors-header-exposure-for-preference-applied) below.
+
+---
+
+## Design Decisions
+
+### 1. Sync and async on the same endpoint (no new endpoints, no breaking change)
+
+Confirmed requirement: both response modes must stay available, with minimal added complexity.
+
+- Opt-in via the **`Prefer: respond-async` request header** (RFC 7240), not a query parameter.
+  Rationale: sync-vs-async is an HTTP-transport-level processing preference (how the request/response
+  cycle itself behaves), not a domain/business-level option — the same category as `Accept` or
+  `If-Match`, unlike e.g. `useExisting` (a business option on _what_ the migration does, correctly left
+  as a query param — see [naming precedent](#naming-precedent-query-param-vs-header) below). `Prefer` is
+  the standard mechanism for exactly this case, used the same way by Microsoft Graph, OData, and Azure
+  REST APIs.
+- When honored, the server echoes back **`Preference-Applied: respond-async`** on the 202 response, per
+  RFC 7240 §3 — a one-line addition that lets clients confirm the async path was actually taken.
+- The branch happens **inside the existing handler**, immediately after input validation, before any
+  slow work starts. Both branches call the _same_ underlying core function — no duplicated business logic.
+- One shared generic helper in `pkg/core/common` removes per-handler boilerplate, regardless of what the
+  wrapped core function does or which package it belongs to (`recommendation`, `migration`, `transx` —
+  see [Open Questions](#open-questions) for why this also covers `executeMigrationAsync`):
+
+```go
+// maxConcurrentAsyncJobs caps background jobs from RunAsync (shared by all async endpoints).
+const maxConcurrentAsyncJobs = 20
+
+var asyncJobSemaphore = make(chan struct{}, maxConcurrentAsyncJobs)
+
+// RunAsync runs work in the background, recovers panics, and finalizes the request record.
+// Returns false at capacity — caller must respond 503, not spawn anyway.
+func RunAsync[T any](reqID string, work func() (T, error)) bool {
+    select {
+    case asyncJobSemaphore <- struct{}{}:
+    default:
+        return false
+    }
+    go func() {
+        defer func() { <-asyncJobSemaphore }()
+        defer func() {
+            if r := recover(); r != nil {
+                // Stack trace stays server-side; clients never see it (see note below).
+                log.Error().Str("reqId", reqID).Str("stack", string(debug.Stack())).Msgf("panic: %v", r)
+                finalizeError(reqID, fmt.Errorf("internal error (panic): %v", r))
+            }
+        }()
+        result, err := work()
+        finalizeRequest(reqID, result, err)
+    }()
+    return true
+}
+
+// preferRespondAsync reports whether Prefer includes "respond-async" (RFC 7240).
+// Other tokens (e.g. wait=N) are ignored.
+func preferRespondAsync(c echo.Context) bool {
+    for _, token := range strings.Split(c.Request().Header.Get("Prefer"), ",") {
+        if strings.TrimSpace(token) == "respond-async" {
+            return true
+        }
+    }
+    return false
+}
+
+func RecommendVmInfraCandidates(c echo.Context) error {
+    // ... existing input validation, unchanged ...
+
+    if preferRespondAsync(c) {
+        reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+        started := common.RunAsync(reqID, func() ([]cloudmodel.RecommendedInfra, error) {
+            return recommendation.RecommendVmInfraCandidates(csp, region, sourceInfra, limit, minMatchRate)
+        })
+        if !started {
+            c.Response().Header().Set("Retry-After", "5")
+            return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+                "Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+        }
+        c.Response().Header().Set("Preference-Applied", "respond-async")
+        return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+            model.AsyncJobResponse{
+                ReqID:     reqID,
+                Status:    common.RequestStatusHandling,
+                StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+            },
+            "Recommendation started. Use GET /request/{reqId} to check status."))
+    }
+
+    // existing synchronous path — unchanged
+    recommendedInfraCandidates, err := recommendation.RecommendVmInfraCandidates(csp, region, sourceInfra, limit, minMatchRate)
+    ...
+}
+```
+
+The handler-level async branch is identical regardless of whether the wrapped core function is a single
+call (`RecommendVmInfraCandidates`) or a multi-stage orchestration (`CreateVMInfraWithDefaults`) — all
+complexity stays inside the closure passed to `RunAsync`, not duplicated per handler.
+
+**Panic messages never reach the client.** `GET /request/{reqId}` returns `common.RequestDetails` verbatim,
+including `ErrorResponse` ([api-request.go](../../pkg/api/rest/controller/api-request.go)) — so a raw
+`debug.Stack()` in that field would leak internal file paths and call frames to any API caller. The full
+stack trace goes to the server log only; `ErrorResponse` gets a short, generic message. This matches how
+`middleware.Recover()` already behaves for synchronous handlers ([server.go:110](../../pkg/api/rest/server.go#L110)) —
+logs the panic, never returns the stack trace to the client.
+
+**Swagger annotation**: document with
+`@Param Prefer header string false "Set to 'respond-async' for async processing (RFC 7240). Only this token is recognized; 'wait=N' and other Prefer tokens are ignored." Enums(respond-async)`,
+plus `@Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"`.
+Swagger UI renders header params as a normal input field, exactly as it already does for `X-Request-Id`
+throughout this codebase, so there's no loss of Swagger UI testability versus a query param.
+
+**Trade-off, accepted deliberately**: one global pool means a burst of slow migration jobs can consume all
+20 slots and cause an unrelated, cheap recommendation call to get `503` even though it would finish in
+seconds. Per-endpoint or per-job-type pools would avoid this but add real configuration surface for a
+problem that hasn't been observed yet — same reasoning as deferring progress reporting
+([Design Decision 3](#3-progress-reporting-deferred-not-part-of-this-plan)). Revisit with separate pools
+only if this starvation is actually observed in practice.
+
+**Hardcoded constant, deliberately not a config value**: making this configurable via
+`config.Beetle` would mean adding a field in four places — `pkg/config/config.go`, `conf/config.yaml`,
+`conf/template-config.yaml`, and `conf/template-setup.env` (this repo's env-var binding is explicit per
+field via `viper.BindEnv` in `bindEnvironmentVariables()`, not automatic, so a config-based value cannot
+skip any of the four) — for a number with no evidence yet that it needs runtime tuning. A Go constant is
+simpler and can be changed and redeployed if 20 turns out to be wrong. Revisit as a config value only if
+real usage shows a concrete need to tune it without a rebuild.
+
+#### Naming precedent: query param vs. header
+
+There is no general convention of "control flags go in headers." The actual distinction is which layer
+the flag belongs to:
+
+- **HTTP-transport-level processing preference** (sync vs. async, response verbosity, conditional
+  requests) → header. Standard examples: `Prefer: respond-async` / `Prefer: return=minimal` (Microsoft
+  Graph, OData), `Idempotency-Key` (Stripe), `If-Match`.
+- **Domain/business-level request option** (dry-run, force, upsert, reuse-existing-resources) → query
+  parameter is the common convention. Examples: Kubernetes `?dryRun=All`, common `?force=true` /
+  `?upsert=true` patterns.
+
+`useExisting` on `MigrateInfra` (a business option on what the migration does) was correctly left as a
+query parameter under this rule — it is not an exception that needs revisiting.
+
+### 2. Status values: no changes
+
+`Handling` / `Success` / `Error` stay as-is — this was a deliberate choice, not an oversight, and it
+also keeps the enum aligned with CB-Tumblebug's status values (per existing code comment). New edge
+cases introduced by making more APIs async (timeouts, orphaned jobs, deleted-mid-job records) are folded
+into `Error` with a descriptive `ErrorResponse` message rather than new status values.
+
+### 3. Progress reporting: deferred, not part of this plan
+
+`common.UpdateRequestProgress` exists but is deliberately **not** wired into any of these APIs now. It
+solves a different problem than "get an async response" (mid-flight visibility into a multi-stage job)
+and, on inspection, its implementation scope varies unpredictably by function:
+
+- `CreateVMInfraWithDefaults` ([vm-infra.go:94](../../pkg/core/migration/vm-infra.go#L94)) is a single
+  Tumblebug call — nothing meaningful to report.
+- `CreateInfra` ([vm-infra.go:123](../../pkg/core/migration/vm-infra.go#L123)) has all its stages
+  (vNet → SSH key → security groups → infra) inline in one function — reporting would touch only this
+  one function.
+- `CreateInfraWithExisting` ([vm-infra.go:321-394](../../pkg/core/migration/vm-infra.go#L321-L394))
+  delegates each stage to separate child functions (`useOrCreateNetwork`, `useOrCreateSshKey`,
+  `useOrCreateSecurityGroup`, each looped per node group) — stage-level reporting only touches the
+  parent function, but reporting anything finer (e.g. "reusing" vs. "creating" per resource) requires
+  threading a parameter into all three child functions.
+
+Because the actual scope ranges from "one function, one line" to "one parent + three child functions,"
+with no immediate requirement driving the need for it, adding it now would be speculative complexity.
+Revisit only if there is a concrete request for granular progress visibility.
+
+### 4. CORS header exposure for `Preference-Applied`
+
+`RequestIdAndDetailsIssuer` ([request-id.go:34](../../pkg/api/rest/middlewares/request-id.go#L34))
+currently sets `Access-Control-Expose-Headers: X-Request-Id` only. Browser-based JS clients calling
+cross-origin cannot read `Preference-Applied` unless it is also listed. This is the one middleware touch
+in this whole plan — purely additive (extends a header value, doesn't remove or change existing behavior),
+so it doesn't conflict with the "no middleware logic changes" statement in
+[Existing Infrastructure](#existing-infrastructure-reused-not-modified):
+
+```go
+c.Response().Header().Set("Access-Control-Expose-Headers", "X-Request-Id, Preference-Applied")
+```
+
+Not strictly required for functionality — `reqId`/`status` are already present in the JSON response body
+(which `data/main.go`'s test-cli already reads from, not the header), so this only matters for
+browser-based JS clients that specifically want to read the confirmation header rather than the body.
+Lower priority than items 1-3, but simple enough to include in the same change.
+
+---
+
+## Status Update Timing — Verified Sequence
+
+Traced precisely to confirm no new middleware work or race conditions are introduced.
+
+**Common prefix (every request):**
+
+```
+1. RequestIdAndDetailsIssuer (before handler)
+   → SetRequest(reqID, {Status: Handling, RequestInfo, StartTime: now})
+2. Handler runs
+3. ResponseBodyDump (same goroutine, right after the handler writes its response)
+   → if response status == 202: return   // guard, does nothing further
+   → else: GetRequest → set Status Success/Error, EndTime, ResponseData/ErrorResponse → SetRequest
+```
+
+**Sync path:** step 3 finalizes the record in the same goroutine as the request — no concurrent writer,
+no race.
+
+**Async path:** step 3 is a no-op (202 guard). The background goroutine — running after the request
+goroutine has already returned — later does its own `GetRequest → SetRequest`. Because the request
+goroutine performs no further writes to that `reqID` after returning 202, this is a sequential handoff
+between goroutines, not concurrent access — no write-write race.
+
+### Confirmed safe, and known limitations
+
+| Item                            | Finding                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lkvstore` concurrency          | Backed by `sync.Map`; individual `Get`/`Put` calls are atomic, but the `GetRequest → SetRequest` _pair_ is not lock-protected (classic read-modify-write). Safe today because exactly one goroutine writes to a given `reqID` at a time in both sync and async paths — confirmed no goroutines/parallelism exist yet in `pkg/core/recommendation` or `pkg/core/migration`. Not a concern for this plan since progress reporting is out of scope (see [Progress Reporting](#3-progress-reporting-deferred-not-part-of-this-plan)); would need re-checking if that is ever added with parallel node-group processing. |
+| Panic safety                    | `executeMigrationAsync` (existing reference implementation) has **no `recover()`** — a panic in the background goroutine currently crashes the process. **Addressed**: `RunAsync` has `recover()` built in, and `executeMigrationAsync` is refactored to use `RunAsync` in Phase 0 (see [Open Questions](#open-questions)), closing this gap for all endpoints at once.                                                                                                                                                                                                                                                                                                                                                    |
+| Record deleted mid-job          | If `DELETE /request/{reqId}` is called while a background job is still running, the job's final `GetRequest` returns `!ok`; it logs an error and silently drops the result. Acceptable given today's usage; no change proposed.                                                                                                                                                                                                                                                                                                                                                                                     |
+| Orphaned `Handling` records     | `CleanupOldRequests` intentionally never deletes `Handling` records regardless of age. A crash mid-job (or a normal shutdown, see [Open Questions](#open-questions)) leaves a permanent stuck record even with `recover()` in place, since `recover()` only handles in-process panics. No new status value proposed (see [Status Values](#2-status-values-no-changes)).                                                                                                                                                                                                                                                                                                           |
+| Unbounded concurrent async jobs | Unlike sync calls (naturally throttled by clients holding a connection open), async lets a client fire many long-running jobs without waiting. No worker-pool/semaphore pattern existed in this codebase to bound this. **Addressed**: `RunAsync`'s `asyncJobSemaphore` (see [Design Decision 1](#1-sync-and-async-on-the-same-endpoint-no-new-endpoints-no-breaking-change)) caps concurrent background jobs at 20, rejecting new ones with `503` rather than queuing unboundedly.                                                                                                                                 |
+
+**Conclusion:** middleware _logic_ requires zero changes; the only middleware touch is the additive CORS
+header list update in [Design Decision 4](#4-cors-header-exposure-for-preference-applied). Handlers only
+need to follow the existing "return 202 → middleware backs off" contract.
+
+---
+
+## Target APIs and Rollout Order
+
+| Phase | Endpoint(s)                                                                      | Why this order                                                                                                                                                                                                                                                                                                                                                                                                             | Breaking change allowed?                       |
+| ----- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| 0     | `POST /migration/data`                                                           | Consistency retrofit: bring Data onto the same opt-in `Prefer` convention as every other endpoint (see [Breaking-Change Policy](#breaking-change-policy-platform-integration-in-progress))                                                                                                                                                                                                                                 | **Yes** — not part of the platform integration |
+| 1     | `POST /migration/ns/{nsId}/infra`, `POST /migration/ns/{nsId}/infraWithDefaults`, `DELETE /migration/ns/{nsId}/infra/{infraId}` | Real provisioning latency from synchronous Tumblebug/CSP calls (`CreateVNet`, `CreateSshKey`, `CreateSecurityGroup`, `CreateInfra`/`CreateInfraDynamic` in [vm-infra.go](../../pkg/core/migration/vm-infra.go)); pattern already proven via `MigrateData`. `DeleteVMInfra` (same file) was added to this phase too — it has four fixed `time.Sleep(3s)` settle-waits plus a vNet-deletion retry loop (up to 10 x 10s), a minimum ~12s and worst case 100s+, a stronger async case than the creation path. | No                                             |
+| 2     | `POST /recommendation/infraWithNlb`                                              | Per-node-group loop over spec/image/security-group lookups ([infra-with-nlb.go:306](../../pkg/core/recommendation/infra-with-nlb.go))                                                                                                                                                                                                                                                                                      | No                                             |
+| 3     | `POST /recommendation/infra`, `POST /recommendation/infraWithDefaults`           | Lower latency than Phase 2, lower urgency                                                                                                                                                                                                                                                                                                                                                                                  | No                                             |
+
+---
+
+## Extended Scope: Object Storage / NLB
+
+After the four phases above shipped, a latency review covered every remaining recommendation/migration
+API (object storage, NLB, individual resources like VNet/SG/SSH key/spec/image) to check whether any of
+them deserved the same treatment. Findings and decisions:
+
+| API | Latency source | Decision |
+|---|---|---|
+| `DELETE /migration/middleware/ns/{nsId}/infra/{infraId}/nlb/{nlbId}` (`DeleteNlb`) | Fixed 15s settle wait after successful deletion ([nlb.go:197-199](../../pkg/core/migration/nlb.go#L197-L199)), same rationale as `DeleteInfra` | **Added** |
+| `POST /migration/middleware/ns/{nsId}/infra/{infraId}/nlb` (`MigrateNlbs`) | N NLBs processed sequentially, each with a lookup + create call ([nlb.go:48-95](../../pkg/core/migration/nlb.go#L48-L95)) | **Added** |
+| `POST /migration/middleware/ns/{nsId}/objectStorage` (`MigrateObjectStorage`) | N buckets created sequentially, up to 2 extra calls per bucket for versioning/CORS ([object-storage.go:64-169](../../pkg/core/migration/object-storage.go#L64-L169)) | **Added** |
+| `RecommendVmSpecs` / `RecommendVmOsImages` | Per-node loop, each with up to 5 retry calls widening the search range ([resource-vm-spec.go:148-263](../../pkg/core/recommendation/resource-vm-spec.go#L148-L263)) | **Left synchronous** — individual calls are fast with no `time.Sleep`; latency only shows up with many nodes, a weaker case than the others |
+| Object Storage/NLB single-item GET/DELETE, `RecommendVNet`/`RecommendSecurityGroups` (local computation only), VNet/SSHKey/SecurityGroup proxy CRUD ([migration-resource.go](../../pkg/api/rest/controller/migration-resource.go)) | Single external call or pure local computation | **Left synchronous** — no meaningful latency to hide |
+
+`DeleteNlb`'s core function (`migration.DeleteNlb`) returns only `error`, like `transx.Transfer` in
+[Phase 0](#target-apis-and-rollout-order) — its closure follows the same shape, returning a small
+`map[string]any` confirmation message as `T` since there is no natural result value.
+
+---
+
+## Work Items per Phase
+
+1. Add `preferRespondAsync(c)` check + `common.RunAsync(reqID, func() (T, error) {...})` branch to the
+   target handler(s), reusing `model.AsyncJobResponse`. Handle the `false` return (capacity reached) with
+   a `503` response, per [Design Decision 1](#1-sync-and-async-on-the-same-endpoint-no-new-endpoints-no-breaking-change).
+2. Add the generic `common.RunAsync[T any]` helper — including the `maxConcurrentAsyncJobs` constant and
+   `asyncJobSemaphore` — once, in Phase 0, and refactor `executeMigrationAsync` to use it in the same PR —
+   see [Open Questions](#open-questions) (resolved: not optional, done in Phase 0). Kept as a Go constant,
+   not a config value — see the trade-off note in
+   [Design Decision 1](#1-sync-and-async-on-the-same-endpoint-no-new-endpoints-no-breaking-change).
+3. Update Swagger annotations: add an `[Async]` usage block matching `MigrateData`'s current
+   `@Description [How to Use]` section, document the `Prefer` header (noting `wait=N` is not supported),
+   add `202` and `503` to `@Success`/`@Failure` alongside the existing success response (multiple
+   `@Success` entries on one endpoint already has precedent — see
+   [Breaking-Change Policy](#breaking-change-policy-platform-integration-in-progress) item 3).
+4. **Phase 0 only**: add a new synchronous code path to `MigrateData` (today it has none — it is
+   unconditionally async) that calls the same underlying migration logic inline and returns `200` directly
+   when `Prefer: respond-async` is absent.
+5. **Phase 0 only**: update `cmd/test-cli/data/main.go`'s migration call to add
+   `.SetHeader("Prefer", "respond-async")` — required, not optional, since after Phase 0 the default
+   response becomes `200` and this test's existing `resp.StatusCode() != 202` check (data/main.go:893)
+   would otherwise start failing.
+6. **Phase 0 only**: add `Preference-Applied` to `Access-Control-Expose-Headers` in
+   `RequestIdAndDetailsIssuer` ([request-id.go:34](../../pkg/api/rest/middlewares/request-id.go#L34)) —
+   see [Design Decision 4](#4-cors-header-exposure-for-preference-applied). The only middleware change in
+   this plan; do it once, in Phase 0, since it applies globally regardless of phase.
+7. Manual test: verify `Prefer: respond-async` and default (sync) against a running Tumblebug backend.
+   For the `503`-at-capacity path: no automated test needed given no `_test.go` infra exists for these
+   packages today ([Test CLI Impact](#test-cli-impact)) — a quick manual check (fire 20+ concurrent
+   async requests with a script) is sufficient to confirm the semaphore rejects correctly.
+8. No changes to `ResponseBodyDump` or the `RequestStatus*` enum. `RequestIdAndDetailsIssuer` gets only
+   the one additive CORS line from item 6 above — no logic changes.
+9. Documentation and guardrails — see [Documentation & Guardrails](#documentation--guardrails-contributor-and-ai-agent-facing) below.
+10. **After all phases ship**: write `docs/feature-guide/async-responses.md` — see
+    [Feature Guide](#feature-guide-post-implementation-user-facing) below. Keep it short (~50-100 lines,
+    table/example-driven like `naming-nameseed.md`), not a long narrative like the existing
+    migration feature guides. Include the `503`-at-capacity behavior and the `wait=N` non-support note.
+
+---
+
+## Documentation & Guardrails (Contributor and AI-Agent Facing)
+
+Today the async convention exists in exactly one place (`MigrateData`) and is undocumented — a new
+contributor (human or AI coding agent) can only learn it by reading `migration-data.go` source. Once this
+plan lands, HTTP `202` becomes a codebase-wide reserved signal (see
+[Existing Infrastructure](#existing-infrastructure-reused-not-modified)): any handler that returns `202`
+for an unrelated reason will silently cause `ResponseBodyDump` to skip finalizing that request's status
+record, leaving it permanently stuck at `Handling` — a trap that isn't obvious from reading the middleware
+code alone. Three additions close this gap, so the rule is visible wherever someone is likely to be
+working, not just in this plan document (which is a point-in-time proposal, not a living reference):
+
+1. **`docs/api-response-policy.md`** — add an "Async Responses" section documenting the
+   `Prefer: respond-async` → `202` → poll `GET /request/{reqId}` contract, the `503`-at-capacity behavior
+   (20 concurrent jobs, see [Design Decision 1](#1-sync-and-async-on-the-same-endpoint-no-new-endpoints-no-breaking-change)),
+   and that `wait=N` and other `Prefer` tokens are not supported. This file currently has no mention of
+   `202` at all; it is the natural, permanent home for this convention, unlike the plan doc.
+2. **Code comments** at the two points where the rule actually matters:
+   - The `if c.Response().Status == http.StatusAccepted` guard in
+     [response-dump.go](../../pkg/api/rest/middlewares/response-dump.go) — explain _why_ it skips, and that
+     `202` must never be returned for a non-async reason.
+   - The `common.RunAsync[T any]` definition itself — a one-line doc comment pointing back to the
+     `docs/api-response-policy.md` section, so a contributor who finds the helper first (not the plan) still
+     gets the contract.
+3. **`CLAUDE.md`** (repo root — does not currently exist, to be created) — add an explicit,
+   agent-readable instruction so AI coding agents pick up the same guardrail automatically in future
+   sessions, not just human contributors reading docs:
+
+   > HTTP `202 Accepted` is reserved repo-wide to mean "async job accepted; a background goroutine will
+   > finalize the `/request/{reqId}` status record." Never return `202` from a handler for any other
+   > reason — `ResponseBodyDump` middleware (`pkg/api/rest/middlewares/response-dump.go`) skips status
+   > finalization for any `202` response, so doing so leaves that request's tracking record permanently
+   > stuck at `Handling`. When adding async support to a new endpoint, use `common.RunAsync` and the
+   > `Prefer: respond-async` header convention documented in `docs/api-response-policy.md`.
+
+---
+
+## Feature Guide (Post-Implementation, User-Facing)
+
+The three items above ([Documentation & Guardrails](#documentation--guardrails-contributor-and-ai-agent-facing))
+target contributors and AI agents working _on_ CM-Beetle. A separate, user-facing doc is also needed for
+people integrating _with_ CM-Beetle's API — this belongs in `docs/feature-guide/`, added as a work item
+once implementation is complete (not before, so it reflects the shipped behavior, not the proposal).
+
+**Existing docs in this directory vary widely in length** — `vm-infrastructure.md` (26 lines) and
+`naming-nameseed.md` (96 lines) are short, table- and example-driven; `data-migration-feature-guide.md`
+(461 lines) and `object-storage-migration-feature-guide.md` (1168 lines) are long narrative walkthroughs.
+**Follow the short style** — a long document works against its own purpose here, since the async
+convention itself is simple (one header, one status code, one polling endpoint) and a long writeup would
+make that simplicity harder to see, not easier.
+
+Target: a new `docs/feature-guide/async-responses.md`, similarly scoped to `naming-nameseed.md` (roughly
+50-100 lines), covering only:
+
+1. **What it is** — one paragraph: opt-in via `Prefer: respond-async`, default stays synchronous.
+2. **How to use it** — the request/response shapes, modeled on `naming-nameseed.md`'s terse
+   request/response code blocks rather than prose:
+
+   ```
+   POST /beetle/recommendation/infra
+   Prefer: respond-async
+   → 202 Accepted, Preference-Applied: respond-async
+     { "reqId": "...", "status": "Handling", "statusUrl": "/beetle/request/{reqId}" }
+
+   GET /beetle/request/{reqId}
+   → { "status": "Success" | "Error" | "Handling", ... }
+   ```
+
+3. **Which endpoints support it** — one table listing the Phase 0-3 endpoints from this plan.
+4. **Status values** — one small table (`Handling` / `Success` / `Error`), no more than that (matching
+   [Status Values](#2-status-values-no-changes) — do not expand this in the user-facing doc either).
+5. **Limits** — one or two lines: at most 20 concurrent async jobs — retry after the `Retry-After`
+   seconds on `503` — and only the `respond-async` preference token is recognized (`wait=N` is ignored,
+   no time-bounded hybrid mode).
+6. A short **Related** section linking to `docs/api-response-policy.md` for the underlying contract and
+   to this plan doc for implementation background, following the same "Related" convention
+   `naming-nameseed.md` already uses.
+
+Explicitly out of scope for this guide: progress reporting (not implemented, see
+[Progress Reporting](#3-progress-reporting-deferred-not-part-of-this-plan)), and internal implementation
+details (`common.RunAsync`, middleware internals) — those belong in code comments and
+`docs/api-response-policy.md`, not in a user-facing feature guide.
+
+---
+
+## Test CLI Impact
+
+`cmd/test-cli/{data,infra,infra-with-nlb}/main.go` are independent `package main` tools (no shared
+library between them — each is copied and adapted, per the existing `nlb-plan-for-recommendation-and-migration.md`
+convention), so client-side impact was assessed directly against their current call sites.
+
+### Existing sync tests: zero changes required
+
+`infra/main.go`'s `runMigrationTest` ([main.go:955-964](../../cmd/test-cli/infra/main.go#L955-L964)) calls
+`common.ExecuteHttpRequest` with no headers set. Since the new async path is opt-in via `Prefer`, and this
+call never sends that header, the server keeps returning its current synchronous response — the existing
+9–13 step test suites in `infra`/`infra-with-nlb` pass unmodified. This is a concrete, code-level
+confirmation of the "no breaking change" requirement.
+
+### Decision: sync-only test coverage for everything except Data
+
+`cmd/test-cli/data/main.go` already implements the full async client flow for `MigrateData`
+(lines 870-989) and remains the one place async is exercised end-to-end. **`infra` and
+`infra-with-nlb` intentionally stay sync-only** — no new `runMigrationTestAsync`-style functions,
+no `Prefer` header, no polling logic added to those tools, even though Phase 1/2 endpoints now
+support async. This was a deliberate scope decision, not an oversight: the async code path in each
+handler is a thin, identical branch around the same core function the sync test already exercises
+(see [Design Decision 1](#1-sync-and-async-on-the-same-endpoint-no-new-endpoints-no-breaking-change)),
+so the sync tests already cover the business logic; only `data/main.go` needed the one-line `Prefer`
+header addition from Phase 0's work items, since `MigrateData` has no sync path to fall back to
+without it.
+
+**If async test coverage for `infra`/`infra-with-nlb` is wanted later**, reuse the pattern already
+proven in `data/main.go` — the reqId-extraction, 202-branch, and poll-loop code, built with raw resty
+(**not** `common.ExecuteHttpRequest`, which is a shared internal helper also used for Beetle→Tumblebug
+calls, [request-manager.go:418](../../pkg/core/common/request-manager.go#L418)).
+
+---
+
+## Open Questions
+
+- ~~Should `executeMigrationAsync` be refactored to use the new shared helpers in the same PR, or left
+  as-is and only the new handlers use them?~~ **Resolved**: refactor it in the same PR as Phase 0, using
+  `common.RunAsync`. `transx.Transfer(req)` returning only `error` (no result value) is not a blocker —
+  the closure just builds the success payload itself and returns it as `T`:
+
+  ```go
+  if preferRespondAsync(c) {
+      reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+      started := common.RunAsync(reqID, func() (map[string]any, error) {
+          start := time.Now()
+          if err := transx.Transfer(*req); err != nil {
+              return nil, fmt.Errorf("data migration failed: %w (%s)", err, time.Since(start).Round(time.Millisecond))
+          }
+          elapsed := time.Since(start).Round(time.Millisecond)
+          return map[string]any{
+              "message":     fmt.Sprintf("Data migrated successfully (%s)", elapsed),
+              "elapsedTime": elapsed.String(),
+          }, nil
+      })
+      if !started {
+          c.Response().Header().Set("Retry-After", "5")
+          return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+              "Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+      }
+      c.Response().Header().Set("Preference-Applied", "respond-async")
+      return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+          model.AsyncJobResponse{ReqID: reqID, Status: common.RequestStatusHandling, StatusURL: fmt.Sprintf("/beetle/request/%s", reqID)},
+          "Migration started. Use GET /request/{reqId} to check status."))
+  }
+  ```
+
+  The custom `"Data migration failed: ... (163ms)"` error format and the `message`/`elapsedTime` success
+  shape are preserved exactly — that formatting is domain-specific and belongs in the closure, not in
+  `RunAsync` itself, the same way every other endpoint's closure owns its own result shape. This is folded
+  into Phase 0's work items above since Data is already being touched there for the sync-path addition.
+
+- **Deferred, explicitly out of scope for this plan**: graceful shutdown does not drain in-flight async
+  jobs. `server.go`'s existing `e.Shutdown(ctx)` ([server.go:467-490](../../pkg/api/rest/server.go#L467-L490))
+  only waits for in-progress HTTP request/response cycles — an async handler's HTTP cycle ends the moment
+  it returns `202`, so Echo's shutdown has no visibility into the detached `RunAsync` goroutine still
+  running afterward. This means a normal rolling restart (not just a crash) can orphan an in-flight async
+  job at "Handling" — a more common trigger than the crash/panic scenario the existing
+  [Orphaned `Handling` records](#confirmed-safe-and-known-limitations) limitation was written around, though
+  the same underlying limitation. Explicitly deferred: no draining, waiting, or shutdown-time logging added
+  in this plan. Revisit only if this proves disruptive in practice.

--- a/pkg/api/rest/controller/migration-data.go
+++ b/pkg/api/rest/controller/migration-data.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
@@ -84,13 +85,15 @@ func GetDataMigrationEncryptionKey(c echo.Context) error {
 
 // MigrateData godoc
 // @ID MigrateData
-// @Summary [Async] Migrate data from source to target
-// @Description **Asynchronous Operation**: This API returns immediately with a request ID. The actual migration runs in the background.
+// @Summary Migrate data from source to target (sync by default; async via Prefer: respond-async)
+// @Description By default this API runs synchronously and returns the migration result directly.
 // @Description
-// @Description [How to Use]
-// @Description 1. Call this API → Receive 202 Accepted with reqId
+// @Description [Async Operation (opt-in)]
+// @Description 1. Send header `Prefer: respond-async` → Receive 202 Accepted with reqId
 // @Description 2. Poll GET /request/{reqId} to check status
 // @Description 3. Status flow: Handling → Success / Error
+// @Description * Only the "respond-async" preference token is recognized; other tokens (e.g. wait=N) are ignored.
+// @Description * If too many async jobs are already running, this returns 503 instead of 202; retry after the `Retry-After` seconds.
 // @Description
 // @Description [Endpoint Requirements]
 // @Description * Both source and destination must be remote endpoints (SSH or object storage)
@@ -112,9 +115,13 @@ func GetDataMigrationEncryptionKey(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used as reqId for tracking migration status."
+// @Param Prefer header string false "Set to 'respond-async' to run this migration asynchronously (RFC 7240)" Enums(respond-async)
 // @Param reqBody body transx.DataMigrationModel true "Data migration request (supports plaintext or encrypted with encryptionKeyId)"
-// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Migration started - use GET /request/{reqId} to check status"
+// @Success 200 {object} model.ApiResponse[any] "Migration completed synchronously"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Migration started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters or decryption failed"
+// @Failure 500 {object} model.ApiResponse[any] "Migration failed"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /migration/data [post]
 func MigrateData(c echo.Context) error {
 
@@ -173,60 +180,60 @@ func MigrateData(c echo.Context) error {
 		Str("strategy", req.Strategy).
 		Msg("Starting data migration")
 
-	// Get the request ID from header for async tracking
-	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (map[string]any, error) {
+			return runDataMigration(*req)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
 
-	// Execute migration asynchronously
-	go executeMigrationAsync(reqID, *req)
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		log.Info().Str("reqId", reqID).Msg("Data migration started asynchronously")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Migration started. Use GET /request/{reqId} to check status.",
+		))
+	}
 
-	// Return immediately with 202 Accepted
-	log.Info().Str("reqId", reqID).Msg("Data migration started asynchronously")
-	return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
-		model.AsyncJobResponse{
-			ReqID:     reqID,
-			Status:    common.RequestStatusHandling,
-			StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
-		},
-		"Migration started. Use GET /request/{reqId} to check status.",
-	))
+	// Synchronous path
+	result, err := runDataMigration(*req)
+	if err != nil {
+		log.Error().Err(err).Msg("Data migration failed")
+		return c.JSON(http.StatusInternalServerError, model.SimpleErrorResponse(err.Error()))
+	}
+	return c.JSON(http.StatusOK, model.SuccessResponseWithMessage(result, "Data migrated successfully"))
 }
 
-// executeMigrationAsync performs the data migration in background and updates request status.
-func executeMigrationAsync(reqID string, req transx.DataMigrationModel) {
-	startTime := time.Now()
-
-	// Execute migration
-	err := transx.Transfer(req)
-
-	// Calculate elapsed time
-	elapsedTime := time.Since(startTime)
-
-	// Get current request details
-	details, ok := common.GetRequest(reqID)
-	if !ok {
-		log.Error().Str("reqId", reqID).Msg("Failed to get request details for status update")
-		return
-	}
-
-	// Update status based on result
-	details.EndTime = time.Now()
-	if err != nil {
-		log.Error().Err(err).Str("reqId", reqID).Dur("elapsedTime", elapsedTime).Msg("Data migration failed")
-		details.Status = common.RequestStatusError
-		details.ErrorResponse = fmt.Sprintf("Data migration failed: %v (%s)", err, elapsedTime.Round(time.Millisecond))
-	} else {
-		log.Info().Str("reqId", reqID).Dur("elapsedTime", elapsedTime).Msg("Data migration completed successfully")
-		details.Status = common.RequestStatusSuccess
-		details.ResponseData = map[string]any{
-			"message":     fmt.Sprintf("Data migrated successfully (%s)", elapsedTime.Round(time.Millisecond)),
-			"elapsedTime": elapsedTime.Round(time.Millisecond).String(),
+// preferRespondAsync reports whether Prefer includes "respond-async" (RFC 7240).
+// Other tokens (e.g. wait=N) are ignored.
+func preferRespondAsync(c echo.Context) bool {
+	for _, token := range strings.Split(c.Request().Header.Get("Prefer"), ",") {
+		if strings.TrimSpace(token) == "respond-async" {
+			return true
 		}
 	}
+	return false
+}
 
-	// Save updated status
-	if err := common.SetRequest(reqID, details); err != nil {
-		log.Error().Err(err).Str("reqId", reqID).Msg("Failed to update request status")
+// runDataMigration performs the data migration and returns a summary of the result.
+func runDataMigration(req transx.DataMigrationModel) (map[string]any, error) {
+	start := time.Now()
+	if err := transx.Transfer(req); err != nil {
+		return nil, fmt.Errorf("data migration failed: %w (%s)", err, time.Since(start).Round(time.Millisecond))
 	}
+	elapsed := time.Since(start).Round(time.Millisecond)
+	return map[string]any{
+		"message":     fmt.Sprintf("Data migrated successfully (%s)", elapsed),
+		"elapsedTime": elapsed.String(),
+	}, nil
 }
 
 // ============================================================================

--- a/pkg/api/rest/controller/migration-nlb.go
+++ b/pkg/api/rest/controller/migration-nlb.go
@@ -21,6 +21,7 @@ import (
 
 	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
 	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
 	"github.com/cloud-barista/cm-beetle/pkg/core/migration"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -44,6 +45,10 @@ import (
 // @Description Ensure `targetGroup.nodeGroupId` matches the NodeGroup IDs created during infra migration.
 // @Description
 // @Description [Note] All NLBs are attempted independently. Partial success is possible.
+// @Description
+// @Description By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+// @Description asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+// @Description (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
 // @Tags [Migration] Managed Network Load Balancer (NLB) - preview
 // @Accept json
 // @Produce json
@@ -52,9 +57,12 @@ import (
 // @Param useExisting query bool false "Reuse existing NLB if one targeting the same nodeGroupId already exists, instead of creating a new one (default: true)"
 // @Param request body cloudmodel.RecommendedNlb true "NLB migration request (use targetNlbList[] from /recommendation/infraWithNlb)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided)"
+// @Param Prefer header string false "Set to 'respond-async' to run this migration asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 201 {object} model.ApiResponse[cloudmodel.MigratedNlbResult] "NLBs created successfully"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Migration started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during NLB creation"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /migration/middleware/ns/{nsId}/infra/{infraId}/nlb [post]
 func MigrateNlbs(c echo.Context) error {
 	nsId := c.Param("nsId")
@@ -87,6 +95,26 @@ func MigrateNlbs(c echo.Context) error {
 	useExisting := true
 	if c.QueryParam("useExisting") == "false" {
 		useExisting = false
+	}
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (cloudmodel.MigratedNlbResult, error) {
+			return migration.CreateNlbs(nsId, infraId, req, useExisting)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"NLB migration started. Use GET /request/{reqId} to check status."))
 	}
 
 	result, err := migration.CreateNlbs(nsId, infraId, req, useExisting)
@@ -240,6 +268,10 @@ func GetNlbHealth(c echo.Context) error {
 // @Description [Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.
 // @Description Deleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).
 // @Description CM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.
+// @Description
+// @Description By default this API runs synchronously (always includes the 15s settle wait). Send header
+// @Description `Prefer: respond-async` to run it asynchronously instead: receive 202 Accepted with a reqId,
+// @Description then poll GET /request/{reqId} (status flow: Handling → Success / Error).
 // @Tags [Migration] Managed Network Load Balancer (NLB) - preview
 // @Accept json
 // @Produce json
@@ -247,9 +279,12 @@ func GetNlbHealth(c echo.Context) error {
 // @Param infraId path string true "Infra ID"
 // @Param nlbId path string true "NLB ID"
 // @Param X-Request-Id header string false "Unique request ID"
+// @Param Prefer header string false "Set to 'respond-async' to run this deletion asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 204 "NLB deleted (includes 15s settle wait for CSP async cleanup)"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Deletion started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /migration/middleware/ns/{nsId}/infra/{infraId}/nlb/{nlbId} [delete]
 func DeleteNlb(c echo.Context) error {
 	nsId := c.Param("nsId")
@@ -265,6 +300,29 @@ func DeleteNlb(c echo.Context) error {
 	nlbId := c.Param("nlbId")
 	if nlbId == "" {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("nlbId required"))
+	}
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (map[string]any, error) {
+			if err := migration.DeleteNlb(nsId, infraId, nlbId); err != nil {
+				return nil, err
+			}
+			return map[string]any{"message": fmt.Sprintf("NLB '%s' deleted successfully", nlbId)}, nil
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"NLB deletion started. Use GET /request/{reqId} to check status."))
 	}
 
 	if err := migration.DeleteNlb(nsId, infraId, nlbId); err != nil {

--- a/pkg/api/rest/controller/migration-object-storage.go
+++ b/pkg/api/rest/controller/migration-object-storage.go
@@ -57,6 +57,9 @@ type MigrateObjectStorageRequest struct {
 // @Description [Examples]
 // @Description * Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md
 // @Description
+// @Description By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+// @Description asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+// @Description (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
 // @Tags [Migration] Managed Object Storage
 // @Accept json
 // @Produce	json
@@ -64,9 +67,12 @@ type MigrateObjectStorageRequest struct {
 // @Param nameSeed query string false "Optional prefix for bucket names (e.g., 'my' → 'my-os-01'). Applied at migration time."
 // @Param request body MigrateObjectStorageRequest true "Object storage migration request (use RecommendObjectStorage response)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this migration asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 201 "Created - Object storages created successfully"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Migration started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during object storage creation"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /migration/middleware/ns/{nsId}/objectStorage [post]
 func MigrateObjectStorage(c echo.Context) error {
 	nsId := c.Param("nsId")
@@ -94,6 +100,29 @@ func MigrateObjectStorage(c echo.Context) error {
 	nameSeed := c.QueryParam("nameSeed")
 	if ok, detail := common.IsValidNameSeed(nameSeed); !ok {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid nameSeed: "+detail))
+	}
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (map[string]any, error) {
+			if err := migration.CreateObjectStorage(nsId, req.RecommendedObjectStorage, nameSeed); err != nil {
+				return nil, err
+			}
+			return map[string]any{"message": "Object storages created successfully"}, nil
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Object storage migration started. Use GET /request/{reqId} to check status."))
 	}
 
 	if err := migration.CreateObjectStorage(nsId, req.RecommendedObjectStorage, nameSeed); err != nil {

--- a/pkg/api/rest/controller/migration.go
+++ b/pkg/api/rest/controller/migration.go
@@ -44,16 +44,23 @@ type MigrateInfraWithDefaultsResponse struct {
 
 // MigrateInfraWithDefaults godoc
 // @ID MigrateInfraWithDefaults
-// @Summary Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults
+// @Summary Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults (sync by default; async via Prefer: respond-async)
 // @Description Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.
+// @Description
+// @Description By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+// @Description asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+// @Description (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
 // @Tags [Migration] Infrastructure
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(mig01)
 // @Param mciInfo body MigrateInfraWithDefaultsRequest true "Specify the information for the targeted mulci-cloud infrastructure (MCI)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this migration asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 201 {object} model.ApiResponse[MigrateInfraWithDefaultsResponse] "Successfully migrated to the multi-cloud infrastructure"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Migration started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 500 {object} model.ApiResponse[any]
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /migration/ns/{nsId}/infraWithDefaults [post]
 func MigrateInfraWithDefaults(c echo.Context) error {
 
@@ -75,6 +82,26 @@ func MigrateInfraWithDefaults(c echo.Context) error {
 	log.Debug().Msgf("req.InfraDynamicReq: %v", req.InfraDynamicReq)
 
 	// [Process]
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (cloudmodel.VmInfraInfo, error) {
+			return migration.CreateVMInfraWithDefaults(nsId, &req.InfraDynamicReq)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Migration started. Use GET /request/{reqId} to check status."))
+	}
+
 	// Create the VM infrastructure for migration
 	mciInfo, err := migration.CreateVMInfraWithDefaults(nsId, &req.InfraDynamicReq)
 
@@ -102,13 +129,17 @@ type MigrateInfraResponse struct {
 
 // MigrateInfra godoc
 // @ID MigrateInfra
-// @Summary Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults
+// @Summary Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults (sync by default; async via Prefer: respond-async)
 // @Description Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.
 // @Description
 // @Description **[Request Field: `nodeGroups[].cspImageName`]** Optional CSP-native image identifier.
 // @Description - **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).
 // @Description - **Empty**: TumbleBug uses `imageId` for the standard DB lookup (may encounter stale images for some CSPs).
 // @Description - Recommended: pass the recommendation API response as-is to use the latest resolved image.
+// @Description
+// @Description By default this API runs synchronously. Send header `Prefer: respond-async` to run it
+// @Description asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+// @Description (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
 // @Tags [Migration] Infrastructure
 // @Accept  json
 // @Produce  json
@@ -117,9 +148,12 @@ type MigrateInfraResponse struct {
 // @Param useExisting query bool false "Reuse existing resources (VNet, SSH Key, Security Group) if they already exist, instead of creating new ones (default: true)"
 // @Param infraInfo body MigrateInfraRequest true "Specify the information for the targeted multi-cloud infrastructure"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this migration asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 201 {object} model.ApiResponse[MigrateInfraResponse] "Successfully migrated to the multi-cloud infrastructure"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Migration started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /migration/ns/{nsId}/infra [post]
 func MigrateInfra(c echo.Context) error {
 
@@ -159,6 +193,29 @@ func MigrateInfra(c echo.Context) error {
 	// Validate names and referential integrity
 	if ok, detail := common.ValidateComposedNames(infraToMigrate); !ok {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Naming/Reference validation failed: "+detail))
+	}
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (cloudmodel.VmInfraInfo, error) {
+			if useExisting {
+				return migration.CreateInfraWithExisting(nsId, &infraToMigrate)
+			}
+			return migration.CreateInfra(nsId, &infraToMigrate)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Migration started. Use GET /request/{reqId} to check status."))
 	}
 
 	// Create the VM infrastructure for migration
@@ -286,8 +343,13 @@ func GetInfra(c echo.Context) error {
 
 // DeleteInfra godoc
 // @ID DeleteInfra
-// @Summary Delete the migrated mult-cloud infrastructure (MCI)
-// @Description Delete the migrated mult-cloud infrastructure (MCI)
+// @Summary Delete the migrated mult-cloud infrastructure (MCI) (sync by default; async via Prefer: respond-async)
+// @Description Delete the migrated mult-cloud infrastructure (MCI).
+// @Description
+// @Description This operation can take a long time (multiple settle-time waits and vNet-deletion
+// @Description retries). By default it runs synchronously. Send header `Prefer: respond-async` to run
+// @Description it asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}
+// @Description (status flow: Handling → Success / Error). Only the "respond-async" token is recognized.
 // @Tags [Migration] Infrastructure
 // @Accept  json
 // @Produce  json
@@ -295,9 +357,12 @@ func GetInfra(c echo.Context) error {
 // @Param infraId path string true "Migrated Cloud Infrastructure ID (the actual ID returned by the migration API; includes NameSeed prefix if used, e.g., 'my-infra101')" default(my-infra101)
 // @Param option query string false "Option for deletion" Enums(terminate,force) default(terminate)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this deletion asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 200 {object} model.ApiResponse[any] "The result of deleting the migrated multi-cloud infrastructure"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Deletion started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /migration/ns/{nsId}/infra/{infraId} [delete]
 func DeleteInfra(c echo.Context) error {
 
@@ -322,6 +387,26 @@ func DeleteInfra(c echo.Context) error {
 		err := fmt.Errorf("invalid request, the option (option: %s) is invalid", option)
 		log.Warn().Msg(err.Error())
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse(err.Error()))
+	}
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (common.SimpleMsg, error) {
+			return migration.DeleteVMInfra(nsId, infraId, option)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Deletion started. Use GET /request/{reqId} to check status."))
 	}
 
 	// [Process]

--- a/pkg/api/rest/controller/recommendation.go
+++ b/pkg/api/rest/controller/recommendation.go
@@ -28,6 +28,7 @@ import (
 	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
 
 	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
 	"github.com/cloud-barista/cm-beetle/pkg/core/recommendation"
 	"github.com/labstack/echo/v4"
 
@@ -67,9 +68,12 @@ type RecommendInfraWithDefaultsResponse struct {
 // @Param desiredCsp query string false "Provider (e.g., aws, azure, gcp)" Enums(aws,azure,gcp,alibaba,ncp) default(aws)
 // @Param desiredRegion query string false "Region (e.g., ap-northeast-2)" default(ap-northeast-2)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 200 {object} model.ApiResponse[RecommendInfraWithDefaultsResponse] "The result of recommended infrastructure"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Recommendation started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 404 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /recommendation/infraWithDefaults [post]
 func RecommendVMInfraWithDefaults(c echo.Context) error {
 
@@ -107,6 +111,26 @@ func RecommendVMInfraWithDefaults(c echo.Context) error {
 	if !ok {
 		log.Error().Err(err).Msg("failed to validate CSP and region")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid provider or region"))
+	}
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() (cloudmodel.RecommendedInfraDynamicList, error) {
+			return recommendation.RecommendVmInfraWithDefaults(csp, region, sourceInfra)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Recommendation started. Use GET /request/{reqId} to check status."))
 	}
 
 	// [Process]
@@ -166,9 +190,12 @@ type RecommendInfraResponse struct {
 // @Param limit query int false "Limit (default: 3) the number of recommended infrastructures"
 // @Param minMatchRate query number false "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 200 {object} model.ApiResponse[[]cloudmodel.RecommendedInfra] "Successfully recommended infrastructure candidates"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Recommendation started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error during recommendation"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /recommendation/infra [post]
 func RecommendVmInfraCandidates(c echo.Context) error {
 
@@ -225,6 +252,26 @@ func RecommendVmInfraCandidates(c echo.Context) error {
 	if !ok {
 		log.Error().Err(err).Msg("failed to validate CSP and region")
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid provider or region"))
+	}
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() ([]cloudmodel.RecommendedInfra, error) {
+			return recommendation.RecommendVmInfraCandidates(csp, region, sourceInfra, limit, minMatchRate)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Recommendation started. Use GET /request/{reqId} to check status."))
 	}
 
 	// [Process]
@@ -299,9 +346,12 @@ type RecommendInfraWithNlbRequest struct {
 // @Param minMatchRate query number false "Minimum match rate (0-100) for highly-matched classification" default(90.0)
 // @Param request body RecommendInfraWithNlbRequest true "Source infra including NLBs (from cm-honeybee)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided)"
+// @Param Prefer header string false "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)" Enums(respond-async)
 // @Success 200 {object} model.ApiResponse[[]cloudmodel.RecommendedInfra] "NLB-aware recommendation candidates"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Recommendation started asynchronously - use GET /request/{reqId} to check status"
 // @Failure 400 {object} model.ApiResponse[any] "Invalid request"
 // @Failure 500 {object} model.ApiResponse[any] "Internal server error"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
 // @Router /recommendation/infraWithNlb [post]
 func RecommendInfraWithNlbCandidates(c echo.Context) error {
 
@@ -354,6 +404,28 @@ func RecommendInfraWithNlbCandidates(c echo.Context) error {
 		Int("limit", limit).
 		Float64("minMatchRate", minMatchRate).
 		Msg("Processing infraWithNlb recommendation request")
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() ([]cloudmodel.RecommendedInfra, error) {
+			return recommendation.RecommendInfraWithNlbCandidates(
+				req.DesiredCsp, req.DesiredRegion, req.SourceInfra, limit, minMatchRate,
+			)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Recommendation started. Use GET /request/{reqId} to check status."))
+	}
 
 	// [Process]
 	candidates, err := recommendation.RecommendInfraWithNlbCandidates(

--- a/pkg/api/rest/middlewares/request-id.go
+++ b/pkg/api/rest/middlewares/request-id.go
@@ -30,8 +30,8 @@ func RequestIdAndDetailsIssuer(next echo.HandlerFunc) echo.HandlerFunc {
 			return next(c)
 		}
 
-		// Make X-Request-Id visible to all handlers
-		c.Response().Header().Set("Access-Control-Expose-Headers", echo.HeaderXRequestID)
+		// Make X-Request-Id and Preference-Applied visible to browser-based clients
+		c.Response().Header().Set("Access-Control-Expose-Headers", echo.HeaderXRequestID+", Preference-Applied")
 
 		// Get or generate Request ID
 		reqID := c.Request().Header.Get(echo.HeaderXRequestID)

--- a/pkg/api/rest/middlewares/response-dump.go
+++ b/pkg/api/rest/middlewares/response-dump.go
@@ -42,8 +42,8 @@ func ResponseBodyDump() echo.MiddlewareFunc {
 			reqID := c.Request().Header.Get(echo.HeaderXRequestID)
 			// log.Debug().Msgf("(BodyDump middleware) Request ID: %s", reqID)
 
-			// Skip status update for async requests (202 Accepted)
-			// The background goroutine will update the status when the job completes.
+			// 202 is reserved repo-wide for async jobs (common.RunAsync finalizes the status
+			// itself); never return 202 for any other reason, or its status stays "Handling" forever.
 			if c.Response().Status == http.StatusAccepted {
 				// log.Debug().Msg("Skipping BodyDump for async request (202 Accepted)")
 				return

--- a/pkg/core/common/request-manager.go
+++ b/pkg/core/common/request-manager.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -352,6 +353,62 @@ func UpdateRequestProgress(reqID string, progressData any) {
 	if err := SetRequest(reqID, details); err != nil {
 		log.Error().Err(err).Str("reqID", reqID).Msg("Failed to update request progress")
 	}
+}
+
+// maxConcurrentAsyncJobs caps background jobs from RunAsync (shared by all async endpoints).
+const maxConcurrentAsyncJobs = 20
+
+var asyncJobSemaphore = make(chan struct{}, maxConcurrentAsyncJobs)
+
+// RunAsync runs work in the background, recovers panics, and finalizes the request record.
+// Returns false at capacity — caller must respond 503, not spawn anyway.
+//
+// See docs/api-response-policy.md ("Async Responses") for the client-facing contract
+// (Prefer: respond-async -> 202 -> poll GET /request/{reqId}).
+func RunAsync[T any](reqID string, work func() (T, error)) bool {
+	select {
+	case asyncJobSemaphore <- struct{}{}:
+	default:
+		return false
+	}
+	go func() {
+		defer func() { <-asyncJobSemaphore }()
+		defer func() {
+			if r := recover(); r != nil {
+				// Stack trace stays server-side; clients never see it (matches middleware.Recover()).
+				log.Error().Str("reqId", reqID).Str("stack", string(debug.Stack())).Msgf("panic: %v", r)
+				finalizeError(reqID, fmt.Errorf("internal error (panic): %v", r))
+			}
+		}()
+		result, err := work()
+		finalizeRequest(reqID, result, err)
+	}()
+	return true
+}
+
+// finalizeRequest updates a request's status to Success or Error and stores the result or error message.
+func finalizeRequest[T any](reqID string, result T, err error) {
+	details, ok := GetRequest(reqID)
+	if !ok {
+		log.Error().Str("reqId", reqID).Msg("Failed to get request details for status update")
+		return
+	}
+	details.EndTime = time.Now()
+	if err != nil {
+		details.Status = RequestStatusError
+		details.ErrorResponse = err.Error()
+	} else {
+		details.Status = RequestStatusSuccess
+		details.ResponseData = result
+	}
+	if setErr := SetRequest(reqID, details); setErr != nil {
+		log.Error().Err(setErr).Str("reqId", reqID).Msg("Failed to update request status")
+	}
+}
+
+// finalizeError marks a request as failed (e.g. after a panic recovery, with no result value).
+func finalizeError(reqID string, err error) {
+	finalizeRequest[any](reqID, nil, err)
 }
 
 // ============================================================================

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,4 +1,4 @@
-# CM-Beetle UI
+# CM-Beetle UX Lab
 
 Web-based dashboard for **CM-Beetle** — the Computing Infrastructure Migration sub-system of the [Cloud-Barista](https://github.com/cloud-barista) platform.
 


### PR DESCRIPTION
- Opt-in via Prefer: respond-async header (RFC 7240)
- Support infra migration, recommendation, NLB, object storage
- Add test-cli/async for end-to-end async flow testing
- Document in feature-guide/async-responses.md


<details>
  <summary>Click to see the test result by `make test-async`</summary>

```
Running async response test CLI...
2026/07/21 17:29:38 No main config file, using default settings: Config File "config" Not Found in "[/home/ubuntu/dev/cloud-barista/cm-beetle/cmd/conf /home/ubuntu/dev/cloud-barista/cm-beetle/cmd/test-cli/async /home/ubuntu/dev/cloud-barista/cm-beetle/cmd/test-cli/async/conf]"
2026/07/21 17:29:38 Finding project root by using project name
Set current directory as project root directory (project name not found in the path)
2026/07/21 17:29:38 Set current directory as project root directory (project name not found in the path)
Project root directory: /tmp/go-build3969088135/b001/exe
2026/07/21 17:29:38 Project root directory: /tmp/go-build3969088135/b001/exe
{"level":"warn","time":"2026-07-21T17:29:38+09:00","message":"Invalid log writer: console. Using default value: both"}
5:29PM INF pkg/logger/logger.go:212 > Multi-writes setup (logs to both file and console) ConsoleWriter=os.Stdout logFilePath=./log/app.log
5:29PM INF pkg/logger/logger.go:144 > New logger created logLevel=debug
=========================================================
 CM-Beetle Async Response Test CLI
 Recommend -> Poll -> Get -> Migrate -> Poll -> Get -> Delete -> Poll -> Get
=========================================================

[1/9] POST /recommendation/infra (Prefer: respond-async)
      -> 202 Accepted, reqId=1784622578160908100

[2/9] Poll GET /request/{reqId} (recommendation)
      ... [2s elapsed, poll #1] status: Handling
      ... [5s elapsed, poll #2] status: Handling
      ... [10s elapsed, poll #3] status: Handling
      ... [16s elapsed, poll #4] status: Success
      -> status: Success

[3/9] Inspect recommendation result
      -> 3 candidate(s) recommended; using candidate #1 for migration

[4/9] POST /migration/ns/{nsId}/infra (Prefer: respond-async)
      -> 202 Accepted, reqId=1784622591980162051

[5/9] Poll GET /request/{reqId} (migration)
      ... [2s elapsed, poll #1] status: Handling
      ... [5s elapsed, poll #2] status: Handling
      ... [10s elapsed, poll #3] status: Handling
      ... [16s elapsed, poll #4] status: Handling
      ... [26s elapsed, poll #5] status: Handling
      ... [41s elapsed, poll #6] status: Handling
      ... [57s elapsed, poll #7] status: Success
      -> status: Success
      -> infraId: infra101

[6/9] GET /migration/ns/{nsId}/infra/{infraId}
      -> HTTP 200: {"success":true,"data":{"resourceType":"infra","id":"infra101","uid":"tbimf2fgnpmrpe7a55dj","name":"infra101","status":"Running:3 (R:3/3)","statusCount":{"countTotal":3,"countCreating":0,"countRunning":3,"countFailed":0,"countSuspended":0,"countRebooting":0,"countTerminated":0,"countSuspending":0,"c...

[7/9] DELETE /migration/ns/{nsId}/infra/{infraId} (Prefer: respond-async)
      -> 202 Accepted, reqId=1784622643511406024

[8/9] Poll GET /request/{reqId} (deletion)
      ... [2s elapsed, poll #1] status: Handling
      ... [5s elapsed, poll #2] status: Handling
      ... [10s elapsed, poll #3] status: Handling
      ... [16s elapsed, poll #4] status: Handling
      ... [26s elapsed, poll #5] status: Handling
      ... [41s elapsed, poll #6] status: Handling
      ... [56s elapsed, poll #7] status: Handling
      ... [1m11s elapsed, poll #8] status: Handling
      ... [1m26s elapsed, poll #9] status: Handling
      ... [1m41s elapsed, poll #10] status: Handling
      ... [1m56s elapsed, poll #11] status: Success
      -> status: Success

[9/9] GET /migration/ns/{nsId}/infra/{infraId} (expect 404)
      -> HTTP 404: deletion confirmed

=========================================================
 Done.
=========================================================
```

</details>
