### PR TITLE
feat(recommendation): add multi-target infra recommendation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ cmd/test-cli/async/testconf/test-config.yaml
 cmd/test-cli/rate-limiting/test-rate-limiting
 cmd/test-cli/rate-limiting/testconf/auth-config.json
 cmd/test-cli/rate-limiting/testconf/test-config.yaml
+cmd/test-cli/multi-infra-recommendation/test-multi-infra-recommendation
+cmd/test-cli/multi-infra-recommendation/testconf/auth-config.json
+cmd/test-cli/multi-infra-recommendation/testconf/test-config.yaml
 pkg/testclient/scripts/sequentialFullTest/executionStatus*
 pkg/testclient/scripts/sequentialFullTest/ansibleAutoConf/*
 pkg/testclient/scripts/credentials*

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ clean: ## Remove previous build
 	@cd cmd/test-cli/data && $(GO) clean
 	@cd cmd/test-cli/async && $(GO) clean
 	@cd cmd/test-cli/rate-limiting && $(GO) clean
+	@cd cmd/test-cli/multi-infra-recommendation && $(GO) clean
 	@echo "Cleaned!"
 
 test-infra: ## Run the infra migration test CLI for all CSP-Region pairs
@@ -153,6 +154,14 @@ test-rate-limiting: ## Run the rate limiting test CLI (retrieval burst + concurr
 		echo "Created testconf/test-config.yaml from template. Edit it before running."; \
 	fi
 	@cd cmd/test-cli/rate-limiting && $(GO) run main.go -config testconf/test-config.yaml
+
+test-multi-infra-recommendation: ## Run the multi-target infra recommendation test CLI (multiInfra / multiInfraWithNlb)
+	@echo "Running multi-infra recommendation test CLI..."
+	@if [ ! -f cmd/test-cli/multi-infra-recommendation/testconf/test-config.yaml ]; then \
+		cp cmd/test-cli/multi-infra-recommendation/testconf/template-test-config.yaml cmd/test-cli/multi-infra-recommendation/testconf/test-config.yaml; \
+		echo "Created testconf/test-config.yaml from template. Edit it before running."; \
+	fi
+	@cd cmd/test-cli/multi-infra-recommendation && $(GO) run main.go -config testconf/test-config.yaml
 
 test-data-clean: ## Clean up data migration test artifacts
 	@echo "Cleaning data migration test artifacts..."

--- a/api/docs.go
+++ b/api/docs.go
@@ -3834,6 +3834,166 @@ const docTemplate = `{
                 }
             }
         },
+        "/recommendation/multiInfra": {
+            "post": {
+                "description": "Recommend a single best-effort infrastructure candidate for each of several target CSP/region pairs.\n\nUse this API to compare candidate clouds before committing to one; once a target is chosen,\nuse ` + "`" + `POST /recommendation/infra` + "`" + ` against that single CSP/region to explore multiple candidates.\n\n**[Required Parameter: ` + "`" + `desiredCspAndRegionPairs` + "`" + `]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).\nDuplicate pairs are rejected.\n\n**[Response]** Always returns exactly one item per requested target, in request order\n(` + "`" + `len(data) == len(desiredCspAndRegionPairs)` + "`" + `), so items map back to targets via ` + "`" + `targetCloud` + "`" + `\nwithout needing to be re-sorted or grouped. A target that fails validation or yields no\ncompatible infrastructure still produces one item, with ` + "`" + `status` + "`" + ` set to ` + "`" + `failed` + "`" + ` or\n` + "`" + `nothing-to-recommend` + "`" + ` and ` + "`" + `targetInfra` + "`" + ` left empty.\n\n**[Optional Parameter: ` + "`" + `minMatchRate` + "`" + `]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n[Note] Each target costs roughly as much as one ` + "`" + `/recommendation/infra` + "`" + ` call; requests with\nseveral targets can take a while. ` + "`" + `Prefer: respond-async` + "`" + ` is strongly recommended.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Infrastructure"
+                ],
+                "summary": "Recommend the best-match infrastructure per target cloud, for cross-CSP comparison",
+                "operationId": "RecommendMultiInfraCandidates",
+                "parameters": [
+                    {
+                        "description": "Target CSP/region pairs and the source infrastructure to be migrated",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendMultiInfraRequest"
+                        }
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
+                        "name": "minMatchRate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "One recommended (or failed/nothing-to-recommend) candidate per target, in request order",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/recommendation/multiInfraWithNlb": {
+            "post": {
+                "description": "NLB-aware counterpart of ` + "`" + `POST /recommendation/multiInfra` + "`" + `. Recommends a single best-effort\ninfrastructure candidate (including NLB mapping) for each of several target CSP/region pairs.\n\nUse this API to compare candidate clouds before committing to one; once a target is chosen,\nuse ` + "`" + `POST /recommendation/infraWithNlb` + "`" + ` against that single CSP/region to explore multiple candidates.\n\n**[Required Parameter: ` + "`" + `desiredCspAndRegionPairs` + "`" + `]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).\nDuplicate pairs are rejected.\n\n[Note] ` + "`" + `sourceInfra.nlbs` + "`" + ` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n**[Response]** Always returns exactly one item per requested target, in request order\n(` + "`" + `len(data) == len(desiredCspAndRegionPairs)` + "`" + `), so items map back to targets via ` + "`" + `targetCloud` + "`" + `\nwithout needing to be re-sorted or grouped. A target that fails validation or yields no\ncompatible infrastructure still produces one item, with ` + "`" + `status` + "`" + ` set to ` + "`" + `failed` + "`" + ` or\n` + "`" + `nothing-to-recommend` + "`" + ` and ` + "`" + `targetInfra` + "`" + ` left empty.\n\n**[Optional Parameter: ` + "`" + `minMatchRate` + "`" + `]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n[Note] Each target costs roughly as much as one ` + "`" + `/recommendation/infraWithNlb` + "`" + ` call; requests with\nseveral targets can take a while. ` + "`" + `Prefer: respond-async` + "`" + ` is strongly recommended.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Infrastructure"
+                ],
+                "summary": "(Preview) Recommend the best-match NLB-aware infrastructure per target cloud, for cross-CSP comparison",
+                "operationId": "RecommendMultiInfraWithNlbCandidates",
+                "parameters": [
+                    {
+                        "description": "Target CSP/region pairs and the source infra including NLBs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendMultiInfraWithNlbRequest"
+                        }
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
+                        "name": "minMatchRate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "One recommended (or failed/nothing-to-recommend) candidate per target, in request order",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
         "/recommendation/resources/osImages": {
             "post": {
                 "description": "Recommend an appropriate OS image for cloud migration\n\n[Note] ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` are required.\n- ` + "`" + `desiredProvider` + "`" + ` and ` + "`" + `desiredRegion` + "`" + ` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
@@ -7633,6 +7793,46 @@ const docTemplate = `{
                 "desiredRegion": {
                     "description": "Target region (e.g., \"ap-northeast-2\")",
                     "type": "string"
+                },
+                "sourceInfra": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendMultiInfraRequest": {
+            "type": "object",
+            "required": [
+                "desiredCspAndRegionPairs",
+                "sourceInfra"
+            ],
+            "properties": {
+                "desiredCspAndRegionPairs": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "minItems": 2,
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.CloudProperty"
+                    }
+                },
+                "sourceInfra": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendMultiInfraWithNlbRequest": {
+            "type": "object",
+            "required": [
+                "desiredCspAndRegionPairs",
+                "sourceInfra"
+            ],
+            "properties": {
+                "desiredCspAndRegionPairs": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "minItems": 2,
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.CloudProperty"
+                    }
                 },
                 "sourceInfra": {
                     "$ref": "#/definitions/onpremisemodel.OnpremInfra"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3828,6 +3828,166 @@
                 }
             }
         },
+        "/recommendation/multiInfra": {
+            "post": {
+                "description": "Recommend a single best-effort infrastructure candidate for each of several target CSP/region pairs.\n\nUse this API to compare candidate clouds before committing to one; once a target is chosen,\nuse `POST /recommendation/infra` against that single CSP/region to explore multiple candidates.\n\n**[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).\nDuplicate pairs are rejected.\n\n**[Response]** Always returns exactly one item per requested target, in request order\n(`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`\nwithout needing to be re-sorted or grouped. A target that fails validation or yields no\ncompatible infrastructure still produces one item, with `status` set to `failed` or\n`nothing-to-recommend` and `targetInfra` left empty.\n\n**[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n[Note] Each target costs roughly as much as one `/recommendation/infra` call; requests with\nseveral targets can take a while. `Prefer: respond-async` is strongly recommended.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Infrastructure"
+                ],
+                "summary": "Recommend the best-match infrastructure per target cloud, for cross-CSP comparison",
+                "operationId": "RecommendMultiInfraCandidates",
+                "parameters": [
+                    {
+                        "description": "Target CSP/region pairs and the source infrastructure to be migrated",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendMultiInfraRequest"
+                        }
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
+                        "name": "minMatchRate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "One recommended (or failed/nothing-to-recommend) candidate per target, in request order",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/recommendation/multiInfraWithNlb": {
+            "post": {
+                "description": "NLB-aware counterpart of `POST /recommendation/multiInfra`. Recommends a single best-effort\ninfrastructure candidate (including NLB mapping) for each of several target CSP/region pairs.\n\nUse this API to compare candidate clouds before committing to one; once a target is chosen,\nuse `POST /recommendation/infraWithNlb` against that single CSP/region to explore multiple candidates.\n\n**[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).\nDuplicate pairs are rejected.\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n**[Response]** Always returns exactly one item per requested target, in request order\n(`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`\nwithout needing to be re-sorted or grouped. A target that fails validation or yields no\ncompatible infrastructure still produces one item, with `status` set to `failed` or\n`nothing-to-recommend` and `targetInfra` left empty.\n\n**[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n[Note] Each target costs roughly as much as one `/recommendation/infraWithNlb` call; requests with\nseveral targets can take a while. `Prefer: respond-async` is strongly recommended.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Recommendation] Infrastructure"
+                ],
+                "summary": "(Preview) Recommend the best-match NLB-aware infrastructure per target cloud, for cross-CSP comparison",
+                "operationId": "RecommendMultiInfraWithNlbCandidates",
+                "parameters": [
+                    {
+                        "description": "Target CSP/region pairs and the source infra including NLBs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.RecommendMultiInfraWithNlbRequest"
+                        }
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)",
+                        "name": "minMatchRate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs.",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "enum": [
+                            "respond-async"
+                        ],
+                        "type": "string",
+                        "description": "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)",
+                        "name": "Prefer",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "One recommended (or failed/nothing-to-recommend) candidate per target, in request order",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra"
+                        }
+                    },
+                    "202": {
+                        "description": "Recommendation started asynchronously - use GET /request/{reqId} to check status",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-model_AsyncJobResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during recommendation",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    },
+                    "503": {
+                        "description": "Too many concurrent async jobs; retry later or without Prefer: respond-async",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-any"
+                        }
+                    }
+                }
+            }
+        },
         "/recommendation/resources/osImages": {
             "post": {
                 "description": "Recommend an appropriate OS image for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.",
@@ -7627,6 +7787,46 @@
                 "desiredRegion": {
                     "description": "Target region (e.g., \"ap-northeast-2\")",
                     "type": "string"
+                },
+                "sourceInfra": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendMultiInfraRequest": {
+            "type": "object",
+            "required": [
+                "desiredCspAndRegionPairs",
+                "sourceInfra"
+            ],
+            "properties": {
+                "desiredCspAndRegionPairs": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "minItems": 2,
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.CloudProperty"
+                    }
+                },
+                "sourceInfra": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                }
+            }
+        },
+        "controller.RecommendMultiInfraWithNlbRequest": {
+            "type": "object",
+            "required": [
+                "desiredCspAndRegionPairs",
+                "sourceInfra"
+            ],
+            "properties": {
+                "desiredCspAndRegionPairs": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "minItems": 2,
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.CloudProperty"
+                    }
                 },
                 "sourceInfra": {
                     "$ref": "#/definitions/onpremisemodel.OnpremInfra"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2169,6 +2169,34 @@ definitions:
     required:
     - sourceInfra
     type: object
+  controller.RecommendMultiInfraRequest:
+    properties:
+      desiredCspAndRegionPairs:
+        items:
+          $ref: '#/definitions/cloudmodel.CloudProperty'
+        maxItems: 10
+        minItems: 2
+        type: array
+      sourceInfra:
+        $ref: '#/definitions/onpremisemodel.OnpremInfra'
+    required:
+    - desiredCspAndRegionPairs
+    - sourceInfra
+    type: object
+  controller.RecommendMultiInfraWithNlbRequest:
+    properties:
+      desiredCspAndRegionPairs:
+        items:
+          $ref: '#/definitions/cloudmodel.CloudProperty'
+        maxItems: 10
+        minItems: 2
+        type: array
+      sourceInfra:
+        $ref: '#/definitions/onpremisemodel.OnpremInfra'
+    required:
+    - desiredCspAndRegionPairs
+    - sourceInfra
+    type: object
   controller.RecommendObjectStorageRequest:
     properties:
       desiredCloud:
@@ -8757,6 +8785,165 @@ paths:
       summary: Get CSP feature support map for object storage (Proxied to Tumblebug)
       tags:
       - '[Recommendation] Managed Object Storage'
+  /recommendation/multiInfra:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Recommend a single best-effort infrastructure candidate for each of several target CSP/region pairs.
+
+        Use this API to compare candidate clouds before committing to one; once a target is chosen,
+        use `POST /recommendation/infra` against that single CSP/region to explore multiple candidates.
+
+        **[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).
+        Duplicate pairs are rejected.
+
+        **[Response]** Always returns exactly one item per requested target, in request order
+        (`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`
+        without needing to be re-sorted or grouped. A target that fails validation or yields no
+        compatible infrastructure still produces one item, with `status` set to `failed` or
+        `nothing-to-recommend` and `targetInfra` left empty.
+
+        **[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)
+
+        [Note] Each target costs roughly as much as one `/recommendation/infra` call; requests with
+        several targets can take a while. `Prefer: respond-async` is strongly recommended.
+      operationId: RecommendMultiInfraCandidates
+      parameters:
+      - description: Target CSP/region pairs and the source infrastructure to be migrated
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/controller.RecommendMultiInfraRequest'
+      - description: 'Minimum match rate for highly-matched classification (default:
+          90.0, range: 0-100)'
+        in: query
+        name: minMatchRate
+        type: number
+      - description: Unique request ID (auto-generated if not provided). Used for
+          tracking request status and correlating logs.
+        in: header
+        name: X-Request-Id
+        type: string
+      - description: Set to 'respond-async' to run this recommendation asynchronously
+          (RFC 7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: One recommended (or failed/nothing-to-recommend) candidate
+            per target, in request order
+          schema:
+            $ref: '#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra'
+        "202":
+          description: Recommendation started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "500":
+          description: Internal server error during recommendation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: Recommend the best-match infrastructure per target cloud, for cross-CSP
+        comparison
+      tags:
+      - '[Recommendation] Infrastructure'
+  /recommendation/multiInfraWithNlb:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        NLB-aware counterpart of `POST /recommendation/multiInfra`. Recommends a single best-effort
+        infrastructure candidate (including NLB mapping) for each of several target CSP/region pairs.
+
+        Use this API to compare candidate clouds before committing to one; once a target is chosen,
+        use `POST /recommendation/infraWithNlb` against that single CSP/region to explore multiple candidates.
+
+        **[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).
+        Duplicate pairs are rejected.
+
+        [Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).
+
+        **[Response]** Always returns exactly one item per requested target, in request order
+        (`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`
+        without needing to be re-sorted or grouped. A target that fails validation or yields no
+        compatible infrastructure still produces one item, with `status` set to `failed` or
+        `nothing-to-recommend` and `targetInfra` left empty.
+
+        **[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)
+
+        [Note] Each target costs roughly as much as one `/recommendation/infraWithNlb` call; requests with
+        several targets can take a while. `Prefer: respond-async` is strongly recommended.
+      operationId: RecommendMultiInfraWithNlbCandidates
+      parameters:
+      - description: Target CSP/region pairs and the source infra including NLBs
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/controller.RecommendMultiInfraWithNlbRequest'
+      - description: 'Minimum match rate for highly-matched classification (default:
+          90.0, range: 0-100)'
+        in: query
+        name: minMatchRate
+        type: number
+      - description: Unique request ID (auto-generated if not provided). Used for
+          tracking request status and correlating logs.
+        in: header
+        name: X-Request-Id
+        type: string
+      - description: Set to 'respond-async' to run this recommendation asynchronously
+          (RFC 7240)
+        enum:
+        - respond-async
+        in: header
+        name: Prefer
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: One recommended (or failed/nothing-to-recommend) candidate
+            per target, in request order
+          schema:
+            $ref: '#/definitions/model.ApiResponse-array_cloudmodel_RecommendedInfra'
+        "202":
+          description: Recommendation started asynchronously - use GET /request/{reqId}
+            to check status
+          schema:
+            $ref: '#/definitions/model.ApiResponse-model_AsyncJobResponse'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "500":
+          description: Internal server error during recommendation
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+        "503":
+          description: 'Too many concurrent async jobs; retry later or without Prefer:
+            respond-async'
+          schema:
+            $ref: '#/definitions/model.ApiResponse-any'
+      summary: (Preview) Recommend the best-match NLB-aware infrastructure per target
+        cloud, for cross-CSP comparison
+      tags:
+      - '[Recommendation] Infrastructure'
   /recommendation/resources/osImages:
     post:
       consumes:

--- a/cmd/test-cli/multi-infra-recommendation/README.md
+++ b/cmd/test-cli/multi-infra-recommendation/README.md
@@ -1,0 +1,63 @@
+# CM-Beetle Multi-Infra Recommendation Test CLI
+
+Automated test tool for `POST /recommendation/multiInfra` and `POST /recommendation/multiInfraWithNlb` —
+the cross-CSP comparison APIs that recommend one best-match candidate per target CSP/region pair.
+
+Modeled on `cmd/test-cli/infra-with-nlb`'s structure (config loading, readiness check, markdown
+report generation), but scoped to exactly the recommendation call itself: no validation,
+migration, SSH check, or cleanup, since neither endpoint provisions anything.
+
+## What It Checks
+
+For each endpoint, the CLI sends one request covering all configured targets and verifies the
+response accurately reflects the input:
+
+1. **Request succeeds** — `200` with `success: true`.
+2. **Input/output accuracy** — the response has exactly one result item per requested target,
+   in request order, matched via `targetCloud` (`csp`/`region`).
+
+## Quick Start
+
+```bash
+# From the repository root
+make test-multi-infra-recommendation
+```
+
+This copies `testconf/template-test-config.yaml` to `testconf/test-config.yaml` on first run —
+edit it to point at your Beetle endpoint and select at least 2 CSP/region cases with `execute: true`.
+
+## Configuration
+
+`testconf/test-config.yaml`:
+
+```yaml
+test:
+  cases:
+    - csp: aws
+      region: ap-northeast-2
+      name: AWS-Seoul
+      execute: true
+    - csp: azure
+      region: koreasouth
+      name: Azure-Busan
+      execute: true
+
+beetle:
+  endpoint: http://localhost:8056
+  requestBodyFile: testconf/source-infra.json
+  requestBodyFileWithNlb: testconf/source-infra-with-nlb.json
+  authConfigFile: testconf/auth-config.json
+```
+
+- `requestBodyFile` / `requestBodyFileWithNlb`: `{"nameSeed": ..., "sourceInfra": {...}}` fixtures
+  (the latter's `sourceInfra` includes `nlbs`), used as the `sourceInfra` field for the two tests.
+- Cases with `execute: true` become the request's `desiredCspAndRegionPairs` (capped at 10).
+  At least 2 are required.
+
+## Results
+
+- Console: real-time pass/fail per endpoint and per-target accuracy detail
+- File: `testresult/multi-infra-recommendation-test-report.md` — full request/response bodies
+  (collapsible) and the accuracy check for both endpoints
+
+Exit code is non-zero if either endpoint's call or accuracy check fails.

--- a/cmd/test-cli/multi-infra-recommendation/main.go
+++ b/cmd/test-cli/multi-infra-recommendation/main.go
@@ -1,0 +1,480 @@
+// Package main is the starting point of CM-Beetle Multi-Infra Recommendation Test CLI.
+//
+// Scoped to exactly one thing: sending a real multi-target recommendation request to
+// POST /recommendation/multiInfra and /recommendation/multiInfraWithNlb, and verifying the
+// response accurately reflects the request — one result item per requested target, in request
+// order. Modeled on cmd/test-cli/infra-with-nlb's structure, but without its migration/
+// validation/SSH/cleanup steps, since neither multi-target endpoint provisions anything.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+
+	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
+	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
+	"github.com/cloud-barista/cm-beetle/pkg/api/rest/controller"
+	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
+	"github.com/cloud-barista/cm-beetle/pkg/config"
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
+	"github.com/cloud-barista/cm-beetle/pkg/logger"
+)
+
+// TestConfig holds test configuration.
+type TestConfig struct {
+	Test struct {
+		Cases []TestCase `yaml:"cases"`
+	} `yaml:"test"`
+	Beetle struct {
+		Endpoint               string `yaml:"endpoint"`
+		RequestBodyFile        string `yaml:"requestBodyFile"`
+		RequestBodyFileWithNlb string `yaml:"requestBodyFileWithNlb"`
+		AuthConfigFile         string `yaml:"authConfigFile"`
+	} `yaml:"beetle"`
+}
+
+// TestCase is one candidate target; only entries with Execute: true are used.
+type TestCase struct {
+	cloudmodel.CloudProperty `yaml:",inline"`
+	Name                     string `yaml:"name"`
+	Execute                  bool   `yaml:"execute"`
+}
+
+// AuthConfig holds Beetle API credentials.
+type AuthConfig struct {
+	BeetleApiUsername string `json:"beetleApiUsername"`
+	BeetleApiPassword string `json:"beetleApiPassword"`
+}
+
+// TestResults holds one API call's execution result.
+type TestResults struct {
+	TestName     string        `json:"testName"`
+	StartTime    time.Time     `json:"startTime"`
+	EndTime      time.Time     `json:"endTime"`
+	Duration     time.Duration `json:"duration"`
+	Success      bool          `json:"success"`
+	StatusCode   int           `json:"statusCode"`
+	ErrorMessage string        `json:"errorMessage,omitempty"`
+	RequestURL   string        `json:"requestUrl,omitempty"`
+}
+
+// AccuracyCheck records whether a response's targetCloud order/coverage matched the request.
+type AccuracyCheck struct {
+	Passed  bool
+	Details []string
+}
+
+// MultiInfraTestReport captures request/response and accuracy checks for both endpoints,
+// making it possible to write out a single markdown report at the end.
+type MultiInfraTestReport struct {
+	TestDate     string
+	TestTime     string
+	TestDateTime time.Time
+	BeetleURL    string
+	Targets      []cloudmodel.CloudProperty
+
+	Request  controller.RecommendMultiInfraRequest
+	Response *model.ApiResponse[[]cloudmodel.RecommendedInfra]
+	Result   TestResults
+	Accuracy AccuracyCheck
+
+	RequestWithNlb  controller.RecommendMultiInfraWithNlbRequest
+	ResponseWithNlb *model.ApiResponse[[]cloudmodel.RecommendedInfra]
+	ResultWithNlb   TestResults
+	AccuracyWithNlb AccuracyCheck
+}
+
+var configFile = flag.String("config", "testconf/test-config.yaml", "Path to config file")
+
+func init() {
+	config.Init()
+	l := logger.NewLogger(logger.Config{
+		LogLevel:    config.Beetle.LogLevel,
+		LogWriter:   config.Beetle.LogWriter,
+		LogFilePath: config.Beetle.LogFile.Path,
+		MaxSize:     config.Beetle.LogFile.MaxSize,
+		MaxBackups:  config.Beetle.LogFile.MaxBackups,
+		MaxAge:      config.Beetle.LogFile.MaxAge,
+		Compress:    config.Beetle.LogFile.Compress,
+	})
+	log.Logger = *l
+}
+
+func main() {
+	flag.Parse()
+
+	cfg, err := loadConfig(*configFile)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to load config")
+	}
+
+	sourceInfra, _, err := loadSourceInfraModel(cfg.Beetle.RequestBodyFile)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to load source infra model")
+	}
+	sourceInfraWithNlb, _, err := loadSourceInfraModel(cfg.Beetle.RequestBodyFileWithNlb)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to load NLB-aware source infra model")
+	}
+
+	var targets []cloudmodel.CloudProperty
+	for _, c := range cfg.Test.Cases {
+		if c.Execute {
+			targets = append(targets, c.CloudProperty)
+		}
+	}
+	if len(targets) < 2 {
+		log.Fatal().Msg("At least 2 test cases must have execute: true")
+	}
+	if len(targets) > 10 {
+		targets = targets[:10]
+	}
+
+	client := resty.New()
+	client.SetTimeout(2 * time.Minute)
+
+	if err := checkBeetleReadiness(client, cfg.Beetle.Endpoint); err != nil {
+		log.Fatal().Err(err).Msg("CM-Beetle readiness check failed")
+	}
+
+	authConfig, err := loadAuthConfig(cfg.Beetle.AuthConfigFile)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to load auth config; proceeding without auth")
+	} else if authConfig.BeetleApiUsername != "" {
+		client.SetBasicAuth(authConfig.BeetleApiUsername, authConfig.BeetleApiPassword)
+	}
+
+	now := time.Now()
+	report := &MultiInfraTestReport{
+		TestDate:     now.Format("2006-01-02"),
+		TestTime:     now.Format("15:04:05"),
+		TestDateTime: now,
+		BeetleURL:    cfg.Beetle.Endpoint,
+		Targets:      targets,
+	}
+
+	fmt.Println("\n--- Test 1: POST /beetle/recommendation/multiInfra ---")
+	report.Request = controller.RecommendMultiInfraRequest{
+		DesiredCspAndRegionPairs: targets,
+		SourceInfra:              sourceInfra,
+	}
+	report.Response, report.Result = runMultiInfraRecommendationTest(
+		client, cfg.Beetle.Endpoint, "/beetle/recommendation/multiInfra", report.Request)
+	if report.Result.Success {
+		report.Accuracy = checkInputOutputAccuracy(targets, report.Response)
+		printAccuracy("Test 1", report.Accuracy)
+	}
+
+	fmt.Println("\n--- Test 2: POST /beetle/recommendation/multiInfraWithNlb ---")
+	report.RequestWithNlb = controller.RecommendMultiInfraWithNlbRequest{
+		DesiredCspAndRegionPairs: targets,
+		SourceInfra:              sourceInfraWithNlb,
+	}
+	report.ResponseWithNlb, report.ResultWithNlb = runMultiInfraRecommendationTest(
+		client, cfg.Beetle.Endpoint, "/beetle/recommendation/multiInfraWithNlb",
+		controller.RecommendMultiInfraRequest(report.RequestWithNlb))
+	if report.ResultWithNlb.Success {
+		report.AccuracyWithNlb = checkInputOutputAccuracy(targets, report.ResponseWithNlb)
+		printAccuracy("Test 2", report.AccuracyWithNlb)
+	}
+
+	if err := generateMarkdownReport(report); err != nil {
+		log.Warn().Err(err).Msg("Failed to generate markdown report")
+	}
+
+	allPassed := report.Result.Success && report.Accuracy.Passed &&
+		report.ResultWithNlb.Success && report.AccuracyWithNlb.Passed
+
+	fmt.Println("\n=========================================================")
+	if allPassed {
+		fmt.Println(" ✅ All recommendation input/output checks passed.")
+	} else {
+		fmt.Println(" ❌ Some recommendation input/output checks failed. See testresult/ for details.")
+	}
+	fmt.Println("=========================================================")
+
+	if !allPassed {
+		os.Exit(1)
+	}
+}
+
+// runMultiInfraRecommendationTest sends the request body as-is to the given path and returns
+// the parsed response alongside execution metadata; both request and response are expected to
+// use the shared cloudmodel.RecommendedInfra shape regardless of which endpoint is called.
+func runMultiInfraRecommendationTest(client *resty.Client, beetleURL, path string, reqBody controller.RecommendMultiInfraRequest) (*model.ApiResponse[[]cloudmodel.RecommendedInfra], TestResults) {
+	url := beetleURL + path
+	result := TestResults{TestName: fmt.Sprintf("POST %s", path), StartTime: time.Now(), RequestURL: url}
+
+	var apiResponse model.ApiResponse[[]cloudmodel.RecommendedInfra]
+	err := common.ExecuteHttpRequest(client, "POST", url, nil, true, &reqBody, &apiResponse, 0)
+
+	result.EndTime = time.Now()
+	result.Duration = result.EndTime.Sub(result.StartTime)
+
+	if err != nil {
+		result.ErrorMessage = err.Error()
+		fmt.Printf("❌ %s failed: %s\n", result.TestName, err)
+		return nil, result
+	}
+	if !apiResponse.Success {
+		result.ErrorMessage = apiResponse.Error
+		fmt.Printf("❌ %s failed: %s\n", result.TestName, apiResponse.Error)
+		return &apiResponse, result
+	}
+
+	result.Success = true
+	result.StatusCode = 200
+	fmt.Printf("✅ %s passed (%d target(s), %v)\n", result.TestName, len(apiResponse.Data), result.Duration.Truncate(time.Millisecond))
+	return &apiResponse, result
+}
+
+// checkInputOutputAccuracy verifies the response has exactly one item per requested target,
+// in request order, matched via targetCloud — the contract both endpoints must uphold.
+func checkInputOutputAccuracy(targets []cloudmodel.CloudProperty, resp *model.ApiResponse[[]cloudmodel.RecommendedInfra]) AccuracyCheck {
+	check := AccuracyCheck{Passed: true}
+
+	if resp == nil {
+		check.Passed = false
+		check.Details = append(check.Details, "no response to check")
+		return check
+	}
+	if len(resp.Data) != len(targets) {
+		check.Passed = false
+		check.Details = append(check.Details, fmt.Sprintf("expected %d result item(s), got %d", len(targets), len(resp.Data)))
+		return check
+	}
+	for i, want := range targets {
+		got := resp.Data[i].TargetCloud
+		if strings.EqualFold(got.Csp, want.Csp) && strings.EqualFold(got.Region, want.Region) {
+			check.Details = append(check.Details, fmt.Sprintf("result[%d] targetCloud=%s/%s status=%s — matches request", i, got.Csp, got.Region, resp.Data[i].Status))
+		} else {
+			check.Passed = false
+			check.Details = append(check.Details, fmt.Sprintf("result[%d] targetCloud=%s/%s, want %s/%s", i, got.Csp, got.Region, want.Csp, want.Region))
+		}
+	}
+	return check
+}
+
+func printAccuracy(label string, check AccuracyCheck) {
+	status := "✅"
+	if !check.Passed {
+		status = "❌"
+	}
+	fmt.Printf("%s %s input/output accuracy check\n", status, label)
+	for _, d := range check.Details {
+		fmt.Printf("      - %s\n", d)
+	}
+}
+
+// checkBeetleReadiness checks if CM-Beetle is ready using GET /beetle/readyz.
+func checkBeetleReadiness(client *resty.Client, beetleURL string) error {
+	fmt.Println("🔍 Checking CM-Beetle readiness...")
+	url := beetleURL + "/beetle/readyz"
+
+	var response map[string]interface{}
+	var emptyBody interface{} = common.NoBody
+	err := common.ExecuteHttpRequest(client, "GET", url, nil, common.SetUseBody(emptyBody), &emptyBody, &response, 0)
+	if err != nil {
+		return fmt.Errorf("CM-Beetle readiness check failed: %w", err)
+	}
+	if message, ok := response["message"].(string); ok && strings.Contains(message, "NOT ready") {
+		return fmt.Errorf("CM-Beetle is not ready: %s", message)
+	}
+	fmt.Println("✅ CM-Beetle is ready!")
+	return nil
+}
+
+func loadConfig(configPath string) (TestConfig, error) {
+	var cfg TestConfig
+	file, err := os.Open(configPath)
+	if err != nil {
+		return cfg, err
+	}
+	defer file.Close()
+	if err := yaml.NewDecoder(file).Decode(&cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func loadAuthConfig(authConfigPath string) (AuthConfig, error) {
+	var auth AuthConfig
+	file, err := os.Open(authConfigPath)
+	if err != nil {
+		return auth, err
+	}
+	defer file.Close()
+	if err := json.NewDecoder(file).Decode(&auth); err != nil {
+		return auth, fmt.Errorf("failed to decode auth config: %w", err)
+	}
+	return auth, nil
+}
+
+// loadSourceInfraModel reads {"nameSeed": ..., "sourceInfra": {...}} — same shape as
+// cmd/test-cli/infra-with-nlb's fixture files.
+func loadSourceInfraModel(requestBodyPath string) (onpremmodel.OnpremInfra, string, error) {
+	var tempRequest struct {
+		NameSeed    string                  `json:"nameSeed"`
+		SourceInfra onpremmodel.OnpremInfra `json:"sourceInfra"`
+	}
+	file, err := os.Open(requestBodyPath)
+	if err != nil {
+		return tempRequest.SourceInfra, tempRequest.NameSeed, fmt.Errorf("failed to open request body file: %w", err)
+	}
+	defer file.Close()
+	if err := json.NewDecoder(file).Decode(&tempRequest); err != nil {
+		return tempRequest.SourceInfra, tempRequest.NameSeed, fmt.Errorf("failed to decode source infra model: %w", err)
+	}
+	return tempRequest.SourceInfra, tempRequest.NameSeed, nil
+}
+
+// generateMarkdownReport writes the request/response bodies and accuracy checks for both
+// endpoints to testresult/multi-infra-recommendation-test-report.md.
+func generateMarkdownReport(report *MultiInfraTestReport) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	testResultDir := filepath.Join(cwd, "testresult")
+	if err := os.MkdirAll(testResultDir, 0755); err != nil {
+		return err
+	}
+
+	content := generateMarkdownContent(report)
+	path := filepath.Join(testResultDir, "multi-infra-recommendation-test-report.md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return err
+	}
+	log.Info().Str("file", path).Msg("✅ Test report generated and saved")
+	return nil
+}
+
+func generateMarkdownContent(report *MultiInfraTestReport) string {
+	var sb strings.Builder
+
+	sb.WriteString("# CM-Beetle Multi-Infra Recommendation Test Results\n\n")
+	sb.WriteString("> [!NOTE]\n")
+	sb.WriteString("> Verifies that `POST /recommendation/multiInfra` and `POST /recommendation/multiInfraWithNlb`\n")
+	sb.WriteString("> return exactly one result item per requested target, in request order.\n\n")
+
+	sb.WriteString("## Environment\n\n")
+	sb.WriteString(fmt.Sprintf("- CM-Beetle URL: %s\n", report.BeetleURL))
+	sb.WriteString(fmt.Sprintf("- Test Date: %s %s\n", report.TestDate, report.TestTime))
+	sb.WriteString(fmt.Sprintf("- Target Count: %d\n", len(report.Targets)))
+	var targetList []string
+	for _, t := range report.Targets {
+		targetList = append(targetList, fmt.Sprintf("%s/%s", t.Csp, t.Region))
+	}
+	sb.WriteString(fmt.Sprintf("- Targets: %s\n\n", strings.Join(targetList, ", ")))
+
+	writeSummarySection(&sb, report)
+
+	writeEndpointSection(&sb, 1, "Test 1: Recommend multiple target infrastructures",
+		"/beetle/recommendation/multiInfra", "Get one best-match cloud infrastructure recommendation per requested CSP/region pair",
+		report.Request, report.Response, report.Result, report.Accuracy)
+	writeEndpointSection(&sb, 2, "Test 2: Recommend multiple target infrastructures (with NLB)",
+		"/beetle/recommendation/multiInfraWithNlb", "Get one best-match, NLB-aware cloud infrastructure recommendation per requested CSP/region pair",
+		report.RequestWithNlb, report.ResponseWithNlb, report.ResultWithNlb, report.AccuracyWithNlb)
+
+	return sb.String()
+}
+
+// writeSummarySection writes an overview table of both endpoint tests, mirroring
+// cmd/test-cli/infra-with-nlb's "Test Results Summary" section.
+func writeSummarySection(sb *strings.Builder, report *MultiInfraTestReport) {
+	sb.WriteString("### Test Results Summary\n\n")
+	sb.WriteString("| Test | Step (Endpoint / Description) | Status | Duration | Details |\n")
+	sb.WriteString("|------|-------------------------------|--------|----------|----------|\n")
+
+	rows := []struct {
+		endpoint string
+		result   TestResults
+		accuracy AccuracyCheck
+	}{
+		{"/beetle/recommendation/multiInfra", report.Result, report.Accuracy},
+		{"/beetle/recommendation/multiInfraWithNlb", report.ResultWithNlb, report.AccuracyWithNlb},
+	}
+
+	passed := 0
+	var totalDuration time.Duration
+	for i, r := range rows {
+		status := "✅ **PASS**"
+		details := "Pass"
+		if !r.result.Success {
+			status = "❌ **FAIL**"
+			details = r.result.ErrorMessage
+		} else if !r.accuracy.Passed {
+			status = "❌ **FAIL**"
+			details = "Input/output accuracy check failed"
+		} else {
+			passed++
+		}
+		sb.WriteString(fmt.Sprintf("| %d | `POST %s` | %s | %v | %s |\n",
+			i+1, r.endpoint, status, r.result.Duration.Truncate(time.Millisecond), details))
+		totalDuration += r.result.Duration
+	}
+
+	sb.WriteString(fmt.Sprintf("\n**Overall Result**: %d/%d tests passed", passed, len(rows)))
+	if passed == len(rows) {
+		sb.WriteString(" ✅\n\n")
+	} else {
+		sb.WriteString(" ❌\n\n")
+	}
+	sb.WriteString(fmt.Sprintf("**Total Duration**: %v\n\n", totalDuration))
+	sb.WriteString(fmt.Sprintf("*Test executed on %s at %s using CM-Beetle automated test CLI*\n\n---\n\n",
+		report.TestDateTime.Format("January 2, 2006"), report.TestDateTime.Format("15:04:05 MST")))
+}
+
+func writeEndpointSection(sb *strings.Builder, testNum int, title, endpoint, purpose string, reqBody interface{}, resp *model.ApiResponse[[]cloudmodel.RecommendedInfra], result TestResults, accuracy AccuracyCheck) {
+	sb.WriteString(fmt.Sprintf("## %s\n\n", title))
+
+	sb.WriteString(fmt.Sprintf("#### %d.1 API Request Information\n\n", testNum))
+	sb.WriteString(fmt.Sprintf("- **API Endpoint**: `POST %s`\n", endpoint))
+	sb.WriteString(fmt.Sprintf("- **Purpose**: %s\n\n", purpose))
+
+	sb.WriteString("**Request Body**:\n\n<details>\n  <summary> <ins>Click to see the request body</ins> </summary>\n\n```json\n")
+	reqJSON, _ := json.MarshalIndent(reqBody, "", "  ")
+	sb.WriteString(string(reqJSON))
+	sb.WriteString("\n```\n\n</details>\n\n")
+
+	sb.WriteString(fmt.Sprintf("#### %d.2 API Response Information\n\n", testNum))
+	status := "✅ **PASS**"
+	if !result.Success {
+		status = "❌ **FAIL**"
+	}
+	sb.WriteString(fmt.Sprintf("- **Status**: %s\n", status))
+	sb.WriteString(fmt.Sprintf("- **Duration**: %v\n", result.Duration.Truncate(time.Millisecond)))
+	if result.ErrorMessage != "" {
+		sb.WriteString(fmt.Sprintf("- **Error**: %s\n", result.ErrorMessage))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("**Response Body**:\n\n<details>\n  <summary> <ins>Click to see the response body</ins> </summary>\n\n```json\n")
+	if resp != nil {
+		respJSON, _ := json.MarshalIndent(resp, "", "  ")
+		sb.WriteString(string(respJSON))
+	} else {
+		sb.WriteString("(no response)")
+	}
+	sb.WriteString("\n```\n\n</details>\n\n")
+
+	sb.WriteString("**Input/Output Accuracy Check**:\n\n")
+	accStatus := "✅ PASS"
+	if !accuracy.Passed {
+		accStatus = "❌ FAIL"
+	}
+	sb.WriteString(fmt.Sprintf("- Overall: %s\n", accStatus))
+	for _, d := range accuracy.Details {
+		sb.WriteString(fmt.Sprintf("- %s\n", d))
+	}
+	sb.WriteString("\n---\n\n")
+}

--- a/cmd/test-cli/multi-infra-recommendation/testconf/source-infra-with-nlb.json
+++ b/cmd/test-cli/multi-infra-recommendation/testconf/source-infra-with-nlb.json
@@ -1,0 +1,408 @@
+{
+  "nameSeed": "my",
+  "sourceInfra": {
+    "network": {
+      "ipv4Networks": {
+        "defaultGateways": [
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec268ed7-821e-9d73-e79f-961262161624"
+          },
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932"
+          },
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 1,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+          "threads": 2,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9999",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-30",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.30/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::6f:deff:fefc:71b1/64"
+            ],
+            "macAddress": "02:6f:de:fc:71:b1",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec268ed7-821e-9d73-e79f-961262161624",
+        "memory": {
+          "available": 1,
+          "totalSize": 2,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 8,
+          "type": "SSD"
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      },
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 2,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
+          "threads": 4,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8086",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-221",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.221/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::8:96ff:fe7d:f417/64"
+            ],
+            "macAddress": "02:08:96:7d:f4:17",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+        "memory": {
+          "available": 15,
+          "totalSize": 16,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 30,
+          "type": "SSD"
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      },
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 2,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+          "threads": 4,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8086",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-138",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.138/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::bf:6eff:fe6c:6e31/64"
+            ],
+            "macAddress": "02:bf:6e:6c:6e:31",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+        "memory": {
+          "available": 7,
+          "totalSize": 8,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 30,
+          "type": "SSD"
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      }
+    ],
+    "nlbs": [
+      {
+        "hostMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+        "software": "haproxy",
+        "listener": {
+          "bindAddress": "*",
+          "port": 9999,
+          "protocol": "tcp"
+        },
+        "backend": {
+          "name": "influxdb_back",
+          "balance": "roundrobin",
+          "protocol": "tcp",
+          "servers": [
+            {
+              "name": "influx1",
+              "ip": "10.0.1.221",
+              "port": 8086
+            },
+            {
+              "name": "influx2",
+              "ip": "10.0.1.138",
+              "port": 8086
+            }
+          ]
+        },
+        "healthCheck": {
+          "enabled": true,
+          "interval": 10,
+          "timeout": 10,
+          "threshold": 3
+        }
+      }
+    ]
+  }
+}

--- a/cmd/test-cli/multi-infra-recommendation/testconf/source-infra.json
+++ b/cmd/test-cli/multi-infra-recommendation/testconf/source-infra.json
@@ -1,0 +1,1844 @@
+{
+  "nameSeed": "my",
+  "sourceInfra": {
+    "network": {
+      "ipv4Networks": {
+        "defaultGateways": [
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec268ed7-821e-9d73-e79f-961262161624"
+          },
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932"
+          },
+          {
+            "interfaceName": "ens5",
+            "ip": "10.0.1.1",
+            "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 1,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+          "threads": 2,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "5432",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9113",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9113",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "5432",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-30",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.30/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::6f:deff:fefc:71b1/64"
+            ],
+            "macAddress": "02:6f:de:fc:71:b1",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec268ed7-821e-9d73-e79f-961262161624",
+        "memory": {
+          "available": 1,
+          "totalSize": 2,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 0,
+          "type": ""
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::6f:deff:fefc:71b1/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      },
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 2,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
+          "threads": 4,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "2049",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "2049",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "111",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "111",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "20048",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "20048",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "32803",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "32803",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9100",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9100",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "2049",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "2049",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "111",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "111",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-221",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.221/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::8:96ff:fe7d:f417/64"
+            ],
+            "macAddress": "02:08:96:7d:f4:17",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+        "memory": {
+          "available": 15,
+          "totalSize": 16,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 0,
+          "type": ""
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::8:96ff:fe7d:f417/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      },
+      {
+        "cpu": {
+          "architecture": "x86_64",
+          "cores": 1,
+          "cpus": 1,
+          "maxSpeed": 2.499,
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+          "threads": 2,
+          "vendor": "GenuineIntel"
+        },
+        "firewallTable": [
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4567",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4567",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4568",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4568",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4444",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4444",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9104",
+            "protocol": "tcp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9104",
+            "protocol": "udp",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "inbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "deny",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          },
+          {
+            "action": "allow",
+            "direction": "outbound",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "srcCIDR": "::/0",
+            "srcPorts": "*"
+          }
+        ],
+        "hostname": "ip-10-0-1-138",
+        "interfaces": [
+          {
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "name": "lo",
+            "state": "up"
+          },
+          {
+            "ipv4CidrBlocks": [
+              "10.0.1.138/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::bf:6eff:fe6c:6e31/64"
+            ],
+            "macAddress": "02:bf:6e:6c:6e:31",
+            "mtu": 9001,
+            "name": "ens5",
+            "state": "up"
+          }
+        ],
+        "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+        "memory": {
+          "available": 7,
+          "totalSize": 8,
+          "type": "DDR4"
+        },
+        "os": {
+          "id": "ubuntu",
+          "idLike": "debian",
+          "name": "Ubuntu",
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "versionCodename": "jammy",
+          "versionId": "22.04"
+        },
+        "rootDisk": {
+          "label": "",
+          "totalSize": 0,
+          "type": ""
+        },
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "fe80::bf:6eff:fe6c:6e31/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "linkState": "up",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "linkState": "up",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cmd/test-cli/multi-infra-recommendation/testconf/template-auth-config.json
+++ b/cmd/test-cli/multi-infra-recommendation/testconf/template-auth-config.json
@@ -1,0 +1,4 @@
+{
+  "beetleApiUsername": "default",
+  "beetleApiPassword": "default"
+}

--- a/cmd/test-cli/multi-infra-recommendation/testconf/template-test-config.yaml
+++ b/cmd/test-cli/multi-infra-recommendation/testconf/template-test-config.yaml
@@ -1,0 +1,28 @@
+test:
+  cases:
+    - csp: aws
+      region: ap-northeast-2
+      name: AWS-Seoul
+      execute: true
+    - csp: azure
+      region: koreasouth
+      name: Azure-Busan
+      execute: true
+    - csp: gcp
+      region: asia-northeast3
+      name: GCP-Seoul
+      execute: false
+    - csp: alibaba
+      region: ap-northeast-2
+      name: Alibaba-Seoul
+      execute: false
+    - csp: ncp
+      region: kr
+      name: NCP-Seoul
+      execute: false
+
+beetle:
+  endpoint: http://localhost:8056
+  requestBodyFile: testconf/source-infra.json
+  requestBodyFileWithNlb: testconf/source-infra-with-nlb.json
+  authConfigFile: testconf/auth-config.json

--- a/cmd/test-cli/multi-infra-recommendation/testresult/multi-infra-recommendation-test-report.md
+++ b/cmd/test-cli/multi-infra-recommendation/testresult/multi-infra-recommendation-test-report.md
@@ -1,0 +1,5496 @@
+# CM-Beetle Multi-Infra Recommendation Test Results
+
+> [!NOTE]
+> Verifies that `POST /recommendation/multiInfra` and `POST /recommendation/multiInfraWithNlb`
+> return exactly one result item per requested target, in request order.
+
+## Environment
+
+- CM-Beetle URL: http://localhost:8056
+- Test Date: 2026-08-06 15:56:15
+- Target Count: 2
+- Targets: aws/ap-northeast-2, azure/koreasouth
+
+### Test Results Summary
+
+| Test | Step (Endpoint / Description) | Status | Duration | Details |
+|------|-------------------------------|--------|----------|----------|
+| 1 | `POST /beetle/recommendation/multiInfra` | ✅ **PASS** | 6.568s | Pass |
+| 2 | `POST /beetle/recommendation/multiInfraWithNlb` | ✅ **PASS** | 2.932s | Pass |
+
+**Overall Result**: 2/2 tests passed ✅
+
+**Total Duration**: 9.50110182s
+
+*Test executed on August 6, 2026 at 15:56:15 KST using CM-Beetle automated test CLI*
+
+---
+
+## Test 1: Recommend multiple target infrastructures
+
+#### 1.1 API Request Information
+
+- **API Endpoint**: `POST /beetle/recommendation/multiInfra`
+- **Purpose**: Get one best-match cloud infrastructure recommendation per requested CSP/region pair
+
+**Request Body**:
+
+<details>
+  <summary> <ins>Click to see the request body</ins> </summary>
+
+```json
+{
+  "desiredCspAndRegionPairs": [
+    {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    {
+      "csp": "azure",
+      "region": "koreasouth"
+    }
+  ],
+  "sourceInfra": {
+    "network": {
+      "ipv4Networks": {
+        "defaultGateways": [
+          {
+            "ip": "10.0.1.1",
+            "interfaceName": "ens5",
+            "machineId": "ec268ed7-821e-9d73-e79f-961262161624"
+          },
+          {
+            "ip": "10.0.1.1",
+            "interfaceName": "ens5",
+            "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932"
+          },
+          {
+            "ip": "10.0.1.1",
+            "interfaceName": "ens5",
+            "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "ip-10-0-1-30",
+        "machineId": "ec268ed7-821e-9d73-e79f-961262161624",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 1,
+          "threads": 2,
+          "maxSpeed": 2.499,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 2,
+          "available": 1
+        },
+        "rootDisk": {
+          "label": "",
+          "type": "",
+          "totalSize": 0
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
+          },
+          {
+            "name": "ens5",
+            "macAddress": "02:6f:de:fc:71:b1",
+            "ipv4CidrBlocks": [
+              "10.0.1.30/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::6f:deff:fefc:71b1/64"
+            ],
+            "mtu": 9001,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::6f:deff:fefc:71b1/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "5432",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9113",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9113",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "5432",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "direction": "outbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "ip-10-0-1-221",
+        "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 2.499,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 16,
+          "available": 15
+        },
+        "rootDisk": {
+          "label": "",
+          "type": "",
+          "totalSize": 0
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
+          },
+          {
+            "name": "ens5",
+            "macAddress": "02:08:96:7d:f4:17",
+            "ipv4CidrBlocks": [
+              "10.0.1.221/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::8:96ff:fe7d:f417/64"
+            ],
+            "mtu": 9001,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::8:96ff:fe7d:f417/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "2049",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "2049",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "111",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "111",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "20048",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "20048",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "32803",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "32803",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9100",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9100",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "2049",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "2049",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "111",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "111",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "direction": "outbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "ip-10-0-1-138",
+        "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 1,
+          "threads": 2,
+          "maxSpeed": 2.499,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 7
+        },
+        "rootDisk": {
+          "label": "",
+          "type": "",
+          "totalSize": 0
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
+          },
+          {
+            "name": "ens5",
+            "macAddress": "02:bf:6e:6c:6e:31",
+            "ipv4CidrBlocks": [
+              "10.0.1.138/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::bf:6eff:fe6c:6e31/64"
+            ],
+            "mtu": 9001,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.0.2/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.1/32",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::/64",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::1/128",
+            "gateway": "on-link",
+            "interface": "lo",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "fe80::bf:6eff:fe6c:6e31/128",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "ff00::/8",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 256,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "::/0",
+            "gateway": "on-link",
+            "interface": "lo",
+            "metric": 2147483647,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "icmp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "67",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "68",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "224.0.0.251/32",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "239.255.255.250/32",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4567",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4567",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4568",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4568",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4444",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "4444",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9104",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9104",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "547",
+            "dstCIDR": "fe80::/10",
+            "dstPorts": "546",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "ff02::fb/128",
+            "dstPorts": "5353",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "ff02::f/128",
+            "dstPorts": "1900",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "80",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "443",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "8080",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "3306",
+            "protocol": "udp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "23",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "135",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "139",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "445",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "deny"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "fe80::/10",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "icmpv6",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "tcp",
+            "direction": "outbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "::/0",
+            "srcPorts": "*",
+            "dstCIDR": "::/0",
+            "dstPorts": "*",
+            "protocol": "udp",
+            "direction": "outbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+#### 1.2 API Response Information
+
+- **Status**: ✅ **PASS**
+- **Duration**: 6.568s
+
+**Response Body**:
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "status": "highly-matched",
+      "description": "Candidate #1 | highly-matched | Overall Match Rate: Min=100.0% Max=100.0% Avg=100.0% | VMs: 3 total, 3 matched, 0 acceptable",
+      "targetCloud": {
+        "csp": "aws",
+        "region": "ap-northeast-2"
+      },
+      "targetInfra": {
+        "name": "infra101",
+        "installMonAgent": "",
+        "label": null,
+        "systemLabel": "",
+        "description": "Recommended VMs comprising multi-cloud infrastructure",
+        "nodeGroups": [
+          {
+            "name": "vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624"
+            },
+            "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+            "connectionName": "aws-ap-northeast-2",
+            "specId": "aws+ap-northeast-2+t3a.small",
+            "imageId": "ami-0afe1fd15675c3f15",
+            "vNetId": "vnet-01",
+            "subnetId": "subnet-01",
+            "securityGroupIds": [
+              "sg-01"
+            ],
+            "sshKeyId": "sshkey-01",
+            "rootDiskSize": 10,
+            "dataDiskIds": null
+          },
+          {
+            "name": "vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932"
+            },
+            "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+            "connectionName": "aws-ap-northeast-2",
+            "specId": "aws+ap-northeast-2+t3a.xlarge",
+            "imageId": "ami-0afe1fd15675c3f15",
+            "vNetId": "vnet-01",
+            "subnetId": "subnet-01",
+            "securityGroupIds": [
+              "sg-02"
+            ],
+            "sshKeyId": "sshkey-01",
+            "rootDiskSize": 10,
+            "dataDiskIds": null
+          },
+          {
+            "name": "vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf"
+            },
+            "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+            "connectionName": "aws-ap-northeast-2",
+            "specId": "aws+ap-northeast-2+t3a.large",
+            "imageId": "ami-0afe1fd15675c3f15",
+            "vNetId": "vnet-01",
+            "subnetId": "subnet-01",
+            "securityGroupIds": [
+              "sg-03"
+            ],
+            "sshKeyId": "sshkey-01",
+            "rootDiskSize": 10,
+            "dataDiskIds": null
+          }
+        ],
+        "postCommand": {
+          "userName": "",
+          "command": null
+        },
+        "policyOnPartialFailure": ""
+      },
+      "targetVNet": {
+        "name": "vnet-01",
+        "connectionName": "aws-ap-northeast-2",
+        "cidrBlock": "10.0.0.0/21",
+        "subnetInfoList": [
+          {
+            "name": "subnet-01",
+            "ipv4_CIDR": "10.0.1.0/24",
+            "description": "a recommended subnet for migration"
+          }
+        ],
+        "description": "a recommended vNet for migration"
+      },
+      "targetSshKey": {
+        "name": "sshkey-01",
+        "connectionName": "aws-ap-northeast-2",
+        "description": "a SSH Key pair for migration (Note - provided ONLY once, MUST be downloaded",
+        "cspResourceId": "",
+        "fingerprint": "",
+        "username": "",
+        "verifiedUsername": "",
+        "publicKey": "",
+        "privateKey": ""
+      },
+      "targetSpecList": [
+        {
+          "id": "aws+ap-northeast-2+t3a.small",
+          "uid": "tbebd1j28q5o5ioi26d6",
+          "cspSpecName": "t3a.small",
+          "name": "aws+ap-northeast-2+t3a.small",
+          "namespace": "system",
+          "connectionName": "aws-ap-northeast-2",
+          "providerName": "aws",
+          "regionName": "ap-northeast-2",
+          "regionLatitude": 37.36,
+          "regionLongitude": 126.78,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 2,
+          "memoryGiB": 2,
+          "diskSizeGB": -1,
+          "costPerHour": 0.0234,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": -1,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "AutoRecoverySupported",
+              "value": "true"
+            },
+            {
+              "key": "BareMetal",
+              "value": "false"
+            },
+            {
+              "key": "BurstablePerformanceSupported",
+              "value": "true"
+            },
+            {
+              "key": "CurrentGeneration",
+              "value": "true"
+            },
+            {
+              "key": "DedicatedHostsSupported",
+              "value": "false"
+            },
+            {
+              "key": "EbsInfo",
+              "value": "{EbsOptimizedInfo:{BaselineBandwidthInMbps:175,BaselineIops:1000,BaselineThroughputInMBps:21.875,MaximumBandwidthInMbps:2085,MaximumIops:11800,MaximumThroughputInMBps:260.625},EbsOptimizedSupport:default,EncryptionSupport:supported,NvmeSupport:required}"
+            },
+            {
+              "key": "FreeTierEligible",
+              "value": "false"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "true"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "nitro"
+            },
+            {
+              "key": "InstanceStorageSupported",
+              "value": "false"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.small"
+            },
+            {
+              "key": "MemoryInfo",
+              "value": "{SizeInMiB:2048}"
+            },
+            {
+              "key": "NetworkInfo",
+              "value": "{DefaultNetworkCardIndex:0,EfaInfo:null,EfaSupported:false,EnaSupport:required,Ipv4AddressesPerInterface:4,Ipv6AddressesPerInterface:4,Ipv6Supported:true,MaximumNetworkCards:1,MaximumNetworkInterfaces:2,NetworkCards:[{MaximumNetworkInterfaces:2,NetworkCardIndex:0,NetworkPerformance:Up to 5 Gigabit}],NetworkPerformance:Up to 5 Gigabit}"
+            },
+            {
+              "key": "PlacementGroupInfo",
+              "value": "{SupportedStrategies:[partition,spread]}"
+            },
+            {
+              "key": "ProcessorInfo",
+              "value": "{SupportedArchitectures:[x86_64],SustainedClockSpeedInGhz:2.2}"
+            },
+            {
+              "key": "SupportedBootModes",
+              "value": "legacy-bios; uefi"
+            },
+            {
+              "key": "SupportedRootDeviceTypes",
+              "value": "ebs"
+            },
+            {
+              "key": "SupportedUsageClasses",
+              "value": "on-demand; spot"
+            },
+            {
+              "key": "SupportedVirtualizationTypes",
+              "value": "hvm"
+            },
+            {
+              "key": "VCpuInfo",
+              "value": "{DefaultCores:1,DefaultThreadsPerCore:2,DefaultVCpus:2,ValidCores:[1],ValidThreadsPerCore:[1,2]}"
+            }
+          ]
+        },
+        {
+          "id": "aws+ap-northeast-2+t3a.xlarge",
+          "uid": "tbssh2pg8r7mima22oe2",
+          "cspSpecName": "t3a.xlarge",
+          "name": "aws+ap-northeast-2+t3a.xlarge",
+          "namespace": "system",
+          "connectionName": "aws-ap-northeast-2",
+          "providerName": "aws",
+          "regionName": "ap-northeast-2",
+          "regionLatitude": 37.36,
+          "regionLongitude": 126.78,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 4,
+          "memoryGiB": 16,
+          "diskSizeGB": -1,
+          "costPerHour": 0.1872,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": -1,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "AutoRecoverySupported",
+              "value": "true"
+            },
+            {
+              "key": "BareMetal",
+              "value": "false"
+            },
+            {
+              "key": "BurstablePerformanceSupported",
+              "value": "true"
+            },
+            {
+              "key": "CurrentGeneration",
+              "value": "true"
+            },
+            {
+              "key": "DedicatedHostsSupported",
+              "value": "false"
+            },
+            {
+              "key": "EbsInfo",
+              "value": "{EbsOptimizedInfo:{BaselineBandwidthInMbps:695,BaselineIops:4000,BaselineThroughputInMBps:86.875,MaximumBandwidthInMbps:2780,MaximumIops:15700,MaximumThroughputInMBps:347.5},EbsOptimizedSupport:default,EncryptionSupport:supported,NvmeSupport:required}"
+            },
+            {
+              "key": "FreeTierEligible",
+              "value": "false"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "true"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "nitro"
+            },
+            {
+              "key": "InstanceStorageSupported",
+              "value": "false"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.xlarge"
+            },
+            {
+              "key": "MemoryInfo",
+              "value": "{SizeInMiB:16384}"
+            },
+            {
+              "key": "NetworkInfo",
+              "value": "{DefaultNetworkCardIndex:0,EfaInfo:null,EfaSupported:false,EnaSupport:required,Ipv4AddressesPerInterface:15,Ipv6AddressesPerInterface:15,Ipv6Supported:true,MaximumNetworkCards:1,MaximumNetworkInterfaces:4,NetworkCards:[{MaximumNetworkInterfaces:4,NetworkCardIndex:0,NetworkPerformance:Up to 5 Gigabit}],NetworkPerformance:Up to 5 Gigabit}"
+            },
+            {
+              "key": "PlacementGroupInfo",
+              "value": "{SupportedStrategies:[partition,spread]}"
+            },
+            {
+              "key": "ProcessorInfo",
+              "value": "{SupportedArchitectures:[x86_64],SustainedClockSpeedInGhz:2.2}"
+            },
+            {
+              "key": "SupportedBootModes",
+              "value": "legacy-bios; uefi"
+            },
+            {
+              "key": "SupportedRootDeviceTypes",
+              "value": "ebs"
+            },
+            {
+              "key": "SupportedUsageClasses",
+              "value": "on-demand; spot"
+            },
+            {
+              "key": "SupportedVirtualizationTypes",
+              "value": "hvm"
+            },
+            {
+              "key": "VCpuInfo",
+              "value": "{DefaultCores:2,DefaultThreadsPerCore:2,DefaultVCpus:4,ValidCores:[2],ValidThreadsPerCore:[1,2]}"
+            }
+          ]
+        },
+        {
+          "id": "aws+ap-northeast-2+t3a.large",
+          "uid": "tb5nrtauv13slltbplo8",
+          "cspSpecName": "t3a.large",
+          "name": "aws+ap-northeast-2+t3a.large",
+          "namespace": "system",
+          "connectionName": "aws-ap-northeast-2",
+          "providerName": "aws",
+          "regionName": "ap-northeast-2",
+          "regionLatitude": 37.36,
+          "regionLongitude": 126.78,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 2,
+          "memoryGiB": 8,
+          "diskSizeGB": -1,
+          "costPerHour": 0.0936,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": -1,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "AutoRecoverySupported",
+              "value": "true"
+            },
+            {
+              "key": "BareMetal",
+              "value": "false"
+            },
+            {
+              "key": "BurstablePerformanceSupported",
+              "value": "true"
+            },
+            {
+              "key": "CurrentGeneration",
+              "value": "true"
+            },
+            {
+              "key": "DedicatedHostsSupported",
+              "value": "false"
+            },
+            {
+              "key": "EbsInfo",
+              "value": "{EbsOptimizedInfo:{BaselineBandwidthInMbps:695,BaselineIops:4000,BaselineThroughputInMBps:86.875,MaximumBandwidthInMbps:2780,MaximumIops:15700,MaximumThroughputInMBps:347.5},EbsOptimizedSupport:default,EncryptionSupport:supported,NvmeSupport:required}"
+            },
+            {
+              "key": "FreeTierEligible",
+              "value": "false"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "true"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "nitro"
+            },
+            {
+              "key": "InstanceStorageSupported",
+              "value": "false"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.large"
+            },
+            {
+              "key": "MemoryInfo",
+              "value": "{SizeInMiB:8192}"
+            },
+            {
+              "key": "NetworkInfo",
+              "value": "{DefaultNetworkCardIndex:0,EfaInfo:null,EfaSupported:false,EnaSupport:required,Ipv4AddressesPerInterface:12,Ipv6AddressesPerInterface:12,Ipv6Supported:true,MaximumNetworkCards:1,MaximumNetworkInterfaces:3,NetworkCards:[{MaximumNetworkInterfaces:3,NetworkCardIndex:0,NetworkPerformance:Up to 5 Gigabit}],NetworkPerformance:Up to 5 Gigabit}"
+            },
+            {
+              "key": "PlacementGroupInfo",
+              "value": "{SupportedStrategies:[partition,spread]}"
+            },
+            {
+              "key": "ProcessorInfo",
+              "value": "{SupportedArchitectures:[x86_64],SustainedClockSpeedInGhz:2.2}"
+            },
+            {
+              "key": "SupportedBootModes",
+              "value": "legacy-bios; uefi"
+            },
+            {
+              "key": "SupportedRootDeviceTypes",
+              "value": "ebs"
+            },
+            {
+              "key": "SupportedUsageClasses",
+              "value": "on-demand; spot"
+            },
+            {
+              "key": "SupportedVirtualizationTypes",
+              "value": "hvm"
+            },
+            {
+              "key": "VCpuInfo",
+              "value": "{DefaultCores:1,DefaultThreadsPerCore:2,DefaultVCpus:2,ValidCores:[1],ValidThreadsPerCore:[1,2]}"
+            }
+          ]
+        }
+      ],
+      "targetOsImageList": [
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "aws",
+          "cspImageName": "ami-0afe1fd15675c3f15",
+          "regionList": [
+            "ap-northeast-2"
+          ],
+          "id": "ami-0afe1fd15675c3f15",
+          "uid": "tbpehspo42fvpin86adv",
+          "name": "ami-0afe1fd15675c3f15",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "aws-ap-northeast-2",
+          "infraType": "",
+          "fetchedTime": "2026.06.29 18:05:23 Mon",
+          "creationDate": "2026-06-10T06:57:25.000Z",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": true,
+          "isBasicGpuImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610",
+          "osDiskType": "ebs",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{DeleteOnTermination:true,Encrypted:false,Iops:null,KmsKeyId:null,OutpostArn:null,SnapshotId:snap-0060c8629d239ea6b,Throughput:null,VolumeSize:8,VolumeType:gp2},NoDevice:null,VirtualName:null}; {DeviceName:/dev/sdb,Ebs:null,NoDevice:null,VirtualName:ephemeral0}; {DeviceName:/dev/sdc,Ebs:null,NoDevice:null,VirtualName:ephemeral1}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CreationDate",
+              "value": "2026-06-10T06:57:25.000Z"
+            },
+            {
+              "key": "DeprecationTime",
+              "value": "2028-06-10T06:57:25.000Z"
+            },
+            {
+              "key": "Description",
+              "value": "Canonical, Ubuntu, 22.04, amd64 jammy image"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-0afe1fd15675c3f15"
+            },
+            {
+              "key": "ImageLocation",
+              "value": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
+            },
+            {
+              "key": "ImageOwnerAlias",
+              "value": "amazon"
+            },
+            {
+              "key": "ImageType",
+              "value": "machine"
+            },
+            {
+              "key": "Name",
+              "value": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
+            },
+            {
+              "key": "OwnerId",
+              "value": "099720109477"
+            },
+            {
+              "key": "PlatformDetails",
+              "value": "Linux/UNIX"
+            },
+            {
+              "key": "Public",
+              "value": "true"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SriovNetSupport",
+              "value": "simple"
+            },
+            {
+              "key": "State",
+              "value": "available"
+            },
+            {
+              "key": "UsageOperation",
+              "value": "RunInstances"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            }
+          ],
+          "systemLabel": "",
+          "description": "Canonical, Ubuntu, 22.04, amd64 jammy image",
+          "commandHistory": null
+        }
+      ],
+      "targetSecurityGroupList": [
+        {
+          "name": "sg-01",
+          "connectionName": "aws-ap-northeast-2",
+          "vNetId": "vnet-01",
+          "description": "Recommended security group for ec268ed7-821e-9d73-e79f-961262161624",
+          "firewallRules": [
+            {
+              "Ports": "",
+              "Protocol": "icmp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "68",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "5353",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1900",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "80",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "443",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "8080",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "9113",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9113",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "tcp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "udp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        },
+        {
+          "name": "sg-02",
+          "connectionName": "aws-ap-northeast-2",
+          "vNetId": "vnet-01",
+          "description": "Recommended security group for ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "firewallRules": [
+            {
+              "Ports": "",
+              "Protocol": "icmp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "68",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "5353",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1900",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "2049",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "2049",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "111",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "111",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "20048",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "20048",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "32803",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "32803",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9100",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9100",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "tcp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "udp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        },
+        {
+          "name": "sg-03",
+          "connectionName": "aws-ap-northeast-2",
+          "vNetId": "vnet-01",
+          "description": "Recommended security group for ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "firewallRules": [
+            {
+              "Ports": "",
+              "Protocol": "icmp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "68",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "5353",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1900",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "3306",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "3306",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4567",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4567",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4568",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4568",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4444",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4444",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9104",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9104",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "tcp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "udp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        }
+      ]
+    },
+    {
+      "status": "partially-matched",
+      "description": "Candidate #1 | partially-matched | Overall Match Rate: Min=51.2% Max=100.0% Avg=94.1% | VMs: 3 total, 2 matched, 1 acceptable",
+      "targetCloud": {
+        "csp": "azure",
+        "region": "koreasouth"
+      },
+      "targetInfra": {
+        "name": "infra101",
+        "installMonAgent": "",
+        "label": null,
+        "systemLabel": "",
+        "description": "Recommended VMs comprising multi-cloud infrastructure",
+        "nodeGroups": [
+          {
+            "name": "vm-ec268ed7-821e-9d73-e79f-961262161624",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineId": "ec268ed7-821e-9d73-e79f-961262161624"
+            },
+            "description": "Recommended VM for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=100.0%",
+            "connectionName": "azure-koreasouth",
+            "specId": "azure+koreasouth+standard_b2als_v2",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202607300",
+            "vNetId": "vnet-01",
+            "subnetId": "subnet-01",
+            "securityGroupIds": [
+              "sg-01"
+            ],
+            "sshKeyId": "sshkey-01",
+            "rootDiskSize": 30,
+            "dataDiskIds": null
+          },
+          {
+            "name": "vm-ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932"
+            },
+            "description": "Recommended VM for ec2d32b5-98fb-5a96-7913-d3db1ec18932 | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+            "connectionName": "azure-koreasouth",
+            "specId": "azure+koreasouth+standard_b4as_v2",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202607300",
+            "vNetId": "vnet-01",
+            "subnetId": "subnet-01",
+            "securityGroupIds": [
+              "sg-02"
+            ],
+            "sshKeyId": "sshkey-01",
+            "rootDiskSize": 30,
+            "dataDiskIds": null
+          },
+          {
+            "name": "vm-ec288dd0-c6fa-8a49-2f60-bc898311febf",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf"
+            },
+            "description": "Recommended VM for ec288dd0-c6fa-8a49-2f60-bc898311febf | Match Rate: CPU=100.0% Memory=97.7% Image=100.0%",
+            "connectionName": "azure-koreasouth",
+            "specId": "azure+koreasouth+standard_b2as_v2",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202607300",
+            "vNetId": "vnet-01",
+            "subnetId": "subnet-01",
+            "securityGroupIds": [
+              "sg-03"
+            ],
+            "sshKeyId": "sshkey-01",
+            "rootDiskSize": 30,
+            "dataDiskIds": null
+          }
+        ],
+        "postCommand": {
+          "userName": "",
+          "command": null
+        },
+        "policyOnPartialFailure": ""
+      },
+      "targetVNet": {
+        "name": "vnet-01",
+        "connectionName": "azure-koreasouth",
+        "cidrBlock": "10.0.0.0/21",
+        "subnetInfoList": [
+          {
+            "name": "subnet-01",
+            "ipv4_CIDR": "10.0.1.0/24",
+            "description": "a recommended subnet for migration"
+          }
+        ],
+        "description": "a recommended vNet for migration"
+      },
+      "targetSshKey": {
+        "name": "sshkey-01",
+        "connectionName": "azure-koreasouth",
+        "description": "a SSH Key pair for migration (Note - provided ONLY once, MUST be downloaded",
+        "cspResourceId": "",
+        "fingerprint": "",
+        "username": "",
+        "verifiedUsername": "",
+        "publicKey": "",
+        "privateKey": ""
+      },
+      "targetSpecList": [
+        {
+          "id": "azure+koreasouth+standard_b2als_v2",
+          "uid": "tbp2modtn0bgras2hitq",
+          "cspSpecName": "Standard_B2als_v2",
+          "name": "azure+koreasouth+standard_b2als_v2",
+          "namespace": "system",
+          "connectionName": "azure-koreasouth",
+          "providerName": "azure",
+          "regionName": "koreasouth",
+          "regionLatitude": 35.1796,
+          "regionLongitude": 129.0756,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 2,
+          "memoryGiB": 3.90625,
+          "costPerHour": 0.0432,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": 0,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "MaxDataDiskCount",
+              "value": "4"
+            },
+            {
+              "key": "MemoryInMB",
+              "value": "4096"
+            },
+            {
+              "key": "Name",
+              "value": "Standard_B2als_v2"
+            },
+            {
+              "key": "NumberOfCores",
+              "value": "2"
+            },
+            {
+              "key": "OSDiskSizeInMB",
+              "value": "1047552"
+            },
+            {
+              "key": "ResourceDiskSizeInMB",
+              "value": "0"
+            },
+            {
+              "key": "MaxResourceVolumeMB",
+              "value": "0"
+            },
+            {
+              "key": "OSVhdSizeMB",
+              "value": "1047552"
+            },
+            {
+              "key": "vCPUs",
+              "value": "2"
+            },
+            {
+              "key": "MemoryPreservingMaintenanceSupported",
+              "value": "True"
+            },
+            {
+              "key": "HyperVGenerations",
+              "value": "V1,V2"
+            },
+            {
+              "key": "SupportedCapacityReservationTypes",
+              "value": "Open,Targeted"
+            },
+            {
+              "key": "MemoryGB",
+              "value": "4"
+            },
+            {
+              "key": "MaxDataDiskCount",
+              "value": "4"
+            },
+            {
+              "key": "CpuArchitectureType",
+              "value": "x64"
+            },
+            {
+              "key": "LowPriorityCapable",
+              "value": "True"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "True"
+            },
+            {
+              "key": "PremiumIO",
+              "value": "True"
+            },
+            {
+              "key": "VMDeploymentTypes",
+              "value": "IaaS"
+            },
+            {
+              "key": "vCPUsConstraintsAllowed",
+              "value": "1, 2"
+            },
+            {
+              "key": "vCPUsAvailable",
+              "value": "2"
+            },
+            {
+              "key": "vCPUsPerCore",
+              "value": "2"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedIOPS",
+              "value": "9000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedReadBytesPerSecond",
+              "value": "125000000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+              "value": "125000000"
+            },
+            {
+              "key": "UncachedDiskIOPS",
+              "value": "3750"
+            },
+            {
+              "key": "UncachedDiskBytesPerSecond",
+              "value": "85000000"
+            },
+            {
+              "key": "EphemeralOSDiskSupported",
+              "value": "False"
+            },
+            {
+              "key": "EncryptionAtHostSupported",
+              "value": "True"
+            },
+            {
+              "key": "CapacityReservationSupported",
+              "value": "True"
+            },
+            {
+              "key": "AcceleratedNetworkingEnabled",
+              "value": "True"
+            },
+            {
+              "key": "RdmaEnabled",
+              "value": "False"
+            },
+            {
+              "key": "MaxNetworkInterfaces",
+              "value": "2"
+            },
+            {
+              "key": "UltraSSDAvailable",
+              "value": "False"
+            },
+            {
+              "key": "LocationInfo_0_Location",
+              "value": "KoreaSouth"
+            },
+            {
+              "key": "Family",
+              "value": "standardBasv2Family"
+            },
+            {
+              "key": "Tier",
+              "value": "Standard"
+            },
+            {
+              "key": "Size",
+              "value": "B2als_v2"
+            },
+            {
+              "key": "ResourceType",
+              "value": "virtualMachines"
+            }
+          ]
+        },
+        {
+          "id": "azure+koreasouth+standard_b4as_v2",
+          "uid": "tbsncjt92f4d837mfelh",
+          "cspSpecName": "Standard_B4as_v2",
+          "name": "azure+koreasouth+standard_b4as_v2",
+          "namespace": "system",
+          "connectionName": "azure-koreasouth",
+          "providerName": "azure",
+          "regionName": "koreasouth",
+          "regionLatitude": 35.1796,
+          "regionLongitude": 129.0756,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 4,
+          "memoryGiB": 15.625,
+          "costPerHour": 0.173,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": 0,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "MaxDataDiskCount",
+              "value": "8"
+            },
+            {
+              "key": "MemoryInMB",
+              "value": "16384"
+            },
+            {
+              "key": "Name",
+              "value": "Standard_B4as_v2"
+            },
+            {
+              "key": "NumberOfCores",
+              "value": "4"
+            },
+            {
+              "key": "OSDiskSizeInMB",
+              "value": "1047552"
+            },
+            {
+              "key": "ResourceDiskSizeInMB",
+              "value": "0"
+            },
+            {
+              "key": "MaxResourceVolumeMB",
+              "value": "0"
+            },
+            {
+              "key": "OSVhdSizeMB",
+              "value": "1047552"
+            },
+            {
+              "key": "vCPUs",
+              "value": "4"
+            },
+            {
+              "key": "MemoryPreservingMaintenanceSupported",
+              "value": "True"
+            },
+            {
+              "key": "HyperVGenerations",
+              "value": "V1,V2"
+            },
+            {
+              "key": "SupportedCapacityReservationTypes",
+              "value": "Open,Targeted"
+            },
+            {
+              "key": "MemoryGB",
+              "value": "16"
+            },
+            {
+              "key": "MaxDataDiskCount",
+              "value": "8"
+            },
+            {
+              "key": "CpuArchitectureType",
+              "value": "x64"
+            },
+            {
+              "key": "LowPriorityCapable",
+              "value": "True"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "True"
+            },
+            {
+              "key": "PremiumIO",
+              "value": "True"
+            },
+            {
+              "key": "VMDeploymentTypes",
+              "value": "IaaS"
+            },
+            {
+              "key": "vCPUsConstraintsAllowed",
+              "value": "1, 2, 4"
+            },
+            {
+              "key": "vCPUsAvailable",
+              "value": "4"
+            },
+            {
+              "key": "vCPUsPerCore",
+              "value": "2"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedIOPS",
+              "value": "19000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedReadBytesPerSecond",
+              "value": "250000000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+              "value": "250000000"
+            },
+            {
+              "key": "UncachedDiskIOPS",
+              "value": "6400"
+            },
+            {
+              "key": "UncachedDiskBytesPerSecond",
+              "value": "145000000"
+            },
+            {
+              "key": "EphemeralOSDiskSupported",
+              "value": "False"
+            },
+            {
+              "key": "EncryptionAtHostSupported",
+              "value": "True"
+            },
+            {
+              "key": "CapacityReservationSupported",
+              "value": "True"
+            },
+            {
+              "key": "AcceleratedNetworkingEnabled",
+              "value": "True"
+            },
+            {
+              "key": "RdmaEnabled",
+              "value": "False"
+            },
+            {
+              "key": "MaxNetworkInterfaces",
+              "value": "3"
+            },
+            {
+              "key": "UltraSSDAvailable",
+              "value": "False"
+            },
+            {
+              "key": "LocationInfo_0_Location",
+              "value": "KoreaSouth"
+            },
+            {
+              "key": "Family",
+              "value": "standardBasv2Family"
+            },
+            {
+              "key": "Tier",
+              "value": "Standard"
+            },
+            {
+              "key": "Size",
+              "value": "B4as_v2"
+            },
+            {
+              "key": "ResourceType",
+              "value": "virtualMachines"
+            }
+          ]
+        },
+        {
+          "id": "azure+koreasouth+standard_b2as_v2",
+          "uid": "tbe881brd6rbogviosto",
+          "cspSpecName": "Standard_B2as_v2",
+          "name": "azure+koreasouth+standard_b2as_v2",
+          "namespace": "system",
+          "connectionName": "azure-koreasouth",
+          "providerName": "azure",
+          "regionName": "koreasouth",
+          "regionLatitude": 35.1796,
+          "regionLongitude": 129.0756,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 2,
+          "memoryGiB": 7.8125,
+          "costPerHour": 0.0865,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": 0,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "MaxDataDiskCount",
+              "value": "4"
+            },
+            {
+              "key": "MemoryInMB",
+              "value": "8192"
+            },
+            {
+              "key": "Name",
+              "value": "Standard_B2as_v2"
+            },
+            {
+              "key": "NumberOfCores",
+              "value": "2"
+            },
+            {
+              "key": "OSDiskSizeInMB",
+              "value": "1047552"
+            },
+            {
+              "key": "ResourceDiskSizeInMB",
+              "value": "0"
+            },
+            {
+              "key": "MaxResourceVolumeMB",
+              "value": "0"
+            },
+            {
+              "key": "OSVhdSizeMB",
+              "value": "1047552"
+            },
+            {
+              "key": "vCPUs",
+              "value": "2"
+            },
+            {
+              "key": "MemoryPreservingMaintenanceSupported",
+              "value": "True"
+            },
+            {
+              "key": "HyperVGenerations",
+              "value": "V1,V2"
+            },
+            {
+              "key": "SupportedCapacityReservationTypes",
+              "value": "Open,Targeted"
+            },
+            {
+              "key": "MemoryGB",
+              "value": "8"
+            },
+            {
+              "key": "MaxDataDiskCount",
+              "value": "4"
+            },
+            {
+              "key": "CpuArchitectureType",
+              "value": "x64"
+            },
+            {
+              "key": "LowPriorityCapable",
+              "value": "True"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "True"
+            },
+            {
+              "key": "PremiumIO",
+              "value": "True"
+            },
+            {
+              "key": "VMDeploymentTypes",
+              "value": "IaaS"
+            },
+            {
+              "key": "vCPUsConstraintsAllowed",
+              "value": "1, 2"
+            },
+            {
+              "key": "vCPUsAvailable",
+              "value": "2"
+            },
+            {
+              "key": "vCPUsPerCore",
+              "value": "2"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedIOPS",
+              "value": "9000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedReadBytesPerSecond",
+              "value": "125000000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+              "value": "125000000"
+            },
+            {
+              "key": "UncachedDiskIOPS",
+              "value": "3750"
+            },
+            {
+              "key": "UncachedDiskBytesPerSecond",
+              "value": "85000000"
+            },
+            {
+              "key": "EphemeralOSDiskSupported",
+              "value": "False"
+            },
+            {
+              "key": "EncryptionAtHostSupported",
+              "value": "True"
+            },
+            {
+              "key": "CapacityReservationSupported",
+              "value": "True"
+            },
+            {
+              "key": "AcceleratedNetworkingEnabled",
+              "value": "True"
+            },
+            {
+              "key": "RdmaEnabled",
+              "value": "False"
+            },
+            {
+              "key": "MaxNetworkInterfaces",
+              "value": "2"
+            },
+            {
+              "key": "UltraSSDAvailable",
+              "value": "False"
+            },
+            {
+              "key": "LocationInfo_0_Location",
+              "value": "KoreaSouth"
+            },
+            {
+              "key": "Family",
+              "value": "standardBasv2Family"
+            },
+            {
+              "key": "Tier",
+              "value": "Standard"
+            },
+            {
+              "key": "Size",
+              "value": "B2as_v2"
+            },
+            {
+              "key": "ResourceType",
+              "value": "virtualMachines"
+            }
+          ]
+        }
+      ],
+      "targetOsImageList": [
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "azure",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "regionList": [
+            "common"
+          ],
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "uid": "tb1s10b0f3hlee1uavl0",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "azure-australiacentral",
+          "infraType": "",
+          "fetchedTime": "2026.06.29 18:09:29 Mon",
+          "creationDate": "",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": false,
+          "isBasicGpuImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "osDiskType": "default",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Location",
+              "value": "australiacentral"
+            },
+            {
+              "key": "Publisher",
+              "value": "Canonical"
+            },
+            {
+              "key": "Offer",
+              "value": "0001-com-ubuntu-server-jammy-daily"
+            },
+            {
+              "key": "SKU",
+              "value": "22_04-daily-lts-gen2"
+            },
+            {
+              "key": "Version",
+              "value": "22.04.202606270"
+            },
+            {
+              "key": "ID",
+              "value": "/Subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202606270"
+            },
+            {
+              "key": "HyperVGeneration",
+              "value": "V2"
+            },
+            {
+              "key": "Features",
+              "value": "SecurityType=TrustedLaunchSupported, IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, NVMe, IsHibernateSupported=True"
+            },
+            {
+              "key": "FeatureCount",
+              "value": "4"
+            },
+            {
+              "key": "ImageDeprecationState",
+              "value": "Active"
+            }
+          ],
+          "systemLabel": "",
+          "description": "",
+          "commandHistory": null
+        }
+      ],
+      "targetSecurityGroupList": [
+        {
+          "name": "sg-01",
+          "connectionName": "azure-koreasouth",
+          "vNetId": "vnet-01",
+          "description": "Recommended security group for ec268ed7-821e-9d73-e79f-961262161624",
+          "firewallRules": [
+            {
+              "Ports": "",
+              "Protocol": "icmp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "68",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "5353",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1900",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "80",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "443",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "8080",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "9113",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9113",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "tcp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "udp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        },
+        {
+          "name": "sg-02",
+          "connectionName": "azure-koreasouth",
+          "vNetId": "vnet-01",
+          "description": "Recommended security group for ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+          "firewallRules": [
+            {
+              "Ports": "",
+              "Protocol": "icmp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "68",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "5353",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1900",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "2049",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "2049",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "111",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "111",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "20048",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "20048",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "32803",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "32803",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9100",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9100",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "tcp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "udp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        },
+        {
+          "name": "sg-03",
+          "connectionName": "azure-koreasouth",
+          "vNetId": "vnet-01",
+          "description": "Recommended security group for ec288dd0-c6fa-8a49-2f60-bc898311febf",
+          "firewallRules": [
+            {
+              "Ports": "",
+              "Protocol": "icmp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "68",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "5353",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1900",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "3306",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "3306",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4567",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4567",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4568",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4568",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4444",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "4444",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9104",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "9104",
+              "Protocol": "udp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "tcp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "1-65535",
+              "Protocol": "udp",
+              "Direction": "outbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        }
+      ]
+    }
+  ],
+  "message": "Recommended infrastructure for 2 target(s)"
+}
+```
+
+</details>
+
+**Input/Output Accuracy Check**:
+
+- Overall: ✅ PASS
+- result[0] targetCloud=aws/ap-northeast-2 status=highly-matched — matches request
+- result[1] targetCloud=azure/koreasouth status=partially-matched — matches request
+
+---
+
+## Test 2: Recommend multiple target infrastructures (with NLB)
+
+#### 2.1 API Request Information
+
+- **API Endpoint**: `POST /beetle/recommendation/multiInfraWithNlb`
+- **Purpose**: Get one best-match, NLB-aware cloud infrastructure recommendation per requested CSP/region pair
+
+**Request Body**:
+
+<details>
+  <summary> <ins>Click to see the request body</ins> </summary>
+
+```json
+{
+  "desiredCspAndRegionPairs": [
+    {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    {
+      "csp": "azure",
+      "region": "koreasouth"
+    }
+  ],
+  "sourceInfra": {
+    "network": {
+      "ipv4Networks": {
+        "defaultGateways": [
+          {
+            "ip": "10.0.1.1",
+            "interfaceName": "ens5",
+            "machineId": "ec268ed7-821e-9d73-e79f-961262161624"
+          },
+          {
+            "ip": "10.0.1.1",
+            "interfaceName": "ens5",
+            "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932"
+          },
+          {
+            "ip": "10.0.1.1",
+            "interfaceName": "ens5",
+            "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "ip-10-0-1-30",
+        "machineId": "ec268ed7-821e-9d73-e79f-961262161624",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 1,
+          "threads": 2,
+          "maxSpeed": 2.499,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 2,
+          "available": 1
+        },
+        "rootDisk": {
+          "label": "",
+          "type": "SSD",
+          "totalSize": 8
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
+          },
+          {
+            "name": "ens5",
+            "macAddress": "02:6f:de:fc:71:b1",
+            "ipv4CidrBlocks": [
+              "10.0.1.30/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::6f:deff:fefc:71b1/64"
+            ],
+            "mtu": 9001,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "9999",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "ip-10-0-1-221",
+        "machineId": "ec2d32b5-98fb-5a96-7913-d3db1ec18932",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 2.499,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 16,
+          "available": 15
+        },
+        "rootDisk": {
+          "label": "",
+          "type": "SSD",
+          "totalSize": 30
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
+          },
+          {
+            "name": "ens5",
+            "macAddress": "02:08:96:7d:f4:17",
+            "ipv4CidrBlocks": [
+              "10.0.1.221/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::8:96ff:fe7d:f417/64"
+            ],
+            "mtu": 9001,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8086",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "ip-10-0-1-138",
+        "machineId": "ec288dd0-c6fa-8a49-2f60-bc898311febf",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 2.499,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 7
+        },
+        "rootDisk": {
+          "label": "",
+          "type": "SSD",
+          "totalSize": 30
+        },
+        "interfaces": [
+          {
+            "name": "lo",
+            "ipv4CidrBlocks": [
+              "127.0.0.1/8"
+            ],
+            "ipv6CidrBlocks": [
+              "::1/128"
+            ],
+            "mtu": 65536,
+            "state": "up"
+          },
+          {
+            "name": "ens5",
+            "macAddress": "02:bf:6e:6c:6e:31",
+            "ipv4CidrBlocks": [
+              "10.0.1.138/24"
+            ],
+            "ipv6CidrBlocks": [
+              "fe80::bf:6eff:fe6c:6e31/64"
+            ],
+            "mtu": 9001,
+            "state": "up"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          },
+          {
+            "destination": "10.0.1.0/24",
+            "gateway": "10.0.1.1",
+            "interface": "ens5",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "universe",
+            "linkState": "up"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "8086",
+            "protocol": "tcp",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/16",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "srcPorts": "*",
+            "dstCIDR": "0.0.0.0/0",
+            "dstPorts": "*",
+            "protocol": "*",
+            "direction": "outbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "nlbs": [
+      {
+        "hostMachineId": "ec268ed7-821e-9d73-e79f-961262161624",
+        "software": "haproxy",
+        "listener": {
+          "bindAddress": "*",
+          "port": 9999,
+          "protocol": "tcp"
+        },
+        "backend": {
+          "name": "influxdb_back",
+          "balance": "roundrobin",
+          "protocol": "tcp",
+          "servers": [
+            {
+              "name": "influx1",
+              "ip": "10.0.1.221",
+              "port": 8086
+            },
+            {
+              "name": "influx2",
+              "ip": "10.0.1.138",
+              "port": 8086
+            }
+          ]
+        },
+        "healthCheck": {
+          "enabled": true,
+          "interval": 10,
+          "timeout": 10,
+          "threshold": 3
+        }
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+#### 2.2 API Response Information
+
+- **Status**: ✅ **PASS**
+- **Duration**: 2.932s
+
+**Response Body**:
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "status": "highly-matched",
+      "description": "Candidate #1 | highly-matched | 1 NLB(s) | Overall Match Rate: Min=100.0% Max=100.0% Avg=100.0% | VMs: 2 total, 2 matched, 0 acceptable | 1 NLB warning(s): NLB backend 'influxdb_back': load-balancing algorithm 'roundrobin' cannot be directly mapped to cloud NLB. CSP default algorithm will be used.",
+      "targetCloud": {
+        "csp": "aws",
+        "region": "ap-northeast-2"
+      },
+      "targetInfra": {
+        "name": "infra101",
+        "installMonAgent": "",
+        "label": null,
+        "systemLabel": "",
+        "description": "NLB-aware recommended infrastructure for cloud migration",
+        "nodeGroups": [
+          {
+            "name": "ng-influxdb-back",
+            "nodeGroupSize": 2,
+            "label": {
+              "nlbBackend": "influxdb_back",
+              "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf"
+            },
+            "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+            "connectionName": "aws-ap-northeast-2",
+            "specId": "aws+ap-northeast-2+t3a.xlarge",
+            "imageId": "ami-0afe1fd15675c3f15",
+            "vNetId": "mig-vnet-01",
+            "subnetId": "mig-subnet-01",
+            "securityGroupIds": [
+              "mig-sg-01"
+            ],
+            "sshKeyId": "mig-sshkey-01",
+            "rootDiskSize": 30,
+            "dataDiskIds": null
+          },
+          {
+            "name": "ng-ec268ed7-821e-9d73-e79f-961262161624",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624"
+            },
+            "description": "Recommended VM 01 for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=100.0% Image=100.0%",
+            "connectionName": "aws-ap-northeast-2",
+            "specId": "aws+ap-northeast-2+t3a.small",
+            "imageId": "ami-0afe1fd15675c3f15",
+            "vNetId": "mig-vnet-01",
+            "subnetId": "mig-subnet-01",
+            "securityGroupIds": [
+              "mig-sg-02"
+            ],
+            "sshKeyId": "mig-sshkey-01",
+            "rootDiskSize": 10,
+            "dataDiskIds": null
+          }
+        ],
+        "postCommand": {
+          "userName": "",
+          "command": null
+        },
+        "policyOnPartialFailure": ""
+      },
+      "targetVNet": {
+        "name": "mig-vnet-01",
+        "connectionName": "aws-ap-northeast-2",
+        "cidrBlock": "10.0.0.0/21",
+        "subnetInfoList": [
+          {
+            "name": "mig-subnet-01",
+            "ipv4_CIDR": "10.0.1.0/24",
+            "description": "a recommended subnet for migration"
+          }
+        ],
+        "description": "a recommended vNet for migration"
+      },
+      "targetSshKey": {
+        "name": "mig-sshkey-01",
+        "connectionName": "aws-ap-northeast-2",
+        "description": "SSH key pair for migration (Note: provided ONLY once, MUST be downloaded)",
+        "cspResourceId": "",
+        "fingerprint": "",
+        "username": "",
+        "verifiedUsername": "",
+        "publicKey": "",
+        "privateKey": ""
+      },
+      "targetSpecList": [
+        {
+          "id": "aws+ap-northeast-2+t3a.xlarge",
+          "uid": "tbssh2pg8r7mima22oe2",
+          "cspSpecName": "t3a.xlarge",
+          "name": "aws+ap-northeast-2+t3a.xlarge",
+          "namespace": "system",
+          "connectionName": "aws-ap-northeast-2",
+          "providerName": "aws",
+          "regionName": "ap-northeast-2",
+          "regionLatitude": 37.36,
+          "regionLongitude": 126.78,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 4,
+          "memoryGiB": 16,
+          "diskSizeGB": -1,
+          "costPerHour": 0.1872,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": -1,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "AutoRecoverySupported",
+              "value": "true"
+            },
+            {
+              "key": "BareMetal",
+              "value": "false"
+            },
+            {
+              "key": "BurstablePerformanceSupported",
+              "value": "true"
+            },
+            {
+              "key": "CurrentGeneration",
+              "value": "true"
+            },
+            {
+              "key": "DedicatedHostsSupported",
+              "value": "false"
+            },
+            {
+              "key": "EbsInfo",
+              "value": "{EbsOptimizedInfo:{BaselineBandwidthInMbps:695,BaselineIops:4000,BaselineThroughputInMBps:86.875,MaximumBandwidthInMbps:2780,MaximumIops:15700,MaximumThroughputInMBps:347.5},EbsOptimizedSupport:default,EncryptionSupport:supported,NvmeSupport:required}"
+            },
+            {
+              "key": "FreeTierEligible",
+              "value": "false"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "true"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "nitro"
+            },
+            {
+              "key": "InstanceStorageSupported",
+              "value": "false"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.xlarge"
+            },
+            {
+              "key": "MemoryInfo",
+              "value": "{SizeInMiB:16384}"
+            },
+            {
+              "key": "NetworkInfo",
+              "value": "{DefaultNetworkCardIndex:0,EfaInfo:null,EfaSupported:false,EnaSupport:required,Ipv4AddressesPerInterface:15,Ipv6AddressesPerInterface:15,Ipv6Supported:true,MaximumNetworkCards:1,MaximumNetworkInterfaces:4,NetworkCards:[{MaximumNetworkInterfaces:4,NetworkCardIndex:0,NetworkPerformance:Up to 5 Gigabit}],NetworkPerformance:Up to 5 Gigabit}"
+            },
+            {
+              "key": "PlacementGroupInfo",
+              "value": "{SupportedStrategies:[partition,spread]}"
+            },
+            {
+              "key": "ProcessorInfo",
+              "value": "{SupportedArchitectures:[x86_64],SustainedClockSpeedInGhz:2.2}"
+            },
+            {
+              "key": "SupportedBootModes",
+              "value": "legacy-bios; uefi"
+            },
+            {
+              "key": "SupportedRootDeviceTypes",
+              "value": "ebs"
+            },
+            {
+              "key": "SupportedUsageClasses",
+              "value": "on-demand; spot"
+            },
+            {
+              "key": "SupportedVirtualizationTypes",
+              "value": "hvm"
+            },
+            {
+              "key": "VCpuInfo",
+              "value": "{DefaultCores:2,DefaultThreadsPerCore:2,DefaultVCpus:4,ValidCores:[2],ValidThreadsPerCore:[1,2]}"
+            }
+          ]
+        },
+        {
+          "id": "aws+ap-northeast-2+t3a.small",
+          "uid": "tbebd1j28q5o5ioi26d6",
+          "cspSpecName": "t3a.small",
+          "name": "aws+ap-northeast-2+t3a.small",
+          "namespace": "system",
+          "connectionName": "aws-ap-northeast-2",
+          "providerName": "aws",
+          "regionName": "ap-northeast-2",
+          "regionLatitude": 37.36,
+          "regionLongitude": 126.78,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 2,
+          "memoryGiB": 2,
+          "diskSizeGB": -1,
+          "costPerHour": 0.0234,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": -1,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "AutoRecoverySupported",
+              "value": "true"
+            },
+            {
+              "key": "BareMetal",
+              "value": "false"
+            },
+            {
+              "key": "BurstablePerformanceSupported",
+              "value": "true"
+            },
+            {
+              "key": "CurrentGeneration",
+              "value": "true"
+            },
+            {
+              "key": "DedicatedHostsSupported",
+              "value": "false"
+            },
+            {
+              "key": "EbsInfo",
+              "value": "{EbsOptimizedInfo:{BaselineBandwidthInMbps:175,BaselineIops:1000,BaselineThroughputInMBps:21.875,MaximumBandwidthInMbps:2085,MaximumIops:11800,MaximumThroughputInMBps:260.625},EbsOptimizedSupport:default,EncryptionSupport:supported,NvmeSupport:required}"
+            },
+            {
+              "key": "FreeTierEligible",
+              "value": "false"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "true"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "nitro"
+            },
+            {
+              "key": "InstanceStorageSupported",
+              "value": "false"
+            },
+            {
+              "key": "InstanceType",
+              "value": "t3a.small"
+            },
+            {
+              "key": "MemoryInfo",
+              "value": "{SizeInMiB:2048}"
+            },
+            {
+              "key": "NetworkInfo",
+              "value": "{DefaultNetworkCardIndex:0,EfaInfo:null,EfaSupported:false,EnaSupport:required,Ipv4AddressesPerInterface:4,Ipv6AddressesPerInterface:4,Ipv6Supported:true,MaximumNetworkCards:1,MaximumNetworkInterfaces:2,NetworkCards:[{MaximumNetworkInterfaces:2,NetworkCardIndex:0,NetworkPerformance:Up to 5 Gigabit}],NetworkPerformance:Up to 5 Gigabit}"
+            },
+            {
+              "key": "PlacementGroupInfo",
+              "value": "{SupportedStrategies:[partition,spread]}"
+            },
+            {
+              "key": "ProcessorInfo",
+              "value": "{SupportedArchitectures:[x86_64],SustainedClockSpeedInGhz:2.2}"
+            },
+            {
+              "key": "SupportedBootModes",
+              "value": "legacy-bios; uefi"
+            },
+            {
+              "key": "SupportedRootDeviceTypes",
+              "value": "ebs"
+            },
+            {
+              "key": "SupportedUsageClasses",
+              "value": "on-demand; spot"
+            },
+            {
+              "key": "SupportedVirtualizationTypes",
+              "value": "hvm"
+            },
+            {
+              "key": "VCpuInfo",
+              "value": "{DefaultCores:1,DefaultThreadsPerCore:2,DefaultVCpus:2,ValidCores:[1],ValidThreadsPerCore:[1,2]}"
+            }
+          ]
+        }
+      ],
+      "targetOsImageList": [
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "aws",
+          "cspImageName": "ami-0afe1fd15675c3f15",
+          "regionList": [
+            "ap-northeast-2"
+          ],
+          "id": "ami-0afe1fd15675c3f15",
+          "uid": "tbpehspo42fvpin86adv",
+          "name": "ami-0afe1fd15675c3f15",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "aws-ap-northeast-2",
+          "infraType": "",
+          "fetchedTime": "2026.06.29 18:05:23 Mon",
+          "creationDate": "2026-06-10T06:57:25.000Z",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": true,
+          "isBasicGpuImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610",
+          "osDiskType": "ebs",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Architecture",
+              "value": "x86_64"
+            },
+            {
+              "key": "BlockDeviceMappings",
+              "value": "{DeviceName:/dev/sda1,Ebs:{DeleteOnTermination:true,Encrypted:false,Iops:null,KmsKeyId:null,OutpostArn:null,SnapshotId:snap-0060c8629d239ea6b,Throughput:null,VolumeSize:8,VolumeType:gp2},NoDevice:null,VirtualName:null}; {DeviceName:/dev/sdb,Ebs:null,NoDevice:null,VirtualName:ephemeral0}; {DeviceName:/dev/sdc,Ebs:null,NoDevice:null,VirtualName:ephemeral1}"
+            },
+            {
+              "key": "BootMode",
+              "value": "uefi-preferred"
+            },
+            {
+              "key": "CreationDate",
+              "value": "2026-06-10T06:57:25.000Z"
+            },
+            {
+              "key": "DeprecationTime",
+              "value": "2028-06-10T06:57:25.000Z"
+            },
+            {
+              "key": "Description",
+              "value": "Canonical, Ubuntu, 22.04, amd64 jammy image"
+            },
+            {
+              "key": "EnaSupport",
+              "value": "true"
+            },
+            {
+              "key": "Hypervisor",
+              "value": "xen"
+            },
+            {
+              "key": "ImageId",
+              "value": "ami-0afe1fd15675c3f15"
+            },
+            {
+              "key": "ImageLocation",
+              "value": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
+            },
+            {
+              "key": "ImageOwnerAlias",
+              "value": "amazon"
+            },
+            {
+              "key": "ImageType",
+              "value": "machine"
+            },
+            {
+              "key": "Name",
+              "value": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610"
+            },
+            {
+              "key": "OwnerId",
+              "value": "099720109477"
+            },
+            {
+              "key": "PlatformDetails",
+              "value": "Linux/UNIX"
+            },
+            {
+              "key": "Public",
+              "value": "true"
+            },
+            {
+              "key": "RootDeviceName",
+              "value": "/dev/sda1"
+            },
+            {
+              "key": "RootDeviceType",
+              "value": "ebs"
+            },
+            {
+              "key": "SriovNetSupport",
+              "value": "simple"
+            },
+            {
+              "key": "State",
+              "value": "available"
+            },
+            {
+              "key": "UsageOperation",
+              "value": "RunInstances"
+            },
+            {
+              "key": "VirtualizationType",
+              "value": "hvm"
+            }
+          ],
+          "systemLabel": "",
+          "description": "Canonical, Ubuntu, 22.04, amd64 jammy image",
+          "commandHistory": null
+        }
+      ],
+      "targetSecurityGroupList": [
+        {
+          "name": "mig-sg-01",
+          "connectionName": "aws-ap-northeast-2",
+          "vNetId": "mig-vnet-01",
+          "description": "Recommended security group for NLB backend influxdb_back",
+          "firewallRules": [
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "8086",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "8086",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        },
+        {
+          "name": "mig-sg-02",
+          "connectionName": "aws-ap-northeast-2",
+          "vNetId": "mig-vnet-01",
+          "description": "Recommended security group for ec268ed7-821e-9d73-e79f-961262161624",
+          "firewallRules": [
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "9999",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            }
+          ],
+          "cspResourceId": ""
+        }
+      ],
+      "targetNlbList": [
+        {
+          "description": "Migrated from HAProxy backend: influxdb_back",
+          "type": "PUBLIC",
+          "scope": "REGION",
+          "listener": {
+            "protocol": "TCP",
+            "port": "9999"
+          },
+          "targetGroup": {
+            "protocol": "TCP",
+            "port": "8086",
+            "nodeGroupId": "ng-influxdb-back"
+          },
+          "healthChecker": {
+            "interval": 10,
+            "threshold": 3,
+            "timeout": 10
+          }
+        }
+      ]
+    },
+    {
+      "status": "partially-matched",
+      "description": "Candidate #1 | partially-matched | 1 NLB(s) | Overall Match Rate: Min=51.2% Max=100.0% Avg=84.8% | VMs: 2 total, 0 matched, 2 acceptable | 1 NLB warning(s): NLB backend 'influxdb_back': load-balancing algorithm 'roundrobin' cannot be directly mapped to cloud NLB. CSP default algorithm will be used.",
+      "targetCloud": {
+        "csp": "azure",
+        "region": "koreasouth"
+      },
+      "targetInfra": {
+        "name": "infra101",
+        "installMonAgent": "",
+        "label": null,
+        "systemLabel": "",
+        "description": "NLB-aware recommended infrastructure for cloud migration",
+        "nodeGroups": [
+          {
+            "name": "ng-influxdb-back",
+            "nodeGroupSize": 2,
+            "label": {
+              "nlbBackend": "influxdb_back",
+              "sourceMachineIds": "ec2d32b5-98fb-5a96-7913-d3db1ec18932,ec288dd0-c6fa-8a49-2f60-bc898311febf"
+            },
+            "description": "Recommended VM for NLB backend influxdb_back (2 nodes) | Match Rate: CPU=100.0% Memory=97.7% Image=80.0%",
+            "connectionName": "azure-koreasouth",
+            "specId": "azure+koreasouth+standard_b4as_v2",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202607300",
+            "vNetId": "mig-vnet-01",
+            "subnetId": "mig-subnet-01",
+            "securityGroupIds": [
+              "mig-sg-01"
+            ],
+            "sshKeyId": "mig-sshkey-01",
+            "rootDiskSize": 30,
+            "dataDiskIds": null
+          },
+          {
+            "name": "ng-ec268ed7-821e-9d73-e79f-961262161624",
+            "nodeGroupSize": 1,
+            "label": {
+              "sourceMachineIds": "ec268ed7-821e-9d73-e79f-961262161624"
+            },
+            "description": "Recommended VM 01 for ec268ed7-821e-9d73-e79f-961262161624 | Match Rate: CPU=100.0% Memory=51.2% Image=80.0%",
+            "connectionName": "azure-koreasouth",
+            "specId": "azure+koreasouth+standard_b2als_v2",
+            "imageId": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+            "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202607300",
+            "vNetId": "mig-vnet-01",
+            "subnetId": "mig-subnet-01",
+            "securityGroupIds": [
+              "mig-sg-02"
+            ],
+            "sshKeyId": "mig-sshkey-01",
+            "rootDiskSize": 30,
+            "dataDiskIds": null
+          }
+        ],
+        "postCommand": {
+          "userName": "",
+          "command": null
+        },
+        "policyOnPartialFailure": ""
+      },
+      "targetVNet": {
+        "name": "mig-vnet-01",
+        "connectionName": "azure-koreasouth",
+        "cidrBlock": "10.0.0.0/21",
+        "subnetInfoList": [
+          {
+            "name": "mig-subnet-01",
+            "ipv4_CIDR": "10.0.1.0/24",
+            "description": "a recommended subnet for migration"
+          }
+        ],
+        "description": "a recommended vNet for migration"
+      },
+      "targetSshKey": {
+        "name": "mig-sshkey-01",
+        "connectionName": "azure-koreasouth",
+        "description": "SSH key pair for migration (Note: provided ONLY once, MUST be downloaded)",
+        "cspResourceId": "",
+        "fingerprint": "",
+        "username": "",
+        "verifiedUsername": "",
+        "publicKey": "",
+        "privateKey": ""
+      },
+      "targetSpecList": [
+        {
+          "id": "azure+koreasouth+standard_b4as_v2",
+          "uid": "tbsncjt92f4d837mfelh",
+          "cspSpecName": "Standard_B4as_v2",
+          "name": "azure+koreasouth+standard_b4as_v2",
+          "namespace": "system",
+          "connectionName": "azure-koreasouth",
+          "providerName": "azure",
+          "regionName": "koreasouth",
+          "regionLatitude": 35.1796,
+          "regionLongitude": 129.0756,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 4,
+          "memoryGiB": 15.625,
+          "costPerHour": 0.173,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": 0,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "MaxDataDiskCount",
+              "value": "8"
+            },
+            {
+              "key": "MemoryInMB",
+              "value": "16384"
+            },
+            {
+              "key": "Name",
+              "value": "Standard_B4as_v2"
+            },
+            {
+              "key": "NumberOfCores",
+              "value": "4"
+            },
+            {
+              "key": "OSDiskSizeInMB",
+              "value": "1047552"
+            },
+            {
+              "key": "ResourceDiskSizeInMB",
+              "value": "0"
+            },
+            {
+              "key": "MaxResourceVolumeMB",
+              "value": "0"
+            },
+            {
+              "key": "OSVhdSizeMB",
+              "value": "1047552"
+            },
+            {
+              "key": "vCPUs",
+              "value": "4"
+            },
+            {
+              "key": "MemoryPreservingMaintenanceSupported",
+              "value": "True"
+            },
+            {
+              "key": "HyperVGenerations",
+              "value": "V1,V2"
+            },
+            {
+              "key": "SupportedCapacityReservationTypes",
+              "value": "Open,Targeted"
+            },
+            {
+              "key": "MemoryGB",
+              "value": "16"
+            },
+            {
+              "key": "MaxDataDiskCount",
+              "value": "8"
+            },
+            {
+              "key": "CpuArchitectureType",
+              "value": "x64"
+            },
+            {
+              "key": "LowPriorityCapable",
+              "value": "True"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "True"
+            },
+            {
+              "key": "PremiumIO",
+              "value": "True"
+            },
+            {
+              "key": "VMDeploymentTypes",
+              "value": "IaaS"
+            },
+            {
+              "key": "vCPUsConstraintsAllowed",
+              "value": "1, 2, 4"
+            },
+            {
+              "key": "vCPUsAvailable",
+              "value": "4"
+            },
+            {
+              "key": "vCPUsPerCore",
+              "value": "2"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedIOPS",
+              "value": "19000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedReadBytesPerSecond",
+              "value": "250000000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+              "value": "250000000"
+            },
+            {
+              "key": "UncachedDiskIOPS",
+              "value": "6400"
+            },
+            {
+              "key": "UncachedDiskBytesPerSecond",
+              "value": "145000000"
+            },
+            {
+              "key": "EphemeralOSDiskSupported",
+              "value": "False"
+            },
+            {
+              "key": "EncryptionAtHostSupported",
+              "value": "True"
+            },
+            {
+              "key": "CapacityReservationSupported",
+              "value": "True"
+            },
+            {
+              "key": "AcceleratedNetworkingEnabled",
+              "value": "True"
+            },
+            {
+              "key": "RdmaEnabled",
+              "value": "False"
+            },
+            {
+              "key": "MaxNetworkInterfaces",
+              "value": "3"
+            },
+            {
+              "key": "UltraSSDAvailable",
+              "value": "False"
+            },
+            {
+              "key": "LocationInfo_0_Location",
+              "value": "KoreaSouth"
+            },
+            {
+              "key": "Family",
+              "value": "standardBasv2Family"
+            },
+            {
+              "key": "Tier",
+              "value": "Standard"
+            },
+            {
+              "key": "Size",
+              "value": "B4as_v2"
+            },
+            {
+              "key": "ResourceType",
+              "value": "virtualMachines"
+            }
+          ]
+        },
+        {
+          "id": "azure+koreasouth+standard_b2als_v2",
+          "uid": "tbp2modtn0bgras2hitq",
+          "cspSpecName": "Standard_B2als_v2",
+          "name": "azure+koreasouth+standard_b2als_v2",
+          "namespace": "system",
+          "connectionName": "azure-koreasouth",
+          "providerName": "azure",
+          "regionName": "koreasouth",
+          "regionLatitude": 35.1796,
+          "regionLongitude": 129.0756,
+          "infraType": "node",
+          "architecture": "x86_64",
+          "vCPU": 2,
+          "memoryGiB": 3.90625,
+          "costPerHour": 0.0432,
+          "evaluationScore01": -1,
+          "evaluationScore02": -1,
+          "evaluationScore03": -1,
+          "evaluationScore04": -1,
+          "evaluationScore05": -1,
+          "evaluationScore06": -1,
+          "evaluationScore07": -1,
+          "evaluationScore08": -1,
+          "evaluationScore09": -1,
+          "evaluationScore10": -1,
+          "rootDiskType": "",
+          "rootDiskSize": 0,
+          "systemLabel": "auto-gen",
+          "details": [
+            {
+              "key": "MaxDataDiskCount",
+              "value": "4"
+            },
+            {
+              "key": "MemoryInMB",
+              "value": "4096"
+            },
+            {
+              "key": "Name",
+              "value": "Standard_B2als_v2"
+            },
+            {
+              "key": "NumberOfCores",
+              "value": "2"
+            },
+            {
+              "key": "OSDiskSizeInMB",
+              "value": "1047552"
+            },
+            {
+              "key": "ResourceDiskSizeInMB",
+              "value": "0"
+            },
+            {
+              "key": "MaxResourceVolumeMB",
+              "value": "0"
+            },
+            {
+              "key": "OSVhdSizeMB",
+              "value": "1047552"
+            },
+            {
+              "key": "vCPUs",
+              "value": "2"
+            },
+            {
+              "key": "MemoryPreservingMaintenanceSupported",
+              "value": "True"
+            },
+            {
+              "key": "HyperVGenerations",
+              "value": "V1,V2"
+            },
+            {
+              "key": "SupportedCapacityReservationTypes",
+              "value": "Open,Targeted"
+            },
+            {
+              "key": "MemoryGB",
+              "value": "4"
+            },
+            {
+              "key": "MaxDataDiskCount",
+              "value": "4"
+            },
+            {
+              "key": "CpuArchitectureType",
+              "value": "x64"
+            },
+            {
+              "key": "LowPriorityCapable",
+              "value": "True"
+            },
+            {
+              "key": "HibernationSupported",
+              "value": "True"
+            },
+            {
+              "key": "PremiumIO",
+              "value": "True"
+            },
+            {
+              "key": "VMDeploymentTypes",
+              "value": "IaaS"
+            },
+            {
+              "key": "vCPUsConstraintsAllowed",
+              "value": "1, 2"
+            },
+            {
+              "key": "vCPUsAvailable",
+              "value": "2"
+            },
+            {
+              "key": "vCPUsPerCore",
+              "value": "2"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedIOPS",
+              "value": "9000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedReadBytesPerSecond",
+              "value": "125000000"
+            },
+            {
+              "key": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+              "value": "125000000"
+            },
+            {
+              "key": "UncachedDiskIOPS",
+              "value": "3750"
+            },
+            {
+              "key": "UncachedDiskBytesPerSecond",
+              "value": "85000000"
+            },
+            {
+              "key": "EphemeralOSDiskSupported",
+              "value": "False"
+            },
+            {
+              "key": "EncryptionAtHostSupported",
+              "value": "True"
+            },
+            {
+              "key": "CapacityReservationSupported",
+              "value": "True"
+            },
+            {
+              "key": "AcceleratedNetworkingEnabled",
+              "value": "True"
+            },
+            {
+              "key": "RdmaEnabled",
+              "value": "False"
+            },
+            {
+              "key": "MaxNetworkInterfaces",
+              "value": "2"
+            },
+            {
+              "key": "UltraSSDAvailable",
+              "value": "False"
+            },
+            {
+              "key": "LocationInfo_0_Location",
+              "value": "KoreaSouth"
+            },
+            {
+              "key": "Family",
+              "value": "standardBasv2Family"
+            },
+            {
+              "key": "Tier",
+              "value": "Standard"
+            },
+            {
+              "key": "Size",
+              "value": "B2als_v2"
+            },
+            {
+              "key": "ResourceType",
+              "value": "virtualMachines"
+            }
+          ]
+        }
+      ],
+      "targetOsImageList": [
+        {
+          "resourceType": "image",
+          "namespace": "system",
+          "providerName": "azure",
+          "cspImageName": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "regionList": [
+            "common"
+          ],
+          "id": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "uid": "tb1s10b0f3hlee1uavl0",
+          "name": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "sourceNodeUid": "",
+          "sourceCspImageName": "",
+          "connectionName": "azure-australiacentral",
+          "infraType": "",
+          "fetchedTime": "2026.06.29 18:09:29 Mon",
+          "creationDate": "",
+          "isGPUImage": false,
+          "isKubernetesImage": false,
+          "isBasicImage": false,
+          "isBasicGpuImage": false,
+          "osType": "Ubuntu 22.04",
+          "osArchitecture": "x86_64",
+          "osPlatform": "Linux/UNIX",
+          "osDistribution": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts-gen2:22.04.202606270",
+          "osDiskType": "default",
+          "osDiskSizeGB": -1,
+          "imageStatus": "Available",
+          "details": [
+            {
+              "key": "Location",
+              "value": "australiacentral"
+            },
+            {
+              "key": "Publisher",
+              "value": "Canonical"
+            },
+            {
+              "key": "Offer",
+              "value": "0001-com-ubuntu-server-jammy-daily"
+            },
+            {
+              "key": "SKU",
+              "value": "22_04-daily-lts-gen2"
+            },
+            {
+              "key": "Version",
+              "value": "22.04.202606270"
+            },
+            {
+              "key": "ID",
+              "value": "/Subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/Providers/Microsoft.Compute/Locations/AustraliaCentral/Publishers/Canonical/ArtifactTypes/VMImage/Offers/0001-com-ubuntu-server-jammy-daily/Skus/22_04-daily-lts-gen2/Versions/22.04.202606270"
+            },
+            {
+              "key": "HyperVGeneration",
+              "value": "V2"
+            },
+            {
+              "key": "Features",
+              "value": "SecurityType=TrustedLaunchSupported, IsAcceleratedNetworkSupported=True, DiskControllerTypes=SCSI, NVMe, IsHibernateSupported=True"
+            },
+            {
+              "key": "FeatureCount",
+              "value": "4"
+            },
+            {
+              "key": "ImageDeprecationState",
+              "value": "Active"
+            }
+          ],
+          "systemLabel": "",
+          "description": "",
+          "commandHistory": null
+        }
+      ],
+      "targetSecurityGroupList": [
+        {
+          "name": "mig-sg-01",
+          "connectionName": "azure-koreasouth",
+          "vNetId": "mig-vnet-01",
+          "description": "Recommended security group for NLB backend influxdb_back",
+          "firewallRules": [
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "8086",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            },
+            {
+              "Ports": "8086",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            }
+          ],
+          "cspResourceId": ""
+        },
+        {
+          "name": "mig-sg-02",
+          "connectionName": "azure-koreasouth",
+          "vNetId": "mig-vnet-01",
+          "description": "Recommended security group for ec268ed7-821e-9d73-e79f-961262161624",
+          "firewallRules": [
+            {
+              "Ports": "22",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "9999",
+              "Protocol": "tcp",
+              "Direction": "inbound",
+              "CIDR": "0.0.0.0/0"
+            },
+            {
+              "Ports": "",
+              "Protocol": "ALL",
+              "Direction": "inbound",
+              "CIDR": "10.0.0.0/16"
+            }
+          ],
+          "cspResourceId": ""
+        }
+      ],
+      "targetNlbList": [
+        {
+          "description": "Migrated from HAProxy backend: influxdb_back",
+          "type": "PUBLIC",
+          "scope": "REGION",
+          "listener": {
+            "protocol": "TCP",
+            "port": "9999"
+          },
+          "targetGroup": {
+            "protocol": "TCP",
+            "port": "8086",
+            "nodeGroupId": "ng-influxdb-back"
+          },
+          "healthChecker": {
+            "interval": 10,
+            "threshold": 3,
+            "timeout": -1
+          }
+        }
+      ]
+    }
+  ],
+  "message": "Recommended infrastructure for 2 target(s)"
+}
+```
+
+</details>
+
+**Input/Output Accuracy Check**:
+
+- Overall: ✅ PASS
+- result[0] targetCloud=aws/ap-northeast-2 status=highly-matched — matches request
+- result[1] targetCloud=azure/koreasouth status=partially-matched — matches request
+
+---
+

--- a/pkg/api/rest/controller/recommendation-multi-infra.go
+++ b/pkg/api/rest/controller/recommendation-multi-infra.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
+	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
+
+	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
+	"github.com/cloud-barista/cm-beetle/pkg/core/recommendation"
+	"github.com/labstack/echo/v4"
+
+	"github.com/rs/zerolog/log"
+)
+
+/*
+ * Multi-target Infrastructure Recommendation (cross-CSP comparison)
+ */
+
+// RecommendMultiInfraRequest is the request body for POST /recommendation/multiInfra.
+type RecommendMultiInfraRequest struct {
+	DesiredCspAndRegionPairs []cloudmodel.CloudProperty `json:"desiredCspAndRegionPairs" validate:"required,min=2,max=10,dive"`
+	SourceInfra              onpremmodel.OnpremInfra    `json:"sourceInfra" validate:"required"`
+}
+
+// validateMultiInfraTargets checks the target count bounds and rejects duplicate CSP/region
+// pairs, so each response item maps back to exactly one requested target unambiguously.
+func validateMultiInfraTargets(pairs []cloudmodel.CloudProperty) (string, bool) {
+	if len(pairs) < recommendation.MinMultiInfraTargets {
+		return fmt.Sprintf("At least %d target CSP/region pairs required", recommendation.MinMultiInfraTargets), false
+	}
+	if len(pairs) > recommendation.MaxMultiInfraTargets {
+		return fmt.Sprintf("At most %d target CSP/region pairs allowed", recommendation.MaxMultiInfraTargets), false
+	}
+
+	seen := make(map[string]bool, len(pairs))
+	for _, pair := range pairs {
+		if pair.Csp == "" || pair.Region == "" {
+			return "Each target requires both csp and region", false
+		}
+		key := strings.ToLower(pair.Csp) + "/" + strings.ToLower(pair.Region)
+		if seen[key] {
+			return fmt.Sprintf("Duplicate target: %s", key), false
+		}
+		seen[key] = true
+	}
+
+	return "", true
+}
+
+// parseMinMatchRate parses the minMatchRate query param, defaulting to 90.0.
+func parseMinMatchRate(c echo.Context) float64 {
+	minMatchRate := 90.0
+	if qp := c.QueryParam("minMatchRate"); qp != "" {
+		if parsed, err := strconv.ParseFloat(qp, 64); err != nil {
+			log.Warn().Err(err).Msgf("invalid minMatchRate value: %s, using default 90.0", qp)
+		} else if parsed < 0 || parsed > 100 {
+			log.Warn().Msgf("minMatchRate out of range [0-100]: %.1f, using default 90.0", parsed)
+		} else {
+			minMatchRate = parsed
+		}
+	}
+	return minMatchRate
+}
+
+// RecommendMultiInfraCandidates godoc
+// @ID RecommendMultiInfraCandidates
+// @Summary Recommend the best-match infrastructure per target cloud, for cross-CSP comparison
+// @Description Recommend a single best-effort infrastructure candidate for each of several target CSP/region pairs.
+// @Description
+// @Description Use this API to compare candidate clouds before committing to one; once a target is chosen,
+// @Description use `POST /recommendation/infra` against that single CSP/region to explore multiple candidates.
+// @Description
+// @Description **[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).
+// @Description Duplicate pairs are rejected.
+// @Description
+// @Description **[Response]** Always returns exactly one item per requested target, in request order
+// @Description (`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`
+// @Description without needing to be re-sorted or grouped. A target that fails validation or yields no
+// @Description compatible infrastructure still produces one item, with `status` set to `failed` or
+// @Description `nothing-to-recommend` and `targetInfra` left empty.
+// @Description
+// @Description **[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)
+// @Description
+// @Description [Note] Each target costs roughly as much as one `/recommendation/infra` call; requests with
+// @Description several targets can take a while. `Prefer: respond-async` is strongly recommended.
+// @Tags [Recommendation] Infrastructure
+// @Accept  json
+// @Produce  json
+// @Param request body RecommendMultiInfraRequest true "Target CSP/region pairs and the source infrastructure to be migrated"
+// @Param minMatchRate query number false "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)"
+// @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)" Enums(respond-async)
+// @Success 200 {object} model.ApiResponse[[]cloudmodel.RecommendedInfra] "One recommended (or failed/nothing-to-recommend) candidate per target, in request order"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Recommendation started asynchronously - use GET /request/{reqId} to check status"
+// @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
+// @Failure 500 {object} model.ApiResponse[any] "Internal server error during recommendation"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
+// @Router /recommendation/multiInfra [post]
+func RecommendMultiInfraCandidates(c echo.Context) error {
+
+	// [Input]
+	reqt := &RecommendMultiInfraRequest{}
+	if err := c.Bind(reqt); err != nil {
+		log.Warn().Err(err).Msg("failed to bind a request body")
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
+	}
+
+	if msg, ok := validateMultiInfraTargets(reqt.DesiredCspAndRegionPairs); !ok {
+		log.Warn().Msg(msg)
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse(msg))
+	}
+
+	minMatchRate := parseMinMatchRate(c)
+	pairs := reqt.DesiredCspAndRegionPairs
+	sourceInfra := reqt.SourceInfra
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() ([]cloudmodel.RecommendedInfra, error) {
+			return recommendation.RecommendMultiInfraCandidates(pairs, sourceInfra, minMatchRate)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Recommendation started. Use GET /request/{reqId} to check status."))
+	}
+
+	// [Process]
+	results, err := recommendation.RecommendMultiInfraCandidates(pairs, sourceInfra, minMatchRate)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to recommend multi-target infrastructure candidates")
+		return c.JSON(http.StatusInternalServerError, model.SimpleErrorResponse("Recommendation failed"))
+	}
+
+	// [Output]
+	return c.JSON(http.StatusOK, model.SuccessListResponseWithMessage(results,
+		fmt.Sprintf("Recommended infrastructure for %d target(s)", len(results))))
+}
+
+// RecommendMultiInfraWithNlbRequest is the request body for POST /recommendation/multiInfraWithNlb.
+type RecommendMultiInfraWithNlbRequest struct {
+	DesiredCspAndRegionPairs []cloudmodel.CloudProperty `json:"desiredCspAndRegionPairs" validate:"required,min=2,max=10,dive"`
+	SourceInfra              onpremmodel.OnpremInfra    `json:"sourceInfra" validate:"required"`
+}
+
+// RecommendMultiInfraWithNlbCandidates godoc
+// @ID RecommendMultiInfraWithNlbCandidates
+// @Summary (Preview) Recommend the best-match NLB-aware infrastructure per target cloud, for cross-CSP comparison
+// @Description NLB-aware counterpart of `POST /recommendation/multiInfra`. Recommends a single best-effort
+// @Description infrastructure candidate (including NLB mapping) for each of several target CSP/region pairs.
+// @Description
+// @Description Use this API to compare candidate clouds before committing to one; once a target is chosen,
+// @Description use `POST /recommendation/infraWithNlb` against that single CSP/region to explore multiple candidates.
+// @Description
+// @Description **[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).
+// @Description Duplicate pairs are rejected.
+// @Description
+// @Description [Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).
+// @Description
+// @Description **[Response]** Always returns exactly one item per requested target, in request order
+// @Description (`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`
+// @Description without needing to be re-sorted or grouped. A target that fails validation or yields no
+// @Description compatible infrastructure still produces one item, with `status` set to `failed` or
+// @Description `nothing-to-recommend` and `targetInfra` left empty.
+// @Description
+// @Description **[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)
+// @Description
+// @Description [Note] Each target costs roughly as much as one `/recommendation/infraWithNlb` call; requests with
+// @Description several targets can take a while. `Prefer: respond-async` is strongly recommended.
+// @Tags [Recommendation] Infrastructure
+// @Accept  json
+// @Produce  json
+// @Param request body RecommendMultiInfraWithNlbRequest true "Target CSP/region pairs and the source infra including NLBs"
+// @Param minMatchRate query number false "Minimum match rate for highly-matched classification (default: 90.0, range: 0-100)"
+// @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
+// @Param Prefer header string false "Set to 'respond-async' to run this recommendation asynchronously (RFC 7240)" Enums(respond-async)
+// @Success 200 {object} model.ApiResponse[[]cloudmodel.RecommendedInfra] "One recommended (or failed/nothing-to-recommend) candidate per target, in request order"
+// @Success 202 {object} model.ApiResponse[model.AsyncJobResponse] "Recommendation started asynchronously - use GET /request/{reqId} to check status"
+// @Failure 400 {object} model.ApiResponse[any] "Invalid request parameters"
+// @Failure 500 {object} model.ApiResponse[any] "Internal server error during recommendation"
+// @Failure 503 {object} model.ApiResponse[any] "Too many concurrent async jobs; retry later or without Prefer: respond-async"
+// @Router /recommendation/multiInfraWithNlb [post]
+func RecommendMultiInfraWithNlbCandidates(c echo.Context) error {
+
+	// [Input]
+	reqt := &RecommendMultiInfraWithNlbRequest{}
+	if err := c.Bind(reqt); err != nil {
+		log.Warn().Err(err).Msg("failed to bind a request body")
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid request format"))
+	}
+
+	if msg, ok := validateMultiInfraTargets(reqt.DesiredCspAndRegionPairs); !ok {
+		log.Warn().Msg(msg)
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse(msg))
+	}
+
+	if len(reqt.SourceInfra.Nodes) == 0 {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("sourceInfra.nodes is required"))
+	}
+	if len(reqt.SourceInfra.NLBs) == 0 {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse(
+			"sourceInfra.nlbs is required for multiInfraWithNlb; use /recommendation/multiInfra for NLB-free recommendation"))
+	}
+
+	minMatchRate := parseMinMatchRate(c)
+	pairs := reqt.DesiredCspAndRegionPairs
+	sourceInfra := reqt.SourceInfra
+
+	if preferRespondAsync(c) {
+		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+		started := common.RunAsync(reqID, func() ([]cloudmodel.RecommendedInfra, error) {
+			return recommendation.RecommendMultiInfraWithNlbCandidates(pairs, sourceInfra, minMatchRate)
+		})
+		if !started {
+			c.Response().Header().Set("Retry-After", "5")
+			return c.JSON(http.StatusServiceUnavailable, model.SimpleErrorResponse(
+				"Too many async jobs in progress; retry shortly, or retry without Prefer: respond-async"))
+		}
+		c.Response().Header().Set("Preference-Applied", "respond-async")
+		return c.JSON(http.StatusAccepted, model.SuccessResponseWithMessage(
+			model.AsyncJobResponse{
+				ReqID:     reqID,
+				Status:    common.RequestStatusHandling,
+				StatusURL: fmt.Sprintf("/beetle/request/%s", reqID),
+			},
+			"Recommendation started. Use GET /request/{reqId} to check status."))
+	}
+
+	// [Process]
+	results, err := recommendation.RecommendMultiInfraWithNlbCandidates(pairs, sourceInfra, minMatchRate)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to recommend multi-target NLB-aware infrastructure candidates")
+		return c.JSON(http.StatusInternalServerError, model.SimpleErrorResponse("Recommendation failed"))
+	}
+
+	// [Output]
+	return c.JSON(http.StatusOK, model.SuccessListResponseWithMessage(results,
+		fmt.Sprintf("Recommended infrastructure for %d target(s)", len(results))))
+}

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -313,6 +313,10 @@ func RunServer(port string) {
 	gRecommendation.POST("/infra", controller.RecommendVmInfraCandidates)
 	gRecommendation.POST("/infraWithDefaults", controller.RecommendVMInfraWithDefaults)
 
+	// Recommendation APIs for infrastructure across multiple target clouds (cross-CSP comparison)
+	gRecommendation.POST("/multiInfra", controller.RecommendMultiInfraCandidates)
+	gRecommendation.POST("/multiInfraWithNlb", controller.RecommendMultiInfraWithNlbCandidates)
+
 	// Naming and validation utility APIs
 	gNaming := gBeetle.Group("/naming")
 	gNaming.POST("/alignment", controller.AlignNames)

--- a/pkg/core/recommendation/infra-multi-target.go
+++ b/pkg/core/recommendation/infra-multi-target.go
@@ -1,0 +1,100 @@
+package recommendation
+
+import (
+	"strings"
+
+	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
+	onpremmodel "github.com/cloud-barista/cm-beetle/imdl/on-premise-model"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// MinMultiInfraTargets is the minimum number of CSP/region pairs a multi-target
+	// recommendation request must include (a single pair is just /recommendation/infra).
+	MinMultiInfraTargets = 2
+
+	// MaxMultiInfraTargets caps the number of CSP/region pairs a multi-target recommendation
+	// request may include. Set to the project's current scope of 10 supported CSPs.
+	MaxMultiInfraTargets = 10
+
+	// multiInfraCandidatesPerTarget is intentionally fixed at 1: multi-target recommendation
+	// is for cross-CSP comparison (breadth), not per-CSP alternatives (depth, still served by
+	// the single-target APIs). This also bounds the per-target preflight-check cost, which
+	// matters because multi-target calls already multiply Tumblebug pacer load by target count.
+	multiInfraCandidatesPerTarget = 1
+)
+
+// singleTargetRecommender is the shape shared by RecommendVmInfraCandidates and
+// RecommendInfraWithNlbCandidates. Letting the multi-target orchestrator take either as a
+// parameter avoids duplicating validation, sequencing, or sentinel-item logic per variant.
+type singleTargetRecommender func(desiredCsp, desiredRegion string, srcInfra onpremmodel.OnpremInfra, limit int, minMatchRate float64) ([]cloudmodel.RecommendedInfra, error)
+
+// RecommendMultiInfraCandidates recommends the single best-match infrastructure candidate for
+// each target CSP/region pair, for cross-CSP comparison. Composes RecommendVmInfraCandidates;
+// no matching/ranking logic is duplicated here.
+func RecommendMultiInfraCandidates(pairs []cloudmodel.CloudProperty, srcInfra onpremmodel.OnpremInfra, minMatchRate float64) ([]cloudmodel.RecommendedInfra, error) {
+	return recommendPerTarget(pairs, srcInfra, minMatchRate, RecommendVmInfraCandidates)
+}
+
+// RecommendMultiInfraWithNlbCandidates is the NLB-aware counterpart of
+// RecommendMultiInfraCandidates, composing RecommendInfraWithNlbCandidates per target.
+func RecommendMultiInfraWithNlbCandidates(pairs []cloudmodel.CloudProperty, srcInfra onpremmodel.OnpremInfra, minMatchRate float64) ([]cloudmodel.RecommendedInfra, error) {
+	return recommendPerTarget(pairs, srcInfra, minMatchRate, RecommendInfraWithNlbCandidates)
+}
+
+// recommendPerTarget runs recommend once per target pair, sequentially. Tumblebug calls share
+// a single process-wide pacer, so parallelizing targets would not reduce latency and would
+// only risk 429s. Every pair yields exactly one result item — the top candidate on success, or
+// a sentinel "failed"/"nothing-to-recommend" item otherwise — so len(result) == len(pairs)
+// always holds, giving callers a predictable, index-free way to match results back to targets.
+func recommendPerTarget(pairs []cloudmodel.CloudProperty, srcInfra onpremmodel.OnpremInfra, minMatchRate float64, recommend singleTargetRecommender) ([]cloudmodel.RecommendedInfra, error) {
+	results := make([]cloudmodel.RecommendedInfra, 0, len(pairs))
+
+	for _, pair := range pairs {
+		csp := strings.ToLower(pair.Csp)
+		region := strings.ToLower(pair.Region)
+
+		if ok, err := IsValidCspAndRegion(csp, region); !ok {
+			log.Warn().Err(err).Str("csp", csp).Str("region", region).Msg("skipping invalid target in multi-target recommendation")
+			results = append(results, failedTargetResult(csp, region, err))
+			continue
+		}
+
+		candidates, err := recommend(csp, region, srcInfra, multiInfraCandidatesPerTarget, minMatchRate)
+		if err != nil {
+			log.Warn().Err(err).Str("csp", csp).Str("region", region).Msg("recommendation failed for target")
+			results = append(results, failedTargetResult(csp, region, err))
+			continue
+		}
+		if len(candidates) == 0 {
+			// Matches the status vocabulary of RecommendVmInfraCandidates/RecommendInfraWithNlbCandidates
+			// ("highly-matched" / "partially-matched" / "nothing-to-recommend"), not the older
+			// RecommendationStatus enum ("none"/"partial"/"ok") used by the dynamic-list recommender.
+			results = append(results, cloudmodel.RecommendedInfra{
+				Status:      "nothing-to-recommend",
+				Description: "No compatible infrastructure could be recommended for this target.",
+				TargetCloud: cloudmodel.CloudProperty{Csp: csp, Region: region},
+			})
+			continue
+		}
+
+		results = append(results, candidates[0])
+	}
+
+	return results, nil
+}
+
+// failedTargetResult builds a sentinel RecommendedInfra for a target that could not be
+// processed (invalid CSP/region, or an internal recommendation error).
+func failedTargetResult(csp, region string, err error) cloudmodel.RecommendedInfra {
+	msg := "recommendation failed"
+	if err != nil {
+		msg = err.Error()
+	}
+	return cloudmodel.RecommendedInfra{
+		Status:      "failed",
+		Description: msg,
+		TargetCloud: cloudmodel.CloudProperty{Csp: csp, Region: region},
+	}
+}


### PR DESCRIPTION
- Add POST /recommendation/multiInfra endpoint
- Add POST /recommendation/multiInfraWithNlb endpoint
- Support 2-10 target CSP/region pairs per request
- Return one candidate per target in request order
- Add test-cli for input/output verification