### PR TITLE
fix(imdl): resync InfraInfo with tumblebug

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -5861,32 +5861,75 @@ const docTemplate = `{
                 }
             }
         },
-        "cloudmodel.InfraCmdReq": {
+        "cloudmodel.InfraClusterInfo": {
             "type": "object",
-            "required": [
-                "command"
-            ],
             "properties": {
-                "command": {
-                    "description": "Command is the list of commands to execute",
+                "connectionNames": {
+                    "description": "ConnectionNames are unique connection names included in this cluster.",
                     "type": "array",
                     "items": {
                         "type": "string"
-                    },
-                    "example": [
-                        "client_ip=$(echo $SSH_CLIENT | awk '{print $1}'); echo SSH client IP is: $client_ip"
-                    ]
+                    }
                 },
-                "timeoutMinutes": {
-                    "description": "TimeoutMinutes is the timeout for command execution in minutes (default: 30, min: 1, max: 120)\nIf not specified or set to 0, the default timeout (30 minutes) will be used",
-                    "type": "integer",
-                    "default": 30,
-                    "example": 30
+                "id": {
+                    "description": "Id is a deterministic cluster identifier generated from grouping attributes.",
+                    "type": "string"
                 },
-                "userName": {
-                    "description": "UserName is the SSH username to use for command execution",
-                    "type": "string",
-                    "example": "cb-user"
+                "infraId": {
+                    "description": "InfraId is the parent Infra ID.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is a human-readable cluster name. Currently same as Id.",
+                    "type": "string"
+                },
+                "nodeCount": {
+                    "description": "NodeCount is the number of Nodes in this cluster.",
+                    "type": "integer"
+                },
+                "nodeGroupCount": {
+                    "description": "NodeGroupCount is the number of NodeGroups in this cluster.",
+                    "type": "integer"
+                },
+                "nodeGroupIds": {
+                    "description": "NodeGroupIds are NodeGroups that belong to this implicit cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "nodeIds": {
+                    "description": "NodeIds are Nodes that belong to this implicit cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "providerNames": {
+                    "description": "ProviderNames are unique CSP providers included in this cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "regionNames": {
+                    "description": "RegionNames are unique regions included in this cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "representativeNodeGroupId": {
+                    "description": "RepresentativeNodeGroupId is a representative NodeGroup ID for quick inspection.",
+                    "type": "string"
+                },
+                "representativeNodeId": {
+                    "description": "RepresentativeNodeId is a representative Node ID for quick inspection.",
+                    "type": "string"
+                },
+                "vNetId": {
+                    "description": "VNetId is the shared VNet boundary used for implicit clustering.",
+                    "type": "string"
                 }
             }
         },
@@ -6007,6 +6050,13 @@ const docTemplate = `{
         "cloudmodel.InfraInfo": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "description": "Cluster is the list of implicit clusters synthesized at query-time from Nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.InfraClusterInfo"
+                    }
+                },
                 "configureCloudAdaptiveNetwork": {
                     "description": "ConfigureCloudAdaptiveNetwork is an option to configure Cloud Adaptive Network (CLADNet) ([yes/no] default:yes)",
                     "type": "string",
@@ -6071,21 +6121,37 @@ const docTemplate = `{
                 "placementAlgo": {
                     "type": "string"
                 },
-                "postCommand": {
-                    "description": "PostCommand is for the command to bootstrap the Nodes",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.InfraCmdReq"
-                        }
-                    ]
+                "postCommandAsync": {
+                    "description": "PostCommandAsync echoes whether the commands run in the background",
+                    "type": "boolean"
                 },
-                "postCommandResult": {
-                    "description": "PostCommandResult is the result of the command for bootstraping the Nodes",
+                "postCommandRequestId": {
+                    "description": "PostCommandRequestId is the streaming/tracking key of the post-deployment run\n(always set when post-deployment commands were requested, in both modes)",
+                    "type": "string",
+                    "example": "pc-infra01-1a2b3c"
+                },
+                "postCommandResults": {
+                    "description": "PostCommandResults holds per-phase outcomes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandPhaseResult"
+                    }
+                },
+                "postCommandStatus": {
+                    "description": "PostCommandStatus summarizes the post-deployment command outcome.\n\"Running\" means execution is still in progress (async mode): stream it with\nGET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}\nor poll this object until the status becomes terminal.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResult"
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
                         }
-                    ]
+                    ],
+                    "example": "Completed"
+                },
+                "postCommands": {
+                    "description": "PostCommands are the requested post-deployment command phases",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandReq"
+                    }
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",
@@ -6204,13 +6270,13 @@ const docTemplate = `{
                 }
             }
         },
-        "cloudmodel.InfraSshCmdResult": {
+        "cloudmodel.InfraSshCmdResultForAPI": {
             "type": "object",
             "properties": {
                 "results": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/cloudmodel.SshCmdResult"
+                        "$ref": "#/definitions/cloudmodel.SshCmdResultForAPI"
                     }
                 }
             }
@@ -6875,6 +6941,38 @@ const docTemplate = `{
                 "PlatformNA"
             ]
         },
+        "cloudmodel.PostCommandPhaseResult": {
+            "type": "object",
+            "properties": {
+                "phase": {
+                    "description": "Phase is the 1-based execution order",
+                    "type": "integer",
+                    "example": 1
+                },
+                "results": {
+                    "description": "Results holds per-node command results",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResultForAPI"
+                        }
+                    ]
+                },
+                "status": {
+                    "description": "Status is the aggregated outcome of this phase (Skipped when a previous phase stopped execution)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
+                        }
+                    ],
+                    "example": "Completed"
+                },
+                "target": {
+                    "description": "Target echoes the scope this phase ran against",
+                    "type": "string",
+                    "example": "nodeGroupId=control"
+                }
+            }
+        },
         "cloudmodel.PostCommandReq": {
             "type": "object",
             "required": [
@@ -6923,6 +7021,25 @@ const docTemplate = `{
                     "example": "cb-user"
                 }
             }
+        },
+        "cloudmodel.PostCommandStatus": {
+            "type": "string",
+            "enum": [
+                "None",
+                "Completed",
+                "CompletedWithErrors",
+                "Failed",
+                "Skipped",
+                "Running"
+            ],
+            "x-enum-varnames": [
+                "PostCommandStatusNone",
+                "PostCommandStatusCompleted",
+                "PostCommandStatusCompletedWithErrors",
+                "PostCommandStatusFailed",
+                "PostCommandStatusSkipped",
+                "PostCommandStatusRunning"
+            ]
         },
         "cloudmodel.RecommendedInfra": {
             "type": "object",
@@ -7424,7 +7541,7 @@ const docTemplate = `{
                 }
             }
         },
-        "cloudmodel.SshCmdResult": {
+        "cloudmodel.SshCmdResultForAPI": {
             "type": "object",
             "properties": {
                 "command": {
@@ -7433,7 +7550,10 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "err": {},
+                "error": {
+                    "description": "String representation of error for JSON serialization",
+                    "type": "string"
+                },
                 "infraId": {
                     "type": "string"
                 },
@@ -7875,6 +7995,13 @@ const docTemplate = `{
         "controller.MigrateInfraResponse": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "description": "Cluster is the list of implicit clusters synthesized at query-time from Nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.InfraClusterInfo"
+                    }
+                },
                 "configureCloudAdaptiveNetwork": {
                     "description": "ConfigureCloudAdaptiveNetwork is an option to configure Cloud Adaptive Network (CLADNet) ([yes/no] default:yes)",
                     "type": "string",
@@ -7939,21 +8066,37 @@ const docTemplate = `{
                 "placementAlgo": {
                     "type": "string"
                 },
-                "postCommand": {
-                    "description": "PostCommand is for the command to bootstrap the Nodes",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.InfraCmdReq"
-                        }
-                    ]
+                "postCommandAsync": {
+                    "description": "PostCommandAsync echoes whether the commands run in the background",
+                    "type": "boolean"
                 },
-                "postCommandResult": {
-                    "description": "PostCommandResult is the result of the command for bootstraping the Nodes",
+                "postCommandRequestId": {
+                    "description": "PostCommandRequestId is the streaming/tracking key of the post-deployment run\n(always set when post-deployment commands were requested, in both modes)",
+                    "type": "string",
+                    "example": "pc-infra01-1a2b3c"
+                },
+                "postCommandResults": {
+                    "description": "PostCommandResults holds per-phase outcomes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandPhaseResult"
+                    }
+                },
+                "postCommandStatus": {
+                    "description": "PostCommandStatus summarizes the post-deployment command outcome.\n\"Running\" means execution is still in progress (async mode): stream it with\nGET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}\nor poll this object until the status becomes terminal.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResult"
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
                         }
-                    ]
+                    ],
+                    "example": "Completed"
+                },
+                "postCommands": {
+                    "description": "PostCommands are the requested post-deployment command phases",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandReq"
+                    }
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",
@@ -8072,6 +8215,13 @@ const docTemplate = `{
         "controller.MigrateInfraWithDefaultsResponse": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "description": "Cluster is the list of implicit clusters synthesized at query-time from Nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.InfraClusterInfo"
+                    }
+                },
                 "configureCloudAdaptiveNetwork": {
                     "description": "ConfigureCloudAdaptiveNetwork is an option to configure Cloud Adaptive Network (CLADNet) ([yes/no] default:yes)",
                     "type": "string",
@@ -8136,21 +8286,37 @@ const docTemplate = `{
                 "placementAlgo": {
                     "type": "string"
                 },
-                "postCommand": {
-                    "description": "PostCommand is for the command to bootstrap the Nodes",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.InfraCmdReq"
-                        }
-                    ]
+                "postCommandAsync": {
+                    "description": "PostCommandAsync echoes whether the commands run in the background",
+                    "type": "boolean"
                 },
-                "postCommandResult": {
-                    "description": "PostCommandResult is the result of the command for bootstraping the Nodes",
+                "postCommandRequestId": {
+                    "description": "PostCommandRequestId is the streaming/tracking key of the post-deployment run\n(always set when post-deployment commands were requested, in both modes)",
+                    "type": "string",
+                    "example": "pc-infra01-1a2b3c"
+                },
+                "postCommandResults": {
+                    "description": "PostCommandResults holds per-phase outcomes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandPhaseResult"
+                    }
+                },
+                "postCommandStatus": {
+                    "description": "PostCommandStatus summarizes the post-deployment command outcome.\n\"Running\" means execution is still in progress (async mode): stream it with\nGET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}\nor poll this object until the status becomes terminal.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResult"
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
                         }
-                    ]
+                    ],
+                    "example": "Completed"
+                },
+                "postCommands": {
+                    "description": "PostCommands are the requested post-deployment command phases",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandReq"
+                    }
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -5855,32 +5855,75 @@
                 }
             }
         },
-        "cloudmodel.InfraCmdReq": {
+        "cloudmodel.InfraClusterInfo": {
             "type": "object",
-            "required": [
-                "command"
-            ],
             "properties": {
-                "command": {
-                    "description": "Command is the list of commands to execute",
+                "connectionNames": {
+                    "description": "ConnectionNames are unique connection names included in this cluster.",
                     "type": "array",
                     "items": {
                         "type": "string"
-                    },
-                    "example": [
-                        "client_ip=$(echo $SSH_CLIENT | awk '{print $1}'); echo SSH client IP is: $client_ip"
-                    ]
+                    }
                 },
-                "timeoutMinutes": {
-                    "description": "TimeoutMinutes is the timeout for command execution in minutes (default: 30, min: 1, max: 120)\nIf not specified or set to 0, the default timeout (30 minutes) will be used",
-                    "type": "integer",
-                    "default": 30,
-                    "example": 30
+                "id": {
+                    "description": "Id is a deterministic cluster identifier generated from grouping attributes.",
+                    "type": "string"
                 },
-                "userName": {
-                    "description": "UserName is the SSH username to use for command execution",
-                    "type": "string",
-                    "example": "cb-user"
+                "infraId": {
+                    "description": "InfraId is the parent Infra ID.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is a human-readable cluster name. Currently same as Id.",
+                    "type": "string"
+                },
+                "nodeCount": {
+                    "description": "NodeCount is the number of Nodes in this cluster.",
+                    "type": "integer"
+                },
+                "nodeGroupCount": {
+                    "description": "NodeGroupCount is the number of NodeGroups in this cluster.",
+                    "type": "integer"
+                },
+                "nodeGroupIds": {
+                    "description": "NodeGroupIds are NodeGroups that belong to this implicit cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "nodeIds": {
+                    "description": "NodeIds are Nodes that belong to this implicit cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "providerNames": {
+                    "description": "ProviderNames are unique CSP providers included in this cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "regionNames": {
+                    "description": "RegionNames are unique regions included in this cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "representativeNodeGroupId": {
+                    "description": "RepresentativeNodeGroupId is a representative NodeGroup ID for quick inspection.",
+                    "type": "string"
+                },
+                "representativeNodeId": {
+                    "description": "RepresentativeNodeId is a representative Node ID for quick inspection.",
+                    "type": "string"
+                },
+                "vNetId": {
+                    "description": "VNetId is the shared VNet boundary used for implicit clustering.",
+                    "type": "string"
                 }
             }
         },
@@ -6001,6 +6044,13 @@
         "cloudmodel.InfraInfo": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "description": "Cluster is the list of implicit clusters synthesized at query-time from Nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.InfraClusterInfo"
+                    }
+                },
                 "configureCloudAdaptiveNetwork": {
                     "description": "ConfigureCloudAdaptiveNetwork is an option to configure Cloud Adaptive Network (CLADNet) ([yes/no] default:yes)",
                     "type": "string",
@@ -6065,21 +6115,37 @@
                 "placementAlgo": {
                     "type": "string"
                 },
-                "postCommand": {
-                    "description": "PostCommand is for the command to bootstrap the Nodes",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.InfraCmdReq"
-                        }
-                    ]
+                "postCommandAsync": {
+                    "description": "PostCommandAsync echoes whether the commands run in the background",
+                    "type": "boolean"
                 },
-                "postCommandResult": {
-                    "description": "PostCommandResult is the result of the command for bootstraping the Nodes",
+                "postCommandRequestId": {
+                    "description": "PostCommandRequestId is the streaming/tracking key of the post-deployment run\n(always set when post-deployment commands were requested, in both modes)",
+                    "type": "string",
+                    "example": "pc-infra01-1a2b3c"
+                },
+                "postCommandResults": {
+                    "description": "PostCommandResults holds per-phase outcomes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandPhaseResult"
+                    }
+                },
+                "postCommandStatus": {
+                    "description": "PostCommandStatus summarizes the post-deployment command outcome.\n\"Running\" means execution is still in progress (async mode): stream it with\nGET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}\nor poll this object until the status becomes terminal.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResult"
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
                         }
-                    ]
+                    ],
+                    "example": "Completed"
+                },
+                "postCommands": {
+                    "description": "PostCommands are the requested post-deployment command phases",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandReq"
+                    }
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",
@@ -6198,13 +6264,13 @@
                 }
             }
         },
-        "cloudmodel.InfraSshCmdResult": {
+        "cloudmodel.InfraSshCmdResultForAPI": {
             "type": "object",
             "properties": {
                 "results": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/cloudmodel.SshCmdResult"
+                        "$ref": "#/definitions/cloudmodel.SshCmdResultForAPI"
                     }
                 }
             }
@@ -6869,6 +6935,38 @@
                 "PlatformNA"
             ]
         },
+        "cloudmodel.PostCommandPhaseResult": {
+            "type": "object",
+            "properties": {
+                "phase": {
+                    "description": "Phase is the 1-based execution order",
+                    "type": "integer",
+                    "example": 1
+                },
+                "results": {
+                    "description": "Results holds per-node command results",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResultForAPI"
+                        }
+                    ]
+                },
+                "status": {
+                    "description": "Status is the aggregated outcome of this phase (Skipped when a previous phase stopped execution)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
+                        }
+                    ],
+                    "example": "Completed"
+                },
+                "target": {
+                    "description": "Target echoes the scope this phase ran against",
+                    "type": "string",
+                    "example": "nodeGroupId=control"
+                }
+            }
+        },
         "cloudmodel.PostCommandReq": {
             "type": "object",
             "required": [
@@ -6917,6 +7015,25 @@
                     "example": "cb-user"
                 }
             }
+        },
+        "cloudmodel.PostCommandStatus": {
+            "type": "string",
+            "enum": [
+                "None",
+                "Completed",
+                "CompletedWithErrors",
+                "Failed",
+                "Skipped",
+                "Running"
+            ],
+            "x-enum-varnames": [
+                "PostCommandStatusNone",
+                "PostCommandStatusCompleted",
+                "PostCommandStatusCompletedWithErrors",
+                "PostCommandStatusFailed",
+                "PostCommandStatusSkipped",
+                "PostCommandStatusRunning"
+            ]
         },
         "cloudmodel.RecommendedInfra": {
             "type": "object",
@@ -7418,7 +7535,7 @@
                 }
             }
         },
-        "cloudmodel.SshCmdResult": {
+        "cloudmodel.SshCmdResultForAPI": {
             "type": "object",
             "properties": {
                 "command": {
@@ -7427,7 +7544,10 @@
                         "type": "string"
                     }
                 },
-                "err": {},
+                "error": {
+                    "description": "String representation of error for JSON serialization",
+                    "type": "string"
+                },
                 "infraId": {
                     "type": "string"
                 },
@@ -7869,6 +7989,13 @@
         "controller.MigrateInfraResponse": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "description": "Cluster is the list of implicit clusters synthesized at query-time from Nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.InfraClusterInfo"
+                    }
+                },
                 "configureCloudAdaptiveNetwork": {
                     "description": "ConfigureCloudAdaptiveNetwork is an option to configure Cloud Adaptive Network (CLADNet) ([yes/no] default:yes)",
                     "type": "string",
@@ -7933,21 +8060,37 @@
                 "placementAlgo": {
                     "type": "string"
                 },
-                "postCommand": {
-                    "description": "PostCommand is for the command to bootstrap the Nodes",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.InfraCmdReq"
-                        }
-                    ]
+                "postCommandAsync": {
+                    "description": "PostCommandAsync echoes whether the commands run in the background",
+                    "type": "boolean"
                 },
-                "postCommandResult": {
-                    "description": "PostCommandResult is the result of the command for bootstraping the Nodes",
+                "postCommandRequestId": {
+                    "description": "PostCommandRequestId is the streaming/tracking key of the post-deployment run\n(always set when post-deployment commands were requested, in both modes)",
+                    "type": "string",
+                    "example": "pc-infra01-1a2b3c"
+                },
+                "postCommandResults": {
+                    "description": "PostCommandResults holds per-phase outcomes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandPhaseResult"
+                    }
+                },
+                "postCommandStatus": {
+                    "description": "PostCommandStatus summarizes the post-deployment command outcome.\n\"Running\" means execution is still in progress (async mode): stream it with\nGET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}\nor poll this object until the status becomes terminal.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResult"
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
                         }
-                    ]
+                    ],
+                    "example": "Completed"
+                },
+                "postCommands": {
+                    "description": "PostCommands are the requested post-deployment command phases",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandReq"
+                    }
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",
@@ -8066,6 +8209,13 @@
         "controller.MigrateInfraWithDefaultsResponse": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "description": "Cluster is the list of implicit clusters synthesized at query-time from Nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.InfraClusterInfo"
+                    }
+                },
                 "configureCloudAdaptiveNetwork": {
                     "description": "ConfigureCloudAdaptiveNetwork is an option to configure Cloud Adaptive Network (CLADNet) ([yes/no] default:yes)",
                     "type": "string",
@@ -8130,21 +8280,37 @@
                 "placementAlgo": {
                     "type": "string"
                 },
-                "postCommand": {
-                    "description": "PostCommand is for the command to bootstrap the Nodes",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/cloudmodel.InfraCmdReq"
-                        }
-                    ]
+                "postCommandAsync": {
+                    "description": "PostCommandAsync echoes whether the commands run in the background",
+                    "type": "boolean"
                 },
-                "postCommandResult": {
-                    "description": "PostCommandResult is the result of the command for bootstraping the Nodes",
+                "postCommandRequestId": {
+                    "description": "PostCommandRequestId is the streaming/tracking key of the post-deployment run\n(always set when post-deployment commands were requested, in both modes)",
+                    "type": "string",
+                    "example": "pc-infra01-1a2b3c"
+                },
+                "postCommandResults": {
+                    "description": "PostCommandResults holds per-phase outcomes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandPhaseResult"
+                    }
+                },
+                "postCommandStatus": {
+                    "description": "PostCommandStatus summarizes the post-deployment command outcome.\n\"Running\" means execution is still in progress (async mode): stream it with\nGET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}\nor poll this object until the status becomes terminal.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/cloudmodel.InfraSshCmdResult"
+                            "$ref": "#/definitions/cloudmodel.PostCommandStatus"
                         }
-                    ]
+                    ],
+                    "example": "Completed"
+                },
+                "postCommands": {
+                    "description": "PostCommands are the requested post-deployment command phases",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.PostCommandReq"
+                    }
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -502,29 +502,60 @@ definitions:
         example: image
         type: string
     type: object
-  cloudmodel.InfraCmdReq:
+  cloudmodel.InfraClusterInfo:
     properties:
-      command:
-        description: Command is the list of commands to execute
-        example:
-        - 'client_ip=$(echo $SSH_CLIENT | awk ''{print $1}''); echo SSH client IP
-          is: $client_ip'
+      connectionNames:
+        description: ConnectionNames are unique connection names included in this
+          cluster.
         items:
           type: string
         type: array
-      timeoutMinutes:
-        default: 30
-        description: |-
-          TimeoutMinutes is the timeout for command execution in minutes (default: 30, min: 1, max: 120)
-          If not specified or set to 0, the default timeout (30 minutes) will be used
-        example: 30
-        type: integer
-      userName:
-        description: UserName is the SSH username to use for command execution
-        example: cb-user
+      id:
+        description: Id is a deterministic cluster identifier generated from grouping
+          attributes.
         type: string
-    required:
-    - command
+      infraId:
+        description: InfraId is the parent Infra ID.
+        type: string
+      name:
+        description: Name is a human-readable cluster name. Currently same as Id.
+        type: string
+      nodeCount:
+        description: NodeCount is the number of Nodes in this cluster.
+        type: integer
+      nodeGroupCount:
+        description: NodeGroupCount is the number of NodeGroups in this cluster.
+        type: integer
+      nodeGroupIds:
+        description: NodeGroupIds are NodeGroups that belong to this implicit cluster.
+        items:
+          type: string
+        type: array
+      nodeIds:
+        description: NodeIds are Nodes that belong to this implicit cluster.
+        items:
+          type: string
+        type: array
+      providerNames:
+        description: ProviderNames are unique CSP providers included in this cluster.
+        items:
+          type: string
+        type: array
+      regionNames:
+        description: RegionNames are unique regions included in this cluster.
+        items:
+          type: string
+        type: array
+      representativeNodeGroupId:
+        description: RepresentativeNodeGroupId is a representative NodeGroup ID for
+          quick inspection.
+        type: string
+      representativeNodeId:
+        description: RepresentativeNodeId is a representative Node ID for quick inspection.
+        type: string
+      vNetId:
+        description: VNetId is the shared VNet boundary used for implicit clustering.
+        type: string
     type: object
   cloudmodel.InfraCreationErrors:
     properties:
@@ -665,6 +696,12 @@ definitions:
     type: object
   cloudmodel.InfraInfo:
     properties:
+      cluster:
+        description: Cluster is the list of implicit clusters synthesized at query-time
+          from Nodes.
+        items:
+          $ref: '#/definitions/cloudmodel.InfraClusterInfo'
+        type: array
       configureCloudAdaptiveNetwork:
         default: "no"
         description: ConfigureCloudAdaptiveNetwork is an option to configure Cloud
@@ -715,15 +752,34 @@ definitions:
         type: array
       placementAlgo:
         type: string
-      postCommand:
+      postCommandAsync:
+        description: PostCommandAsync echoes whether the commands run in the background
+        type: boolean
+      postCommandRequestId:
+        description: |-
+          PostCommandRequestId is the streaming/tracking key of the post-deployment run
+          (always set when post-deployment commands were requested, in both modes)
+        example: pc-infra01-1a2b3c
+        type: string
+      postCommandResults:
+        description: PostCommandResults holds per-phase outcomes
+        items:
+          $ref: '#/definitions/cloudmodel.PostCommandPhaseResult'
+        type: array
+      postCommandStatus:
         allOf:
-        - $ref: '#/definitions/cloudmodel.InfraCmdReq'
-        description: PostCommand is for the command to bootstrap the Nodes
-      postCommandResult:
-        allOf:
-        - $ref: '#/definitions/cloudmodel.InfraSshCmdResult'
-        description: PostCommandResult is the result of the command for bootstraping
-          the Nodes
+        - $ref: '#/definitions/cloudmodel.PostCommandStatus'
+        description: |-
+          PostCommandStatus summarizes the post-deployment command outcome.
+          "Running" means execution is still in progress (async mode): stream it with
+          GET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}
+          or poll this object until the status becomes terminal.
+        example: Completed
+      postCommands:
+        description: PostCommands are the requested post-deployment command phases
+        items:
+          $ref: '#/definitions/cloudmodel.PostCommandReq'
+        type: array
       resourceType:
         description: ResourceType is the type of the resource
         type: string
@@ -818,11 +874,11 @@ definitions:
     - name
     - nodeGroups
     type: object
-  cloudmodel.InfraSshCmdResult:
+  cloudmodel.InfraSshCmdResultForAPI:
     properties:
       results:
         items:
-          $ref: '#/definitions/cloudmodel.SshCmdResult'
+          $ref: '#/definitions/cloudmodel.SshCmdResultForAPI'
         type: array
     type: object
   cloudmodel.K8sClusterReq:
@@ -1298,6 +1354,27 @@ definitions:
     - Linux_UNIX
     - Windows
     - PlatformNA
+  cloudmodel.PostCommandPhaseResult:
+    properties:
+      phase:
+        description: Phase is the 1-based execution order
+        example: 1
+        type: integer
+      results:
+        allOf:
+        - $ref: '#/definitions/cloudmodel.InfraSshCmdResultForAPI'
+        description: Results holds per-node command results
+      status:
+        allOf:
+        - $ref: '#/definitions/cloudmodel.PostCommandStatus'
+        description: Status is the aggregated outcome of this phase (Skipped when
+          a previous phase stopped execution)
+        example: Completed
+      target:
+        description: Target echoes the scope this phase ran against
+        example: nodeGroupId=control
+        type: string
+    type: object
   cloudmodel.PostCommandReq:
     properties:
       command:
@@ -1340,6 +1417,22 @@ definitions:
     required:
     - command
     type: object
+  cloudmodel.PostCommandStatus:
+    enum:
+    - None
+    - Completed
+    - CompletedWithErrors
+    - Failed
+    - Skipped
+    - Running
+    type: string
+    x-enum-varnames:
+    - PostCommandStatusNone
+    - PostCommandStatusCompleted
+    - PostCommandStatusCompletedWithErrors
+    - PostCommandStatusFailed
+    - PostCommandStatusSkipped
+    - PostCommandStatusRunning
   cloudmodel.RecommendedInfra:
     properties:
       description:
@@ -1680,13 +1773,15 @@ definitions:
         example: 2
         type: integer
     type: object
-  cloudmodel.SshCmdResult:
+  cloudmodel.SshCmdResultForAPI:
     properties:
       command:
         additionalProperties:
           type: string
         type: object
-      err: {}
+      error:
+        description: String representation of error for JSON serialization
+        type: string
       infraId:
         type: string
       nodeId:
@@ -1997,6 +2092,12 @@ definitions:
     type: object
   controller.MigrateInfraResponse:
     properties:
+      cluster:
+        description: Cluster is the list of implicit clusters synthesized at query-time
+          from Nodes.
+        items:
+          $ref: '#/definitions/cloudmodel.InfraClusterInfo'
+        type: array
       configureCloudAdaptiveNetwork:
         default: "no"
         description: ConfigureCloudAdaptiveNetwork is an option to configure Cloud
@@ -2047,15 +2148,34 @@ definitions:
         type: array
       placementAlgo:
         type: string
-      postCommand:
+      postCommandAsync:
+        description: PostCommandAsync echoes whether the commands run in the background
+        type: boolean
+      postCommandRequestId:
+        description: |-
+          PostCommandRequestId is the streaming/tracking key of the post-deployment run
+          (always set when post-deployment commands were requested, in both modes)
+        example: pc-infra01-1a2b3c
+        type: string
+      postCommandResults:
+        description: PostCommandResults holds per-phase outcomes
+        items:
+          $ref: '#/definitions/cloudmodel.PostCommandPhaseResult'
+        type: array
+      postCommandStatus:
         allOf:
-        - $ref: '#/definitions/cloudmodel.InfraCmdReq'
-        description: PostCommand is for the command to bootstrap the Nodes
-      postCommandResult:
-        allOf:
-        - $ref: '#/definitions/cloudmodel.InfraSshCmdResult'
-        description: PostCommandResult is the result of the command for bootstraping
-          the Nodes
+        - $ref: '#/definitions/cloudmodel.PostCommandStatus'
+        description: |-
+          PostCommandStatus summarizes the post-deployment command outcome.
+          "Running" means execution is still in progress (async mode): stream it with
+          GET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}
+          or poll this object until the status becomes terminal.
+        example: Completed
+      postCommands:
+        description: PostCommands are the requested post-deployment command phases
+        items:
+          $ref: '#/definitions/cloudmodel.PostCommandReq'
+        type: array
       resourceType:
         description: ResourceType is the type of the resource
         type: string
@@ -2193,6 +2313,12 @@ definitions:
     type: object
   controller.MigrateInfraWithDefaultsResponse:
     properties:
+      cluster:
+        description: Cluster is the list of implicit clusters synthesized at query-time
+          from Nodes.
+        items:
+          $ref: '#/definitions/cloudmodel.InfraClusterInfo'
+        type: array
       configureCloudAdaptiveNetwork:
         default: "no"
         description: ConfigureCloudAdaptiveNetwork is an option to configure Cloud
@@ -2243,15 +2369,34 @@ definitions:
         type: array
       placementAlgo:
         type: string
-      postCommand:
+      postCommandAsync:
+        description: PostCommandAsync echoes whether the commands run in the background
+        type: boolean
+      postCommandRequestId:
+        description: |-
+          PostCommandRequestId is the streaming/tracking key of the post-deployment run
+          (always set when post-deployment commands were requested, in both modes)
+        example: pc-infra01-1a2b3c
+        type: string
+      postCommandResults:
+        description: PostCommandResults holds per-phase outcomes
+        items:
+          $ref: '#/definitions/cloudmodel.PostCommandPhaseResult'
+        type: array
+      postCommandStatus:
         allOf:
-        - $ref: '#/definitions/cloudmodel.InfraCmdReq'
-        description: PostCommand is for the command to bootstrap the Nodes
-      postCommandResult:
-        allOf:
-        - $ref: '#/definitions/cloudmodel.InfraSshCmdResult'
-        description: PostCommandResult is the result of the command for bootstraping
-          the Nodes
+        - $ref: '#/definitions/cloudmodel.PostCommandStatus'
+        description: |-
+          PostCommandStatus summarizes the post-deployment command outcome.
+          "Running" means execution is still in progress (async mode): stream it with
+          GET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}
+          or poll this object until the status becomes terminal.
+        example: Completed
+      postCommands:
+        description: PostCommands are the requested post-deployment command phases
+        items:
+          $ref: '#/definitions/cloudmodel.PostCommandReq'
+        type: array
       resourceType:
         description: ResourceType is the type of the resource
         type: string

--- a/imdl/cloud-model/copied-tb-model.go
+++ b/imdl/cloud-model/copied-tb-model.go
@@ -6,6 +6,9 @@ import "time"
 // TODO: When the cb-tumblebug framework is updated, we should synchronize these structs.
 // * Version: CB-Tumblebug v0.12.30 (commit: c2c4e76b3cc7ba158a6f61918fe061470f039c6b)
 // * Synchronized: 2026-08-07 (VerifiedMessage, NodeInfoInNs, NLBInfoInNs for namespace-wide listing)
+// * Synchronized: 2026-08-12 (InfraInfo: replaced stale PostCommand/PostCommandResult with
+//   PostCommands/PostCommandAsync/PostCommandResults/PostCommandStatus/PostCommandRequestId,
+//   added Cluster field and the InfraClusterInfo type)
 
 // InfraReq is struct for requirements to create Infra
 type InfraReq struct {
@@ -444,17 +447,76 @@ type InfraInfo struct {
 	Description   string     `json:"description"`
 	Node          []NodeInfo `json:"node"`
 
+	// Cluster is the list of implicit clusters synthesized at query-time from Nodes.
+	Cluster []InfraClusterInfo `json:"cluster,omitempty"`
+
 	// List of IDs for new nodes. Return IDs if the nodes are newly added. This field should be used for return body only.
 	NewNodeList []string `json:"newNodeList"`
 
-	// PostCommand is for the command to bootstrap the Nodes
-	PostCommand InfraCmdReq `json:"postCommand"`
+	// PostCommands are the requested post-deployment command phases
+	PostCommands []PostCommandReq `json:"postCommands,omitempty"`
 
-	// PostCommandResult is the result of the command for bootstraping the Nodes
-	PostCommandResult InfraSshCmdResult `json:"postCommandResult"`
+	// PostCommandAsync echoes whether the commands run in the background
+	PostCommandAsync bool `json:"postCommandAsync,omitempty"`
+
+	// PostCommandResults holds per-phase outcomes
+	PostCommandResults []PostCommandPhaseResult `json:"postCommandResults,omitempty"`
+
+	// PostCommandStatus summarizes the post-deployment command outcome.
+	// "Running" means execution is still in progress (async mode): stream it with
+	// GET /ns/{nsId}/stream/cmd/infra/{infraId}?xRequestId={postCommandRequestId}
+	// or poll this object until the status becomes terminal.
+	PostCommandStatus PostCommandStatus `json:"postCommandStatus,omitempty" example:"Completed"`
+
+	// PostCommandRequestId is the streaming/tracking key of the post-deployment run
+	// (always set when post-deployment commands were requested, in both modes)
+	PostCommandRequestId string `json:"postCommandRequestId,omitempty" example:"pc-infra01-1a2b3c"`
 
 	// CreationErrors contains information about Node creation failures (if any)
 	CreationErrors *InfraCreationErrors `json:"creationErrors,omitempty"`
+}
+
+// InfraClusterInfo is a lightweight, on-demand cluster view synthesized from Infra NodeGroups and Nodes.
+// A cluster is implicitly formed by NodeGroups that share the same network boundary (currently VNet-centric grouping).
+type InfraClusterInfo struct {
+	// Id is a deterministic cluster identifier generated from grouping attributes.
+	Id string `json:"id"`
+
+	// Name is a human-readable cluster name. Currently same as Id.
+	Name string `json:"name"`
+
+	// InfraId is the parent Infra ID.
+	InfraId string `json:"infraId"`
+
+	// VNetId is the shared VNet boundary used for implicit clustering.
+	VNetId string `json:"vNetId,omitempty"`
+
+	// ConnectionNames are unique connection names included in this cluster.
+	ConnectionNames []string `json:"connectionNames"`
+
+	// ProviderNames are unique CSP providers included in this cluster.
+	ProviderNames []string `json:"providerNames"`
+
+	// RegionNames are unique regions included in this cluster.
+	RegionNames []string `json:"regionNames"`
+
+	// NodeGroupIds are NodeGroups that belong to this implicit cluster.
+	NodeGroupIds []string `json:"nodeGroupIds"`
+
+	// NodeIds are Nodes that belong to this implicit cluster.
+	NodeIds []string `json:"nodeIds"`
+
+	// NodeGroupCount is the number of NodeGroups in this cluster.
+	NodeGroupCount int `json:"nodeGroupCount"`
+
+	// NodeCount is the number of Nodes in this cluster.
+	NodeCount int `json:"nodeCount"`
+
+	// RepresentativeNodeGroupId is a representative NodeGroup ID for quick inspection.
+	RepresentativeNodeGroupId string `json:"representativeNodeGroupId,omitempty"`
+
+	// RepresentativeNodeId is a representative Node ID for quick inspection.
+	RepresentativeNodeId string `json:"representativeNodeId,omitempty"`
 }
 
 // InfraCreationErrors represents errors that occurred during Infra creation


### PR DESCRIPTION
- Fix type-sync crash in migration
- Add multi-phase postCommand fields
- Add Cluster/InfraClusterInfo field

BREAKING CHANGE:
* InfraInfo drops postCommand/postCommandResult JSON fields;
* use postCommands/postCommandResults instead.