### PR TITLE
feat(k8s): add K8s infra test CLIs and support concurrent multi-CSP migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,14 @@ cmd/test-cli/rate-limiting/testconf/test-config.yaml
 cmd/test-cli/multi-infra-recommendation/test-multi-infra-recommendation
 cmd/test-cli/multi-infra-recommendation/testconf/auth-config.json
 cmd/test-cli/multi-infra-recommendation/testconf/test-config.yaml
+cmd/test-cli/k8s-infra-recommendation/test-k8s-infra-recommendation
+cmd/test-cli/k8s-infra-recommendation/k8s-infra-recommendation
+cmd/test-cli/k8s-infra-recommendation/testconf/auth-config.json
+cmd/test-cli/k8s-infra-recommendation/testconf/test-config.yaml
+cmd/test-cli/k8s-infra-migration/test-k8s-infra-migration
+cmd/test-cli/k8s-infra-migration/k8s-infra-migration
+cmd/test-cli/k8s-infra-migration/testconf/auth-config.json
+cmd/test-cli/k8s-infra-migration/testconf/test-config.yaml
 pkg/testclient/scripts/sequentialFullTest/executionStatus*
 pkg/testclient/scripts/sequentialFullTest/ansibleAutoConf/*
 pkg/testclient/scripts/credentials*
@@ -102,6 +110,10 @@ deployments/docker-compose/data
 
 # Backup Files
 *_backup
+
+# Work-in-progress docs (personal notes, drafts, and material that must not be
+# published — e.g. patent drafts, whose disclosure in a public repo can destroy novelty)
+docs/_wip/
 
 # Specific Project Excludes
 transx/examples/object-storage/main

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ clean: ## Remove previous build
 	@cd cmd/test-cli/async && $(GO) clean
 	@cd cmd/test-cli/rate-limiting && $(GO) clean
 	@cd cmd/test-cli/multi-infra-recommendation && $(GO) clean
+	@cd cmd/test-cli/k8s-infra-recommendation && $(GO) clean
+	@cd cmd/test-cli/k8s-infra-migration && $(GO) clean
 	@echo "Cleaned!"
 
 test-infra: ## Run the infra migration test CLI for all CSP-Region pairs
@@ -162,6 +164,22 @@ test-multi-infra-recommendation: ## Run the multi-target infra recommendation te
 		echo "Created testconf/test-config.yaml from template. Edit it before running."; \
 	fi
 	@cd cmd/test-cli/multi-infra-recommendation && $(GO) run main.go -config testconf/test-config.yaml
+
+test-k8s-infra-recommendation: ## Run the K8s infra recommendation test CLI (scenario fixtures x CSP-Region pairs)
+	@echo "Running K8s infra recommendation test CLI..."
+	@if [ ! -f cmd/test-cli/k8s-infra-recommendation/testconf/test-config.yaml ]; then \
+		cp cmd/test-cli/k8s-infra-recommendation/testconf/template-test-config.yaml cmd/test-cli/k8s-infra-recommendation/testconf/test-config.yaml; \
+		echo "Created testconf/test-config.yaml from template. Edit it before running."; \
+	fi
+	@cd cmd/test-cli/k8s-infra-recommendation && $(GO) run main.go -config testconf/test-config.yaml
+
+test-k8s-infra-migration: ## Run the K8s infra migration test CLI (WARNING: provisions real clusters)
+	@echo "Running K8s infra migration test CLI..."
+	@if [ ! -f cmd/test-cli/k8s-infra-migration/testconf/test-config.yaml ]; then \
+		cp cmd/test-cli/k8s-infra-migration/testconf/template-test-config.yaml cmd/test-cli/k8s-infra-migration/testconf/test-config.yaml; \
+		echo "Created testconf/test-config.yaml from template. Edit it before running."; \
+	fi
+	@cd cmd/test-cli/k8s-infra-migration && $(GO) run . -config testconf/test-config.yaml
 
 test-data-clean: ## Clean up data migration test artifacts
 	@echo "Cleaning data migration test artifacts..."

--- a/cmd/test-cli/k8s-infra-migration/README.md
+++ b/cmd/test-cli/k8s-infra-migration/README.md
@@ -1,0 +1,179 @@
+# CM-Beetle K8s Infra Migration Test CLI
+
+End-to-end test tool for CM-Beetle's K8s migration APIs. It runs the full lifecycle against a
+real CSP: recommend → migrate → list → get (verified against the recommendation) → delete →
+residual resource check.
+
+> [!WARNING]
+> Every enabled target provisions a **real managed K8s cluster and incurs cost**. Enable one
+> CSP at a time until the flow is confirmed for it. Cleanup always runs once a cluster exists,
+> even when an earlier step fails.
+
+Recommendation-only checks live in `cmd/test-cli/k8s-infra-recommendation`, which is free to
+run and needs no CSP write permissions.
+
+## Test Flow
+
+| # | Step | API |
+| --- | --- | --- |
+| 1 | Recommend | `POST /beetle/recommendation/k8sCluster` |
+| 2 | Migrate | `POST /beetle/migration/ns/{nsId}/k8sCluster` |
+| 3 | List | `GET /beetle/migration/ns/{nsId}/k8sCluster` |
+| 4 | Get + **verify vs recommendation** | `GET /beetle/migration/ns/{nsId}/k8sCluster/{id}` |
+| 5 | **Workload verification** | CB-Tumblebug kubeconfig + token -> the cluster's own K8s API |
+| 6 | Delete | `DELETE /beetle/migration/ns/{nsId}/k8sCluster/{id}` |
+| 7 | Residual resource check | CB-Tumblebug (VNet / SecurityGroup / SshKey) |
+
+If a step fails, the remaining steps are skipped — except cleanup. **Step 6 always runs once a
+cluster ID exists**, so a mid-run failure never leaves a billable cluster behind.
+
+Beetle creates the cluster before its node groups, so a migration can fail *after* a running
+cluster exists — a node group failure is the common case. The failure response does not
+necessarily carry the cluster's ID. When step 2 fails, the CLI therefore looks the cluster up by
+the recommended name and adopts it for cleanup, rather than assuming nothing was created.
+
+### Step 5 proves the cluster is usable
+
+Steps 1-4 confirm the cluster was *created* as designed. Step 5 confirms it *works*: it fetches
+the kubeconfig from CB-Tumblebug, reaches the cluster's own API server, checks that the number
+of Ready nodes matches the recommendation, then runs an nginx Deployment and waits for its pod
+to reach `Running` before removing it.
+
+This is the K8s counterpart of the SSH connectivity check `cmd/test-cli/infra` runs against
+every migrated VM. A cluster that reports `Active` but cannot schedule a pod has not been
+migrated in any useful sense.
+
+Three things make this work without Docker or `kubectl`:
+
+- The **dedicated `/kubeconfig` sub-resource** is used, not the generic cluster GET — the latter
+  returns `AccessInfo.Kubeconfig` without the native flag and never becomes ready on some CSPs.
+  It is polled, because it lags the `Active` status while the control-plane endpoint provisions.
+- The **bearer token** comes from Tumblebug's `/token` endpoint, since CSP-native kubeconfigs
+  authenticate through an exec plugin rather than a static token.
+- The **cluster CA** from `certificate-authority-data` is trusted explicitly, because the API
+  server's certificate is signed by the cluster's own CA.
+
+Headlamp (used by cb-tumblebug's own `k8s-test`) is deliberately not used: it only forwards the
+bearer token to the API server unchanged, so it adds a Docker dependency without adding reach.
+
+With `workload.loadBalancerEnabled` (default on), the step goes further: it publishes the
+Deployment through a `LoadBalancer` Service, waits for the CSP to assign an ingress address, and
+fetches the page from outside the cluster. Scheduling a pod proves the cluster runs work; this
+proves the work is *reachable*, which is a distinct failure mode — a cluster can come up healthy
+and still fail to provision a working load balancer.
+
+Two details make this reliable across CSPs:
+
+- AWS publishes a **hostname**, other CSPs an **IP**; both `status.loadBalancer.ingress[].ip` and
+  `.hostname` are accepted.
+- An address appears **before** the load balancer forwards traffic — health checks must pass, and
+  a hostname has to resolve — so the HTTP fetch is retried rather than attempted once.
+
+Cleanup deletes the Service **before** the Deployment, because the Service is what holds the real,
+billable cloud load balancer. A cleanup failure there is reported as an error rather than a note,
+since a leaked load balancer keeps costing money after the run.
+
+Expect roughly 2-6 extra minutes per target. Set `workload.loadBalancerEnabled: false` to stop at
+pod `Running`, or `workload.enabled: false` to skip the whole step.
+
+### Step 4 is the point of this CLI
+
+Steps 1–3 confirm the API responded. Step 4 confirms the cluster **matches what was
+recommended**: node group count, and per node group (matched by name, since CSPs may reorder)
+the `specId` and `desiredNodeSize`. A migration that succeeds while silently dropping a node
+group or substituting a spec would otherwise go unnoticed.
+
+## Waiting: the CLI does not track per-CSP provisioning times
+
+Cluster creation takes roughly 3–25 minutes depending on the CSP. **The CLI does not need to
+know that.** Beetle already polls until the cluster reaches `Active` — 15 s × 160 = 40 min in
+`pkg/core/migration/k8s-infra.go` — and a per-CSP timeout was deliberately rejected there as
+false precision, since provisioning time also grows with cluster size.
+
+So the only problem left for the CLI is *how to wait for a call that can take tens of minutes*:
+
+- **`migration.mode: async`** (default) — sends `Prefer: respond-async`, gets `202` with a
+  `reqId`, then polls `GET /request/{reqId}`. The HTTP connection stays short, progress is
+  printed each poll, and the timeout is the CLI's to control. A `503` (Beetle's async job pool
+  of 20 is full) is retried, not failed.
+- **`migration.mode: sync`** — holds the connection until the cluster is `Active`. Useful for
+  exercising the blocking path; `migration.timeoutSec` must exceed Beetle's own 40 min budget.
+
+Deletion has **no async mode**, so it is a long synchronous call with its own timeout and a
+retry loop (see below).
+
+## Quick Start
+
+```bash
+# From the repository root
+make test-k8s-infra-migration
+```
+
+This copies `testconf/template-test-config.yaml` to `testconf/test-config.yaml` on first run.
+Edit it to enable exactly the CSP you intend to provision.
+
+Credentials go in `testconf/auth-config.json` (copy from `testconf/template-auth-config.json`).
+Tumblebug credentials are needed only for step 6.
+
+## Configuration
+
+`testconf/test-config.yaml`:
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `test.set.mode` | `parallel` | `parallel` (one goroutine per target) or `sequential` |
+| `test.set.startDelaySeconds` | `10` | Stagger between parallel starts, to avoid bursting Tumblebug's read APIs |
+| `migration.mode` | `async` | `async` or `sync` — see above |
+| `migration.timeoutSec` | `3600` | HTTP timeout for the sync path |
+| `poll.intervalSec` | `30` | Async status poll interval |
+| `poll.timeoutSec` | `3600` | Async overall budget — must exceed Beetle's 40 min |
+| `delete.timeoutSec` | `1800` | Beetle polls node group teardown for up to 20 min |
+| `delete.retryIntervalSec` | `60` | Backoff between deletion attempts |
+| `delete.maxRetries` | `10` | Deletion attempts before giving up |
+| `verify.residualResources` | `true` | Run step 7 |
+| `workload.enabled` | `true` | Run step 5 |
+| `workload.kubeconfigTimeoutSec` | `600` | Kubeconfig readiness budget |
+| `workload.podReadyTimeoutSec` | `180` | nginx pod `Running` budget |
+| `workload.loadBalancerEnabled` | `true` | Publish via LoadBalancer and fetch from outside |
+| `workload.lbAddressTimeoutSec` | `900` | Budget for the CSP to assign an ingress address |
+| `workload.lbAccessTimeoutSec` | `300` | Budget for the endpoint to start serving |
+
+## Known CSP behaviours — recorded, not failed
+
+These are Beetle/CSP behaviours the CLI reports without failing the run. Fixing them is tracked
+in `docs/k8s-migration/k8s-migration-improvement-analysis.md`, not here.
+
+| Behaviour | Handling |
+| --- | --- |
+| Deletion rejected for minutes after `Active` (observed on NCP: `409 UPDATING`) | Retried on a fixed backoff, up to `delete.maxRetries` |
+| Deleting an already-absent cluster returns 500 instead of a no-op success | Treated as cleanup success, noted in the report |
+| VNet / SecurityGroup / SshKey survive cluster deletion (all CSPs) | Step 6 records what remains; informational only |
+
+The primary target is **AWS**; a run that passes on AWS is treated as green.
+
+## Results
+
+- Console: per-step pass/fail with check outcomes and live polling progress
+- Files, under `testresult/`:
+  - `k8s-infra-migration-test-results-{csp}.md` — full lifecycle per CSP, with the
+    recommendation and the created cluster attached
+  - `k8s-infra-migration-test-summary-all.md` — one-row-per-target overview
+
+CSP account identifiers (Azure subscription IDs, GCP project IDs, email addresses) are masked.
+
+Exit code is non-zero if any step fails.
+
+## Prerequisites
+
+1. CM-Beetle running at the configured endpoint
+2. CB-Tumblebug and CB-Spider reachable, with credentials registered for the target CSP
+3. **CSP write permissions** — clusters, VPCs, security groups and SSH keys are created
+4. `testconf/auth-config.json` filled in
+
+## Known limitation: repeated runs
+
+Resource names are derived from the source cluster and are not uniquified per run, and creation
+is not idempotent. Sequential runs are fine because each run deletes its cluster, but two
+concurrent runs against the same CSP/region will collide, and leftover prerequisites from an
+earlier run (see step 6) can cause a later run to fail. This is Beetle behaviour tracked as
+improvements #3 and #9 in `docs/k8s-migration/k8s-migration-improvement-analysis.md`.

--- a/cmd/test-cli/k8s-infra-migration/main.go
+++ b/cmd/test-cli/k8s-infra-migration/main.go
@@ -105,8 +105,16 @@ type AuthConfig struct {
 	TumblebugEndpoint    string `json:"tumblebugEndpoint"`
 }
 
+// progressf prints an in-flight progress line. Targets run concurrently and their output
+// interleaves, so every line carries the target name — without it a stalled CSP cannot be told
+// apart from a healthy one.
+func progressf(target, format string, a ...interface{}) {
+	fmt.Printf("      [%s] %s\n", target, fmt.Sprintf(format, a...))
+}
+
 // StepResult holds one lifecycle step's outcome.
 type StepResult struct {
+	Target     string
 	Number     int
 	Name       string
 	StartTime  time.Time
@@ -273,39 +281,43 @@ func runLifecycle(cfg TestConfig, auth AuthConfig, target TestCase, requestBody 
 
 	printBanner(target)
 
-	steps := []func(*resty.Client, TestConfig, AuthConfig, *CSPTestReport, []byte) StepResult{
-		stepRecommend,
-		stepMigrate,
-		stepList,
-		stepGetAndVerify,
+	// The name is declared here rather than read back from the result, so it can be announced
+	// before the step runs — a step that takes minutes needs its heading up front.
+	steps := []struct {
+		number int
+		name   string
+		run    func(*resty.Client, TestConfig, AuthConfig, *CSPTestReport, []byte) StepResult
+	}{
+		{1, "POST /recommendation/k8sCluster", stepRecommend},
+		{2, "POST /migration/ns/{nsId}/k8sCluster", stepMigrate},
+		{3, "GET /migration/ns/{nsId}/k8sCluster", stepList},
+		{4, "GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation", stepGetAndVerify},
 	}
 
-	for _, step := range steps {
-		res := step(client, cfg, auth, report, requestBody)
+	runStep := func(number int, name string, fn func(*resty.Client, TestConfig, AuthConfig, *CSPTestReport, []byte) StepResult) StepResult {
+		printStepStart(report.DisplayName, number, name)
+		res := fn(client, cfg, auth, report, requestBody)
 		report.Steps = append(report.Steps, res)
 		printStep(report.DisplayName, res)
-		if !res.Success {
+		return res
+	}
+
+	for _, st := range steps {
+		if res := runStep(st.number, st.name, st.run); !res.Success {
 			break
 		}
 	}
 
 	// Workload verification runs only on a healthy cluster, and always before cleanup.
 	if report.ClusterID != "" && cfg.Workload.Enabled && lastStepPassed(report) {
-		res := stepWorkload(client, cfg, auth, report, requestBody)
-		report.Steps = append(report.Steps, res)
-		printStep(report.DisplayName, res)
+		runStep(5, "Workload verification (kubeconfig -> K8s API -> nginx)", stepWorkload)
 	}
 
 	// Cleanup always runs when there is something to clean up.
 	if report.ClusterID != "" {
-		res := stepDelete(client, cfg, auth, report, requestBody)
-		report.Steps = append(report.Steps, res)
-		printStep(report.DisplayName, res)
-
+		res := runStep(6, "DELETE /migration/ns/{nsId}/k8sCluster/{id}", stepDelete)
 		if res.Success && cfg.Verify.ResidualResources {
-			res := stepResidualCheck(client, cfg, auth, report, requestBody)
-			report.Steps = append(report.Steps, res)
-			printStep(report.DisplayName, res)
+			runStep(7, "Residual resource check (Tumblebug)", stepResidualCheck)
 		}
 	}
 
@@ -315,7 +327,7 @@ func runLifecycle(cfg TestConfig, auth AuthConfig, target TestCase, requestBody 
 // --- Steps -----------------------------------------------------------------
 
 func stepRecommend(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, requestBody []byte) StepResult {
-	res := StepResult{Number: 1, Name: "POST /recommendation/k8sCluster", StartTime: time.Now()}
+	res := StepResult{Target: report.DisplayName, Number: 1, Name: "POST /recommendation/k8sCluster", StartTime: time.Now()}
 
 	url := cfg.Beetle.Endpoint + "/beetle/recommendation/k8sCluster"
 	resp, err := client.R().
@@ -362,7 +374,7 @@ func stepRecommend(client *resty.Client, cfg TestConfig, _ AuthConfig, report *C
 // minutes by its own polling budget — so the async path keeps the HTTP connection short and
 // prints progress while waiting.
 func stepMigrate(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, _ []byte) StepResult {
-	res := StepResult{Number: 2, Name: "POST /migration/ns/{nsId}/k8sCluster", StartTime: time.Now()}
+	res := StepResult{Target: report.DisplayName, Number: 2, Name: "POST /migration/ns/{nsId}/k8sCluster", StartTime: time.Now()}
 
 	body, err := json.Marshal(report.Recommendation)
 	if err != nil {
@@ -418,7 +430,7 @@ func migrateSync(client *resty.Client, cfg TestConfig, url string, body []byte, 
 	syncClient := *client
 	sc := (&syncClient).SetTimeout(time.Duration(cfg.Migration.TimeoutSec) * time.Second)
 
-	fmt.Printf("      ... sync mode: holding the connection for up to %ds\n", cfg.Migration.TimeoutSec)
+	progressf(res.Target, "... sync mode: holding the connection for up to %ds", cfg.Migration.TimeoutSec)
 	resp, err := sc.R().SetHeader("Content-Type", "application/json").SetBody(body).Post(url)
 	if err != nil {
 		return nil, 0, err
@@ -453,7 +465,7 @@ func migrateAsync(client *resty.Client, cfg TestConfig, url string, body []byte,
 			break
 		}
 		wait := 30 * time.Second
-		fmt.Printf("      ... async job pool full (503), retrying in %v (%d/%d)\n", wait, attempt, maxAdmissionRetries)
+		progressf(res.Target, "... async job pool full (503), retrying in %v (%d/%d)", wait, attempt, maxAdmissionRetries)
 		time.Sleep(wait)
 	}
 
@@ -466,9 +478,9 @@ func migrateAsync(client *resty.Client, cfg TestConfig, url string, body []byte,
 		return nil, resp.StatusCode(), err
 	}
 	res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  async reqId: %s", reqID))
-	fmt.Printf("      -> 202 Accepted, reqId=%s\n", reqID)
+	progressf(res.Target, "-> 202 Accepted, reqId=%s", reqID)
 
-	details, err := pollUntilDone(client, cfg.Beetle.Endpoint, reqID, cfg.Poll.IntervalSec, cfg.Poll.TimeoutSec)
+	details, err := pollUntilDone(client, res.Target, cfg.Beetle.Endpoint, reqID, cfg.Poll.IntervalSec, cfg.Poll.TimeoutSec)
 	if err != nil {
 		return nil, resp.StatusCode(), err
 	}
@@ -573,7 +585,7 @@ func adoptOrphanCluster(client *resty.Client, cfg TestConfig, report *CSPTestRep
 }
 
 func stepList(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, _ []byte) StepResult {
-	res := StepResult{Number: 3, Name: "GET /migration/ns/{nsId}/k8sCluster", StartTime: time.Now()}
+	res := StepResult{Target: report.DisplayName, Number: 3, Name: "GET /migration/ns/{nsId}/k8sCluster", StartTime: time.Now()}
 
 	// option=id keeps this cheap: the full listing refreshes every cluster through the CSP and
 	// exceeds Tumblebug's 120 s request timeout once several clusters exist. Presence of the ID
@@ -618,7 +630,7 @@ func stepList(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTes
 // against what the recommendation asked for. A migration that succeeds but silently drops a
 // node group or substitutes a spec would otherwise go unnoticed.
 func stepGetAndVerify(client *resty.Client, cfg TestConfig, auth AuthConfig, report *CSPTestReport, _ []byte) StepResult {
-	res := StepResult{Number: 4, Name: "GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation", StartTime: time.Now()}
+	res := StepResult{Target: report.DisplayName, Number: 4, Name: "GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation", StartTime: time.Now()}
 
 	url := fmt.Sprintf("%s/beetle/migration/ns/%s/k8sCluster/%s", cfg.Beetle.Endpoint, cfg.Beetle.NamespaceID, report.ClusterID)
 	resp, err := client.R().Get(url)
@@ -722,7 +734,7 @@ func stepGetAndVerify(client *resty.Client, cfg TestConfig, auth AuthConfig, rep
 // (observed on NCP) reject deletion for several minutes after reporting Active, so failures
 // are retried with a fixed backoff rather than matched against specific error strings.
 func stepDelete(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, _ []byte) StepResult {
-	res := StepResult{Number: 6, Name: "DELETE /migration/ns/{nsId}/k8sCluster/{id}", StartTime: time.Now()}
+	res := StepResult{Target: report.DisplayName, Number: 6, Name: "DELETE /migration/ns/{nsId}/k8sCluster/{id}", StartTime: time.Now()}
 
 	deleteClient := *client
 	dc := (&deleteClient).SetTimeout(time.Duration(cfg.Delete.TimeoutSec) * time.Second)
@@ -756,7 +768,7 @@ func stepDelete(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPT
 
 		if attempt < cfg.Delete.MaxRetries {
 			wait := time.Duration(cfg.Delete.RetryIntervalSec) * time.Second
-			fmt.Printf("      ... deletion not accepted yet, retrying in %v (%d/%d)\n", wait, attempt, cfg.Delete.MaxRetries)
+			progressf(res.Target, "... deletion not accepted yet, retrying in %v (%d/%d)", wait, attempt, cfg.Delete.MaxRetries)
 			time.Sleep(wait)
 		}
 	}
@@ -771,7 +783,7 @@ func stepDelete(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPT
 // Leftover VNet/SecurityGroup/SshKey is current known behaviour, so this is recorded rather
 // than failed: cleanup scope is tracked as a separate Beetle improvement.
 func stepResidualCheck(_ *resty.Client, cfg TestConfig, auth AuthConfig, report *CSPTestReport, _ []byte) StepResult {
-	res := StepResult{Number: 7, Name: "Residual resource check (Tumblebug)", StartTime: time.Now()}
+	res := StepResult{Target: report.DisplayName, Number: 7, Name: "Residual resource check (Tumblebug)", StartTime: time.Now()}
 
 	if auth.TumblebugEndpoint == "" {
 		res.Duration = time.Since(res.StartTime)
@@ -855,7 +867,7 @@ func extractReqID(resp *resty.Response) (string, error) {
 }
 
 // pollUntilDone polls GET /request/{reqId} until the job finishes or the timeout elapses.
-func pollUntilDone(client *resty.Client, endpoint, reqID string, intervalSec, timeoutSec int) (RequestDetails, error) {
+func pollUntilDone(client *resty.Client, target, endpoint, reqID string, intervalSec, timeoutSec int) (RequestDetails, error) {
 	statusURL := fmt.Sprintf("%s/beetle/request/%s", endpoint, reqID)
 	start := time.Now()
 	deadline := start.Add(time.Duration(timeoutSec) * time.Second)
@@ -869,21 +881,21 @@ func pollUntilDone(client *resty.Client, endpoint, reqID string, intervalSec, ti
 
 		resp, err := client.R().Get(statusURL)
 		if err != nil {
-			fmt.Printf("      ... [%s elapsed, poll #%d] request error: %v\n", elapsed, attempt, err)
+			progressf(target, "... [%s elapsed, poll #%d] request error: %v", elapsed, attempt, err)
 			continue
 		}
 		var apiResp ApiResponseRaw
 		if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
-			fmt.Printf("      ... [%s elapsed, poll #%d] parse error: %v\n", elapsed, attempt, err)
+			progressf(target, "... [%s elapsed, poll #%d] parse error: %v", elapsed, attempt, err)
 			continue
 		}
 		var details RequestDetails
 		if err := json.Unmarshal(apiResp.Data, &details); err != nil {
-			fmt.Printf("      ... [%s elapsed, poll #%d] parse error: %v\n", elapsed, attempt, err)
+			progressf(target, "... [%s elapsed, poll #%d] parse error: %v", elapsed, attempt, err)
 			continue
 		}
 
-		fmt.Printf("      ... [%s elapsed, poll #%d] status: %s\n", elapsed, attempt, details.Status)
+		progressf(target, "... [%s elapsed, poll #%d] status: %s", elapsed, attempt, details.Status)
 		if details.Status == "Success" || details.Status == "Error" {
 			return details, nil
 		}
@@ -955,8 +967,15 @@ func printBanner(t TestCase) {
 	fmt.Printf("=========================================================\n")
 }
 
-// printStep labels every line with the target, because targets run concurrently and their
-// output interleaves; without the label a failure cannot be attributed to a CSP.
+// printStepStart announces a step before it runs, so long-running work (cluster creation,
+// load balancer provisioning) has a heading above its progress lines instead of appearing
+// under the previous step's result.
+func printStepStart(target string, number int, name string) {
+	fmt.Printf("▶  [%s] Step %d: %s ...\n", target, number, name)
+}
+
+// printStep reports a finished step. The duration belongs here rather than on the start line,
+// because it is only known once the step ends.
 func printStep(target string, res StepResult) {
 	icon := "✅"
 	switch {
@@ -965,7 +984,8 @@ func printStep(target string, res StepResult) {
 	case !res.Success:
 		icon = "❌"
 	}
-	fmt.Printf("%s [%s] Step %d: %s (%v)\n", icon, target, res.Number, res.Name, res.Duration.Truncate(time.Millisecond))
+	fmt.Printf("%s [%s] Step %d: %s — done in %v\n", icon, target, res.Number, res.Name,
+		res.Duration.Truncate(time.Millisecond))
 	for _, n := range res.Notes {
 		fmt.Printf("      [%s] %s\n", target, n)
 	}

--- a/cmd/test-cli/k8s-infra-migration/main.go
+++ b/cmd/test-cli/k8s-infra-migration/main.go
@@ -1,0 +1,1242 @@
+// Package main is the starting point of CM-Beetle K8s Infra Migration Test CLI.
+//
+// Runs the full K8s migration lifecycle against real CSPs: recommend -> migrate -> list ->
+// get (verified against the recommendation) -> delete -> residual resource check.
+//
+// The CLI does not track per-CSP provisioning times. Beetle already polls until the cluster
+// reaches Active (see pkg/core/migration/k8s-infra.go), so the only thing the CLI must solve
+// is how to wait for a call that can take tens of minutes. It does that with the async job
+// pattern (Prefer: respond-async -> poll GET /request/{reqId}), the same flow exercised by
+// cmd/test-cli/async. Set migration.mode to "sync" to exercise the blocking path instead.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+
+	tbmodel "github.com/cloud-barista/cb-tumblebug/src/core/model"
+	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
+	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
+	tbclient "github.com/cloud-barista/cm-beetle/pkg/client/tumblebug"
+	"github.com/cloud-barista/cm-beetle/pkg/config"
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
+	"github.com/cloud-barista/cm-beetle/pkg/logger"
+)
+
+// restyNoopLogger silences all Resty log output (e.g. "Basic Auth in HTTP mode" warnings).
+type restyNoopLogger struct{}
+
+func (restyNoopLogger) Errorf(_ string, _ ...interface{}) {}
+func (restyNoopLogger) Warnf(_ string, _ ...interface{})  {}
+func (restyNoopLogger) Debugf(_ string, _ ...interface{}) {}
+
+// TestConfig holds test configuration.
+type TestConfig struct {
+	Test struct {
+		Set struct {
+			Mode              string `yaml:"mode"`              // parallel or sequential
+			StartDelaySeconds int    `yaml:"startDelaySeconds"` // stagger between parallel starts
+		} `yaml:"set"`
+		Cases []TestCase `yaml:"cases"`
+	} `yaml:"test"`
+	Beetle struct {
+		Endpoint        string `yaml:"endpoint"`
+		NamespaceID     string `yaml:"namespaceId"`
+		RequestBodyFile string `yaml:"requestBodyFile"`
+		AuthConfigFile  string `yaml:"authConfigFile"`
+		NameSeed        string `yaml:"nameSeed"`
+	} `yaml:"beetle"`
+	Migration struct {
+		Mode       string `yaml:"mode"`       // async (default) or sync
+		TimeoutSec int    `yaml:"timeoutSec"` // HTTP timeout for the sync path
+	} `yaml:"migration"`
+	Poll struct {
+		IntervalSec int `yaml:"intervalSec"`
+		TimeoutSec  int `yaml:"timeoutSec"`
+	} `yaml:"poll"`
+	Delete struct {
+		TimeoutSec       int `yaml:"timeoutSec"`
+		RetryIntervalSec int `yaml:"retryIntervalSec"`
+		MaxRetries       int `yaml:"maxRetries"`
+	} `yaml:"delete"`
+	Verify struct {
+		ResidualResources bool `yaml:"residualResources"`
+	} `yaml:"verify"`
+	Workload struct {
+		Enabled              bool `yaml:"enabled"`
+		KubeconfigTimeoutSec int  `yaml:"kubeconfigTimeoutSec"`
+		KubeconfigPollSec    int  `yaml:"kubeconfigPollSec"`
+		PodReadyTimeoutSec   int  `yaml:"podReadyTimeoutSec"`
+		PodPollSec           int  `yaml:"podPollSec"`
+		LoadBalancerEnabled  bool `yaml:"loadBalancerEnabled"`
+		LbAddressTimeoutSec  int  `yaml:"lbAddressTimeoutSec"`
+		LbAccessTimeoutSec   int  `yaml:"lbAccessTimeoutSec"`
+		LbPollSec            int  `yaml:"lbPollSec"`
+	} `yaml:"workload"`
+}
+
+// TestCase is one target CSP/region pair; only entries with Execute: true are used.
+type TestCase struct {
+	cloudmodel.CloudProperty `yaml:",inline"`
+	Name                     string `yaml:"name"`
+	Execute                  bool   `yaml:"execute"`
+}
+
+// AuthConfig holds Beetle and Tumblebug credentials. Tumblebug is called directly only for
+// the residual resource check, since Beetle exposes no API for it.
+type AuthConfig struct {
+	BeetleApiUsername    string `json:"beetleApiUsername"`
+	BeetleApiPassword    string `json:"beetleApiPassword"`
+	TumblebugApiUsername string `json:"tumblebugApiUsername"`
+	TumblebugApiPassword string `json:"tumblebugApiPassword"`
+	TumblebugEndpoint    string `json:"tumblebugEndpoint"`
+}
+
+// StepResult holds one lifecycle step's outcome.
+type StepResult struct {
+	Number     int
+	Name       string
+	StartTime  time.Time
+	Duration   time.Duration
+	Success    bool
+	Skipped    bool
+	StatusCode int
+	Notes      []string // check outcomes, prefixed with ✅ / ❌ / ℹ️
+	Error      string
+}
+
+// CSPTestReport captures the whole lifecycle for one CSP/region pair.
+type CSPTestReport struct {
+	CSP          string
+	Region       string
+	DisplayName  string
+	TestDateTime time.Time
+
+	BeetleURL     string
+	NamespaceID   string
+	BeetleVersion string
+	GitHash       string
+
+	NameSeed       string
+	Recommendation *cloudmodel.RecommendedInfra
+	ClusterID      string
+	ClusterInfo    *tbmodel.K8sClusterInfo
+
+	Steps []StepResult
+}
+
+// ApiResponseRaw mirrors model.ApiResponse[T] for payloads parsed in two stages.
+type ApiResponseRaw struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data"`
+	Message string          `json:"message,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+// AsyncJobData mirrors model.AsyncJobResponse.
+type AsyncJobData struct {
+	ReqID     string `json:"reqId"`
+	Status    string `json:"status"`
+	StatusURL string `json:"statusUrl"`
+}
+
+// RequestDetails mirrors the fields of common.RequestDetails this CLI reads.
+type RequestDetails struct {
+	Status        string          `json:"status"`
+	ResponseData  json.RawMessage `json:"responseData"`
+	ErrorResponse string          `json:"errorResponse"`
+}
+
+var configFile = flag.String("config", "testconf/test-config.yaml", "Path to config file")
+
+func init() {
+	config.Init()
+	l := logger.NewLogger(logger.Config{
+		LogLevel:    config.Beetle.LogLevel,
+		LogWriter:   config.Beetle.LogWriter,
+		LogFilePath: config.Beetle.LogFile.Path,
+		MaxSize:     config.Beetle.LogFile.MaxSize,
+		MaxBackups:  config.Beetle.LogFile.MaxBackups,
+		MaxAge:      config.Beetle.LogFile.MaxAge,
+		Compress:    config.Beetle.LogFile.Compress,
+	})
+	log.Logger = *l
+}
+
+func main() {
+	flag.Parse()
+
+	cfg, err := loadConfig(*configFile)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to load config")
+	}
+	applyDefaults(&cfg)
+
+	targets := selectedTargets(cfg)
+	if len(targets) == 0 {
+		log.Fatal().Msg("At least 1 test case must have execute: true")
+	}
+
+	requestBody, err := os.ReadFile(cfg.Beetle.RequestBodyFile)
+	if err != nil {
+		log.Fatal().Err(err).Str("file", cfg.Beetle.RequestBodyFile).Msg("Failed to read request body file")
+	}
+
+	auth, err := loadAuthConfig(cfg.Beetle.AuthConfigFile)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to load auth config; proceeding without auth")
+	}
+
+	client := newClient(cfg, auth)
+	if err := checkBeetleReadiness(client, cfg.Beetle.Endpoint); err != nil {
+		log.Fatal().Err(err).Msg("CM-Beetle readiness check failed")
+	}
+
+	fmt.Println("=========================================================")
+	fmt.Println(" CM-Beetle K8s Infra Migration Test CLI")
+	fmt.Printf(" %d target(s), mode: %s, migration: %s\n", len(targets), cfg.Test.Set.Mode, cfg.Migration.Mode)
+	fmt.Println(" Recommend -> Migrate -> List -> Get -> Delete -> Residual check")
+	fmt.Println("=========================================================")
+
+	reports := runAllTargets(cfg, auth, targets, requestBody)
+
+	for _, r := range reports {
+		if err := generateCSPReport(r); err != nil {
+			log.Warn().Err(err).Str("csp", r.CSP).Msg("Failed to generate CSP report")
+		}
+	}
+	if err := generateSummaryReport(reports); err != nil {
+		log.Warn().Err(err).Msg("Failed to generate summary report")
+	}
+
+	if !printFinalSummary(reports) {
+		os.Exit(1)
+	}
+}
+
+func runAllTargets(cfg TestConfig, auth AuthConfig, targets []TestCase, requestBody []byte) []*CSPTestReport {
+	reports := make([]*CSPTestReport, len(targets))
+
+	if cfg.Test.Set.Mode == "sequential" {
+		for i, t := range targets {
+			reports[i] = runLifecycle(cfg, auth, t, requestBody, caseNameSeed(cfg, i))
+		}
+		return reports
+	}
+
+	// Each goroutine writes only its own slot, so results stay in target order without a mutex.
+	var wg sync.WaitGroup
+	for i, t := range targets {
+		wg.Add(1)
+		go func(idx int, target TestCase) {
+			defer wg.Done()
+			// Stagger starts so concurrent runs do not burst Tumblebug's read APIs at once.
+			if d := cfg.Test.Set.StartDelaySeconds; d > 0 && idx > 0 {
+				time.Sleep(time.Duration(idx*d) * time.Second)
+			}
+			reports[idx] = runLifecycle(cfg, auth, target, requestBody, caseNameSeed(cfg, idx))
+		}(i, t)
+	}
+	wg.Wait()
+	return reports
+}
+
+// runLifecycle executes the ordered steps for one target. A failed step skips the remaining
+// ones, except cleanup: deletion always runs once a cluster ID exists, so a failure mid-run
+// never leaves a billable cluster behind.
+func runLifecycle(cfg TestConfig, auth AuthConfig, target TestCase, requestBody []byte, nameSeed string) *CSPTestReport {
+	report := &CSPTestReport{
+		CSP:           target.Csp,
+		Region:        target.Region,
+		DisplayName:   target.Name,
+		TestDateTime:  time.Now(),
+		BeetleURL:     cfg.Beetle.Endpoint,
+		NamespaceID:   cfg.Beetle.NamespaceID,
+		BeetleVersion: getBeetleVersion(),
+		GitHash:       getGitHash(),
+		NameSeed:      nameSeed,
+	}
+	client := newClient(cfg, auth)
+
+	printBanner(target)
+
+	steps := []func(*resty.Client, TestConfig, AuthConfig, *CSPTestReport, []byte) StepResult{
+		stepRecommend,
+		stepMigrate,
+		stepList,
+		stepGetAndVerify,
+	}
+
+	for _, step := range steps {
+		res := step(client, cfg, auth, report, requestBody)
+		report.Steps = append(report.Steps, res)
+		printStep(report.DisplayName, res)
+		if !res.Success {
+			break
+		}
+	}
+
+	// Workload verification runs only on a healthy cluster, and always before cleanup.
+	if report.ClusterID != "" && cfg.Workload.Enabled && lastStepPassed(report) {
+		res := stepWorkload(client, cfg, auth, report, requestBody)
+		report.Steps = append(report.Steps, res)
+		printStep(report.DisplayName, res)
+	}
+
+	// Cleanup always runs when there is something to clean up.
+	if report.ClusterID != "" {
+		res := stepDelete(client, cfg, auth, report, requestBody)
+		report.Steps = append(report.Steps, res)
+		printStep(report.DisplayName, res)
+
+		if res.Success && cfg.Verify.ResidualResources {
+			res := stepResidualCheck(client, cfg, auth, report, requestBody)
+			report.Steps = append(report.Steps, res)
+			printStep(report.DisplayName, res)
+		}
+	}
+
+	return report
+}
+
+// --- Steps -----------------------------------------------------------------
+
+func stepRecommend(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, requestBody []byte) StepResult {
+	res := StepResult{Number: 1, Name: "POST /recommendation/k8sCluster", StartTime: time.Now()}
+
+	url := cfg.Beetle.Endpoint + "/beetle/recommendation/k8sCluster"
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetQueryParam("desiredProvider", report.CSP).
+		SetQueryParam("desiredRegion", report.Region).
+		SetBody(requestBody).
+		Post(url)
+	res.Duration = time.Since(res.StartTime)
+
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	res.StatusCode = resp.StatusCode()
+	if resp.StatusCode() != http.StatusOK {
+		res.Error = fmt.Sprintf("expected 200, got %d: %s", resp.StatusCode(), truncate(string(resp.Body()), 300))
+		return res
+	}
+
+	var apiResp model.ApiResponse[cloudmodel.RecommendedInfra]
+	if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+		res.Error = fmt.Sprintf("failed to parse recommendation: %s", err)
+		return res
+	}
+	if !apiResp.Success {
+		res.Error = apiResp.Error
+		return res
+	}
+
+	report.Recommendation = &apiResp.Data
+	cluster := apiResp.Data.TargetK8sCluster
+	res.Notes = append(res.Notes,
+		fmt.Sprintf("ℹ️  cluster: %s (version %s)", cluster.Name, cluster.Version),
+		fmt.Sprintf("ℹ️  node groups: %d", len(cluster.K8sNodeGroupList)))
+	for i, ng := range cluster.K8sNodeGroupList {
+		res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  node group[%d] %q spec=%s nodes=%d", i, ng.Name, ng.SpecId, ng.DesiredNodeSize))
+	}
+	res.Success = true
+	return res
+}
+
+// stepMigrate provisions the cluster. Beetle blocks until the cluster is Active — up to 40
+// minutes by its own polling budget — so the async path keeps the HTTP connection short and
+// prints progress while waiting.
+func stepMigrate(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, _ []byte) StepResult {
+	res := StepResult{Number: 2, Name: "POST /migration/ns/{nsId}/k8sCluster", StartTime: time.Now()}
+
+	body, err := json.Marshal(report.Recommendation)
+	if err != nil {
+		res.Duration = time.Since(res.StartTime)
+		res.Error = fmt.Sprintf("failed to marshal recommendation: %s", err)
+		return res
+	}
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/k8sCluster", cfg.Beetle.Endpoint, cfg.Beetle.NamespaceID)
+	if report.NameSeed != "" {
+		url += "?nameSeed=" + report.NameSeed
+		res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  nameSeed: %s", report.NameSeed))
+	}
+
+	var clusterJSON []byte
+	if cfg.Migration.Mode == "sync" {
+		clusterJSON, res.StatusCode, err = migrateSync(client, cfg, url, body, &res)
+	} else {
+		clusterJSON, res.StatusCode, err = migrateAsync(client, cfg, url, body, &res)
+	}
+	res.Duration = time.Since(res.StartTime)
+	if err != nil {
+		res.Error = err.Error()
+		// Migration can fail after the cluster itself was created (e.g. a node group fails).
+		// Recover the ID by name so cleanup still runs and no billable cluster is orphaned.
+		adoptOrphanCluster(client, cfg, report, &res)
+		return res
+	}
+
+	var info tbmodel.K8sClusterInfo
+	if err := json.Unmarshal(clusterJSON, &info); err != nil {
+		res.Error = fmt.Sprintf("failed to parse cluster info: %s", err)
+		adoptOrphanCluster(client, cfg, report, &res)
+		return res
+	}
+	report.ClusterInfo = &info
+	report.ClusterID = info.Id
+
+	res.Notes = append(res.Notes,
+		fmt.Sprintf("ℹ️  cluster id: %s", info.Id),
+		fmt.Sprintf("ℹ️  elapsed: %v", res.Duration.Truncate(time.Second)))
+	if string(info.Status) == "Active" {
+		res.Notes = append(res.Notes, "✅ status: Active")
+	} else {
+		res.Notes = append(res.Notes, fmt.Sprintf("❌ status: %s (want Active)", info.Status))
+		res.Error = fmt.Sprintf("cluster status is %s", info.Status)
+		return res // ClusterID is already set, so cleanup still runs
+	}
+	res.Success = true
+	return res
+}
+
+func migrateSync(client *resty.Client, cfg TestConfig, url string, body []byte, res *StepResult) ([]byte, int, error) {
+	syncClient := *client
+	sc := (&syncClient).SetTimeout(time.Duration(cfg.Migration.TimeoutSec) * time.Second)
+
+	fmt.Printf("      ... sync mode: holding the connection for up to %ds\n", cfg.Migration.TimeoutSec)
+	resp, err := sc.R().SetHeader("Content-Type", "application/json").SetBody(body).Post(url)
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return nil, resp.StatusCode(), fmt.Errorf("expected 201, got %d: %s", resp.StatusCode(), truncate(string(resp.Body()), 300))
+	}
+	var apiResp ApiResponseRaw
+	if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+		return nil, resp.StatusCode(), fmt.Errorf("failed to parse response: %w", err)
+	}
+	return apiResp.Data, resp.StatusCode(), nil
+}
+
+// migrateAsync posts with Prefer: respond-async and polls the request record. A 503 means
+// Beetle's async job pool (20 concurrent) is full, so it is retried rather than failed.
+func migrateAsync(client *resty.Client, cfg TestConfig, url string, body []byte, res *StepResult) ([]byte, int, error) {
+	const maxAdmissionRetries = 5
+	var resp *resty.Response
+	var err error
+
+	for attempt := 1; attempt <= maxAdmissionRetries; attempt++ {
+		resp, err = client.R().
+			SetHeader("Content-Type", "application/json").
+			SetHeader("Prefer", "respond-async").
+			SetBody(body).
+			Post(url)
+		if err != nil {
+			return nil, 0, err
+		}
+		if resp.StatusCode() != http.StatusServiceUnavailable {
+			break
+		}
+		wait := 30 * time.Second
+		fmt.Printf("      ... async job pool full (503), retrying in %v (%d/%d)\n", wait, attempt, maxAdmissionRetries)
+		time.Sleep(wait)
+	}
+
+	if resp.StatusCode() != http.StatusAccepted {
+		return nil, resp.StatusCode(), fmt.Errorf("expected 202, got %d: %s", resp.StatusCode(), truncate(string(resp.Body()), 300))
+	}
+
+	reqID, err := extractReqID(resp)
+	if err != nil {
+		return nil, resp.StatusCode(), err
+	}
+	res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  async reqId: %s", reqID))
+	fmt.Printf("      -> 202 Accepted, reqId=%s\n", reqID)
+
+	details, err := pollUntilDone(client, cfg.Beetle.Endpoint, reqID, cfg.Poll.IntervalSec, cfg.Poll.TimeoutSec)
+	if err != nil {
+		return nil, resp.StatusCode(), err
+	}
+	if details.Status != "Success" {
+		return nil, resp.StatusCode(), fmt.Errorf("async job ended with status %s: %s", details.Status, truncate(details.ErrorResponse, 300))
+	}
+
+	// The recorded response body is the same ApiResponse envelope the sync path returns.
+	var apiResp ApiResponseRaw
+	if err := json.Unmarshal(details.ResponseData, &apiResp); err == nil && len(apiResp.Data) > 0 {
+		return apiResp.Data, resp.StatusCode(), nil
+	}
+	return details.ResponseData, resp.StatusCode(), nil
+}
+
+// caseNameSeed gives each target its own name prefix so concurrent runs against different
+// CSPs do not fight over the fixed resource names a recommendation produces. Mirrors the
+// per-case seeding cmd/test-cli/infra uses.
+func caseNameSeed(cfg TestConfig, index int) string {
+	if cfg.Beetle.NameSeed == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s%02d", cfg.Beetle.NameSeed, index+1)
+}
+
+// lastStepPassed reports whether the most recent step succeeded, so workload verification is
+// attempted only on a cluster that passed the earlier checks.
+// specMatch reports whether a created node group's spec is the one that was recommended.
+//
+// Tumblebug normally echoes back its own namespaced spec ID ("aws+ap-northeast-2+c5a.xlarge"),
+// but for some CSPs the stored ID is empty and the CSP's native name surfaces instead
+// ("Standard_B4as_v2" on Azure). Rather than loosening the comparison to accommodate that, the
+// recommended ID is resolved through Tumblebug and its recorded cspSpecName is compared
+// exactly — so both renderings are checked against the same authoritative source.
+//
+// matched=false with err!=nil means the check could not be performed, which is reported as
+// unknown rather than as a mismatch: a failed lookup is not evidence of a wrong spec.
+func specMatch(sess *tbclient.Session, got, want string) (matched bool, err error) {
+	if got == want {
+		return true, nil
+	}
+	if sess == nil {
+		return false, fmt.Errorf("no Tumblebug endpoint configured to resolve the spec")
+	}
+	spec, err := sess.ReadVmSpec("system", want)
+	if err != nil {
+		return false, fmt.Errorf("could not resolve spec %q via Tumblebug: %w", want, err)
+	}
+	if spec.CspSpecName == "" {
+		return false, fmt.Errorf("Tumblebug has no cspSpecName recorded for spec %q", want)
+	}
+	return got == spec.CspSpecName, nil
+}
+
+func lastStepPassed(report *CSPTestReport) bool {
+	if len(report.Steps) == 0 {
+		return false
+	}
+	return report.Steps[len(report.Steps)-1].Success
+}
+
+// adoptOrphanCluster looks up a cluster by the recommended name and records its ID on the
+// report. Beetle creates the cluster before its node groups, so a migration that fails
+// partway can leave a running, billable cluster whose ID never reached the caller. Recording
+// it here is what lets the cleanup step tear it down.
+func adoptOrphanCluster(client *resty.Client, cfg TestConfig, report *CSPTestReport, res *StepResult) {
+	if report.ClusterID != "" || report.Recommendation == nil {
+		return
+	}
+	wantName := report.Recommendation.TargetK8sCluster.Name
+	if wantName == "" {
+		return
+	}
+	// Beetle applies the seed server-side, so the created cluster carries the prefixed name.
+	if report.NameSeed != "" {
+		wantName = report.NameSeed + "-" + wantName
+	}
+
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/k8sCluster", cfg.Beetle.Endpoint, cfg.Beetle.NamespaceID)
+	resp, err := client.R().Get(url)
+	if err != nil || resp.StatusCode() != http.StatusOK {
+		res.Notes = append(res.Notes, "❌ could not list clusters to check for a partially created one — verify manually")
+		return
+	}
+
+	var apiResp model.ApiResponse[[]tbmodel.K8sClusterInfo]
+	if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+		res.Notes = append(res.Notes, "❌ could not parse cluster list to check for a partially created one — verify manually")
+		return
+	}
+	for _, c := range apiResp.Data {
+		if c.Name == wantName || c.Id == wantName {
+			cluster := c
+			report.ClusterID = cluster.Id
+			report.ClusterInfo = &cluster
+			res.Notes = append(res.Notes,
+				fmt.Sprintf("⚠️  cluster %s exists despite the failure (status %s) — scheduling cleanup", cluster.Id, cluster.Status))
+			return
+		}
+	}
+	res.Notes = append(res.Notes, "ℹ️  no partially created cluster found — nothing to clean up")
+}
+
+func stepList(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, _ []byte) StepResult {
+	res := StepResult{Number: 3, Name: "GET /migration/ns/{nsId}/k8sCluster", StartTime: time.Now()}
+
+	// option=id keeps this cheap: the full listing refreshes every cluster through the CSP and
+	// exceeds Tumblebug's 120 s request timeout once several clusters exist. Presence of the ID
+	// is all this step needs.
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/k8sCluster?option=id", cfg.Beetle.Endpoint, cfg.Beetle.NamespaceID)
+	resp, err := client.R().Get(url)
+	res.Duration = time.Since(res.StartTime)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	res.StatusCode = resp.StatusCode()
+	if resp.StatusCode() != http.StatusOK {
+		res.Error = fmt.Sprintf("expected 200, got %d", resp.StatusCode())
+		return res
+	}
+
+	var apiResp model.ApiResponse[cloudmodel.IdList]
+	if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+		res.Error = fmt.Sprintf("failed to parse cluster ID list: %s", err)
+		return res
+	}
+
+	found := false
+	for _, id := range apiResp.Data.IdList {
+		if id == report.ClusterID {
+			found = true
+			break
+		}
+	}
+	if found {
+		res.Notes = append(res.Notes, fmt.Sprintf("✅ migrated cluster present in list (%d total)", len(apiResp.Data.IdList)))
+		res.Success = true
+	} else {
+		res.Notes = append(res.Notes, fmt.Sprintf("❌ cluster %s not found in list of %d", report.ClusterID, len(apiResp.Data.IdList)))
+		res.Error = "migrated cluster missing from list"
+	}
+	return res
+}
+
+// stepGetAndVerify is this CLI's distinctive check: it compares what was actually created
+// against what the recommendation asked for. A migration that succeeds but silently drops a
+// node group or substitutes a spec would otherwise go unnoticed.
+func stepGetAndVerify(client *resty.Client, cfg TestConfig, auth AuthConfig, report *CSPTestReport, _ []byte) StepResult {
+	res := StepResult{Number: 4, Name: "GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation", StartTime: time.Now()}
+
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/k8sCluster/%s", cfg.Beetle.Endpoint, cfg.Beetle.NamespaceID, report.ClusterID)
+	resp, err := client.R().Get(url)
+	res.Duration = time.Since(res.StartTime)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	res.StatusCode = resp.StatusCode()
+	if resp.StatusCode() != http.StatusOK {
+		res.Error = fmt.Sprintf("expected 200, got %d", resp.StatusCode())
+		return res
+	}
+
+	var apiResp model.ApiResponse[tbmodel.K8sClusterInfo]
+	if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+		res.Error = fmt.Sprintf("failed to parse cluster: %s", err)
+		return res
+	}
+	actual := apiResp.Data
+	report.ClusterInfo = &actual
+
+	want := report.Recommendation.TargetK8sCluster
+	ok := true
+
+	if string(actual.Status) == "Active" {
+		res.Notes = append(res.Notes, "✅ status: Active")
+	} else {
+		ok = false
+		res.Notes = append(res.Notes, fmt.Sprintf("❌ status: %s (want Active)", actual.Status))
+	}
+
+	if len(actual.K8sNodeGroupList) == len(want.K8sNodeGroupList) {
+		res.Notes = append(res.Notes, fmt.Sprintf("✅ node group count matches recommendation: %d", len(actual.K8sNodeGroupList)))
+	} else {
+		ok = false
+		res.Notes = append(res.Notes, fmt.Sprintf("❌ node group count %d, recommendation asked for %d",
+			len(actual.K8sNodeGroupList), len(want.K8sNodeGroupList)))
+	}
+
+	// Spec IDs are resolved through Tumblebug (see specMatch); Beetle exposes no spec API.
+	// A nil session leaves the spec check unverified rather than failing it.
+	var specSession *tbclient.Session
+	if auth.TumblebugEndpoint != "" {
+		specSession = tbclient.NewClient(tbclient.ApiConfig{
+			RestUrl:  auth.TumblebugEndpoint + "/tumblebug",
+			Username: auth.TumblebugApiUsername,
+			Password: auth.TumblebugApiPassword,
+		}).NewSession()
+	}
+
+	// Match by name: CSPs may reorder node groups, so index-based comparison is unreliable.
+	wantByName := make(map[string]cloudmodel.K8sNodeGroupReq, len(want.K8sNodeGroupList))
+	for _, ng := range want.K8sNodeGroupList {
+		wantByName[ng.Name] = ng
+	}
+	for _, got := range actual.K8sNodeGroupList {
+		w, exists := wantByName[got.Name]
+		if !exists {
+			ok = false
+			res.Notes = append(res.Notes, fmt.Sprintf("❌ node group %q was not in the recommendation", got.Name))
+			continue
+		}
+		specOK, specErr := specMatch(specSession, got.SpecId, w.SpecId)
+		switch {
+		case specErr != nil:
+			res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  node group %q spec=%s — not verified: %s", got.Name, got.SpecId, specErr))
+		case !specOK:
+			ok = false
+			res.Notes = append(res.Notes, fmt.Sprintf("❌ node group %q spec=%s, recommended %s", got.Name, got.SpecId, w.SpecId))
+		}
+		if got.DesiredNodeSize != w.DesiredNodeSize {
+			ok = false
+			res.Notes = append(res.Notes, fmt.Sprintf("❌ node group %q desiredNodeSize=%d, recommended %d",
+				got.Name, got.DesiredNodeSize, w.DesiredNodeSize))
+		}
+		if specOK && got.DesiredNodeSize == w.DesiredNodeSize {
+			res.Notes = append(res.Notes, fmt.Sprintf("✅ node group %q matches (spec=%s, nodes=%d)", got.Name, got.SpecId, got.DesiredNodeSize))
+		}
+	}
+
+	// Version is reported by the CSP and may carry a provider suffix (e.g. "1.30.1-aliyun.1"),
+	// so a prefix match is the meaningful comparison.
+	if want.Version != "" {
+		if strings.HasPrefix(actual.Version, want.Version) || strings.HasPrefix(want.Version, actual.Version) {
+			res.Notes = append(res.Notes, fmt.Sprintf("✅ version: %s (recommended %s)", actual.Version, want.Version))
+		} else {
+			res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  version: %s (recommended %s) — provider-specific rendering", actual.Version, want.Version))
+		}
+	}
+
+	res.Success = ok
+	if !ok {
+		res.Error = "created cluster does not match the recommendation"
+	}
+	return res
+}
+
+// stepDelete removes the cluster. Deletion has no async mode, and Beetle waits for every node
+// group to disappear before deleting the cluster, so this call is long-running. Some CSPs
+// (observed on NCP) reject deletion for several minutes after reporting Active, so failures
+// are retried with a fixed backoff rather than matched against specific error strings.
+func stepDelete(client *resty.Client, cfg TestConfig, _ AuthConfig, report *CSPTestReport, _ []byte) StepResult {
+	res := StepResult{Number: 6, Name: "DELETE /migration/ns/{nsId}/k8sCluster/{id}", StartTime: time.Now()}
+
+	deleteClient := *client
+	dc := (&deleteClient).SetTimeout(time.Duration(cfg.Delete.TimeoutSec) * time.Second)
+	url := fmt.Sprintf("%s/beetle/migration/ns/%s/k8sCluster/%s", cfg.Beetle.Endpoint, cfg.Beetle.NamespaceID, report.ClusterID)
+
+	for attempt := 1; attempt <= cfg.Delete.MaxRetries; attempt++ {
+		resp, err := dc.R().Delete(url)
+		if err != nil {
+			res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  attempt %d: %s", attempt, err))
+		} else {
+			res.StatusCode = resp.StatusCode()
+			body := string(resp.Body())
+
+			if resp.StatusCode() == http.StatusOK {
+				res.Duration = time.Since(res.StartTime)
+				res.Notes = append(res.Notes, fmt.Sprintf("✅ deleted on attempt %d (%v)", attempt, res.Duration.Truncate(time.Second)))
+				res.Success = true
+				return res
+			}
+			// Deletion of an already-absent cluster is a no-op success for cleanup purposes.
+			if isAlreadyGone(body) {
+				res.Duration = time.Since(res.StartTime)
+				res.Notes = append(res.Notes,
+					"✅ cluster already absent — treated as cleanup success",
+					"ℹ️  known gap: Beetle returns 500 for a missing cluster instead of a no-op success")
+				res.Success = true
+				return res
+			}
+			res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  attempt %d: HTTP %d — %s", attempt, resp.StatusCode(), truncate(body, 200)))
+		}
+
+		if attempt < cfg.Delete.MaxRetries {
+			wait := time.Duration(cfg.Delete.RetryIntervalSec) * time.Second
+			fmt.Printf("      ... deletion not accepted yet, retrying in %v (%d/%d)\n", wait, attempt, cfg.Delete.MaxRetries)
+			time.Sleep(wait)
+		}
+	}
+
+	res.Duration = time.Since(res.StartTime)
+	res.Error = fmt.Sprintf("deletion failed after %d attempts — cluster %s may still exist and incur cost",
+		cfg.Delete.MaxRetries, report.ClusterID)
+	return res
+}
+
+// stepResidualCheck reports whether the prerequisite resources survive cluster deletion.
+// Leftover VNet/SecurityGroup/SshKey is current known behaviour, so this is recorded rather
+// than failed: cleanup scope is tracked as a separate Beetle improvement.
+func stepResidualCheck(_ *resty.Client, cfg TestConfig, auth AuthConfig, report *CSPTestReport, _ []byte) StepResult {
+	res := StepResult{Number: 7, Name: "Residual resource check (Tumblebug)", StartTime: time.Now()}
+
+	if auth.TumblebugEndpoint == "" {
+		res.Duration = time.Since(res.StartTime)
+		res.Skipped = true
+		res.Success = true
+		res.Notes = append(res.Notes, "ℹ️  skipped: tumblebugEndpoint not set in auth config")
+		return res
+	}
+	if report.ClusterInfo == nil {
+		res.Duration = time.Since(res.StartTime)
+		res.Skipped = true
+		res.Success = true
+		res.Notes = append(res.Notes, "ℹ️  skipped: no cluster info captured before deletion")
+		return res
+	}
+
+	sess := tbclient.NewClient(tbclient.ApiConfig{
+		RestUrl:  auth.TumblebugEndpoint + "/tumblebug",
+		Username: auth.TumblebugApiUsername,
+		Password: auth.TumblebugApiPassword,
+	}).NewSession()
+
+	ns := cfg.Beetle.NamespaceID
+	net := report.ClusterInfo.Network
+
+	if net.VNetId != "" {
+		if _, err := sess.ReadVNet(ns, net.VNetId); err == nil {
+			res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  VNet %s still exists (known gap)", net.VNetId))
+		} else {
+			res.Notes = append(res.Notes, fmt.Sprintf("✅ VNet %s removed", net.VNetId))
+		}
+	}
+	for _, sgID := range net.SecurityGroupIds {
+		if _, err := sess.ReadSecurityGroup(ns, sgID); err == nil {
+			res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  SecurityGroup %s still exists (known gap)", sgID))
+		} else {
+			res.Notes = append(res.Notes, fmt.Sprintf("✅ SecurityGroup %s removed", sgID))
+		}
+	}
+	seenKeys := map[string]bool{}
+	for _, ng := range report.ClusterInfo.K8sNodeGroupList {
+		if ng.SshKeyId == "" || seenKeys[ng.SshKeyId] {
+			continue
+		}
+		seenKeys[ng.SshKeyId] = true
+		if _, err := sess.ReadSshKey(ns, ng.SshKeyId); err == nil {
+			res.Notes = append(res.Notes, fmt.Sprintf("ℹ️  SshKey %s still exists (known gap)", ng.SshKeyId))
+		} else {
+			res.Notes = append(res.Notes, fmt.Sprintf("✅ SshKey %s removed", ng.SshKeyId))
+		}
+	}
+
+	res.Duration = time.Since(res.StartTime)
+	res.Success = true // informational only
+	return res
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+func isAlreadyGone(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "not exist") || strings.Contains(lower, "not found")
+}
+
+func extractReqID(resp *resty.Response) (string, error) {
+	var apiResp ApiResponseRaw
+	if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+		return "", fmt.Errorf("failed to parse async job response: %w", err)
+	}
+	var job AsyncJobData
+	if err := json.Unmarshal(apiResp.Data, &job); err != nil {
+		return "", fmt.Errorf("failed to parse async job data: %w", err)
+	}
+	if job.ReqID == "" {
+		job.ReqID = resp.Header().Get("X-Request-Id")
+	}
+	if job.ReqID == "" {
+		return "", fmt.Errorf("no reqId in async job response")
+	}
+	return job.ReqID, nil
+}
+
+// pollUntilDone polls GET /request/{reqId} until the job finishes or the timeout elapses.
+func pollUntilDone(client *resty.Client, endpoint, reqID string, intervalSec, timeoutSec int) (RequestDetails, error) {
+	statusURL := fmt.Sprintf("%s/beetle/request/%s", endpoint, reqID)
+	start := time.Now()
+	deadline := start.Add(time.Duration(timeoutSec) * time.Second)
+	interval := time.Duration(intervalSec) * time.Second
+	attempt := 0
+
+	for time.Now().Before(deadline) {
+		time.Sleep(interval)
+		attempt++
+		elapsed := time.Since(start).Round(time.Second)
+
+		resp, err := client.R().Get(statusURL)
+		if err != nil {
+			fmt.Printf("      ... [%s elapsed, poll #%d] request error: %v\n", elapsed, attempt, err)
+			continue
+		}
+		var apiResp ApiResponseRaw
+		if err := json.Unmarshal(resp.Body(), &apiResp); err != nil {
+			fmt.Printf("      ... [%s elapsed, poll #%d] parse error: %v\n", elapsed, attempt, err)
+			continue
+		}
+		var details RequestDetails
+		if err := json.Unmarshal(apiResp.Data, &details); err != nil {
+			fmt.Printf("      ... [%s elapsed, poll #%d] parse error: %v\n", elapsed, attempt, err)
+			continue
+		}
+
+		fmt.Printf("      ... [%s elapsed, poll #%d] status: %s\n", elapsed, attempt, details.Status)
+		if details.Status == "Success" || details.Status == "Error" {
+			return details, nil
+		}
+	}
+	return RequestDetails{}, fmt.Errorf("polling timed out after %ds", timeoutSec)
+}
+
+func newClient(cfg TestConfig, auth AuthConfig) *resty.Client {
+	c := resty.New().SetTimeout(2 * time.Minute).SetLogger(restyNoopLogger{})
+	if auth.BeetleApiUsername != "" {
+		c.SetBasicAuth(auth.BeetleApiUsername, auth.BeetleApiPassword)
+	}
+	return c
+}
+
+func applyDefaults(cfg *TestConfig) {
+	if cfg.Test.Set.Mode != "sequential" {
+		cfg.Test.Set.Mode = "parallel"
+	}
+	if cfg.Migration.Mode != "sync" {
+		cfg.Migration.Mode = "async"
+	}
+	setIfZero(&cfg.Migration.TimeoutSec, 3600) // 60 min: Beetle polls up to 40 min for Active
+	setIfZero(&cfg.Poll.IntervalSec, 30)
+	setIfZero(&cfg.Poll.TimeoutSec, 3600)
+	setIfZero(&cfg.Delete.TimeoutSec, 1800) // 30 min: node group teardown is polled for up to 20 min
+	setIfZero(&cfg.Delete.RetryIntervalSec, 60)
+	setIfZero(&cfg.Delete.MaxRetries, 10)
+	setIfZero(&cfg.Test.Set.StartDelaySeconds, 10)
+	setIfZero(&cfg.Workload.KubeconfigTimeoutSec, 600) // kubeconfig lags Active on some CSPs
+	setIfZero(&cfg.Workload.KubeconfigPollSec, 60)
+	setIfZero(&cfg.Workload.PodReadyTimeoutSec, 180)
+	setIfZero(&cfg.Workload.PodPollSec, 10)
+	setIfZero(&cfg.Workload.LbAddressTimeoutSec, 900) // CSP load balancer provisioning is slow
+	setIfZero(&cfg.Workload.LbAccessTimeoutSec, 300)  // health checks and DNS settle after the address appears
+	setIfZero(&cfg.Workload.LbPollSec, 15)
+	if cfg.Beetle.NamespaceID == "" {
+		cfg.Beetle.NamespaceID = "mig01"
+	}
+}
+
+func setIfZero(v *int, def int) {
+	if *v <= 0 {
+		*v = def
+	}
+}
+
+func selectedTargets(cfg TestConfig) []TestCase {
+	var out []TestCase
+	for _, c := range cfg.Test.Cases {
+		if c.Execute {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+func printBanner(t TestCase) {
+	fmt.Printf("\n=========================================================\n")
+	fmt.Printf(" Target: %s (%s / %s)\n", t.Name, t.Csp, t.Region)
+	fmt.Printf("=========================================================\n")
+}
+
+// printStep labels every line with the target, because targets run concurrently and their
+// output interleaves; without the label a failure cannot be attributed to a CSP.
+func printStep(target string, res StepResult) {
+	icon := "✅"
+	switch {
+	case res.Skipped:
+		icon = "⏭️"
+	case !res.Success:
+		icon = "❌"
+	}
+	fmt.Printf("%s [%s] Step %d: %s (%v)\n", icon, target, res.Number, res.Name, res.Duration.Truncate(time.Millisecond))
+	for _, n := range res.Notes {
+		fmt.Printf("      [%s] %s\n", target, n)
+	}
+	if res.Error != "" {
+		fmt.Printf("      [%s] error: %s\n", target, res.Error)
+	}
+}
+
+func printFinalSummary(reports []*CSPTestReport) bool {
+	fmt.Println("\n=========================================================")
+	fmt.Println(" OVERALL TEST SUMMARY")
+	fmt.Println("=========================================================")
+
+	allPassed := true
+	for _, r := range reports {
+		passed, total := countSteps(r)
+		status := "✅"
+		if passed != total {
+			status = "❌"
+			allPassed = false
+		}
+		fmt.Printf(" %s %-22s %d/%d steps passed\n", status, r.DisplayName, passed, total)
+	}
+	fmt.Println("=========================================================")
+	return allPassed
+}
+
+func countSteps(r *CSPTestReport) (passed, total int) {
+	for _, s := range r.Steps {
+		total++
+		if s.Success {
+			passed++
+		}
+	}
+	return passed, total
+}
+
+// checkBeetleReadiness checks if CM-Beetle is ready using GET /beetle/readyz.
+func checkBeetleReadiness(client *resty.Client, beetleURL string) error {
+	fmt.Println("🔍 Checking CM-Beetle readiness...")
+	url := beetleURL + "/beetle/readyz"
+
+	var response map[string]interface{}
+	var emptyBody interface{} = common.NoBody
+	err := common.ExecuteHttpRequest(client, "GET", url, nil, common.SetUseBody(emptyBody), &emptyBody, &response, 0)
+	if err != nil {
+		return fmt.Errorf("CM-Beetle readiness check failed: %w", err)
+	}
+	if message, ok := response["message"].(string); ok && strings.Contains(message, "NOT ready") {
+		return fmt.Errorf("CM-Beetle is not ready: %s", message)
+	}
+	fmt.Println("✅ CM-Beetle is ready!")
+	return nil
+}
+
+func loadConfig(configPath string) (TestConfig, error) {
+	var cfg TestConfig
+	file, err := os.Open(configPath)
+	if err != nil {
+		return cfg, err
+	}
+	defer file.Close()
+	if err := yaml.NewDecoder(file).Decode(&cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func loadAuthConfig(authConfigPath string) (AuthConfig, error) {
+	var auth AuthConfig
+	file, err := os.Open(authConfigPath)
+	if err != nil {
+		return auth, err
+	}
+	defer file.Close()
+	if err := json.NewDecoder(file).Decode(&auth); err != nil {
+		return auth, fmt.Errorf("failed to decode auth config: %w", err)
+	}
+	return auth, nil
+}
+
+// getGitHash returns the current git commit hash.
+func getGitHash() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// getBeetleVersion returns the CM-Beetle version from git tags or commit hash.
+// Only beetle release tags (v[0-9]*) are matched to avoid picking up imdl/*, transx/* tags.
+func getBeetleVersion() string {
+	commitHash := getGitHash()
+
+	if exactTag, err := exec.Command("git", "describe", "--tags", "--exact-match", "--match", "v[0-9]*").Output(); err == nil {
+		return strings.TrimSpace(string(exactTag))
+	}
+	if tag, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*").Output(); err == nil {
+		if tagStr := strings.TrimSpace(string(tag)); tagStr != "" {
+			if commitHash != "unknown" {
+				return fmt.Sprintf("%s+ (%s)", tagStr, commitHash)
+			}
+			return tagStr + "+"
+		}
+	}
+	if commitHash != "unknown" {
+		return fmt.Sprintf("main (%s)", commitHash)
+	}
+	return "main (unknown)"
+}
+
+// maskSensitiveInfo removes CSP account identifiers from report content.
+func maskSensitiveInfo(content string) string {
+	reSub := regexp.MustCompile(`(?i)/subscriptions/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
+	content = reSub.ReplaceAllString(content, "/subscriptions/AZURE_SUBSCRIPTION_ID")
+
+	reGCP := regexp.MustCompile(`projects/([a-z0-9\-]+)/`)
+	content = reGCP.ReplaceAllStringFunc(content, func(match string) string {
+		parts := strings.Split(match, "/")
+		if len(parts) >= 2 && (parts[1] == "compute" || parts[1] == "v1") {
+			return match
+		}
+		return "projects/GCP_PROJECT_ID/"
+	})
+
+	reEmail := regexp.MustCompile(`[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}`)
+	return reEmail.ReplaceAllString(content, "MASKED_EMAIL")
+}
+
+func testResultDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(cwd, "testresult")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func generateCSPReport(report *CSPTestReport) error {
+	dir, err := testResultDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, fmt.Sprintf("k8s-infra-migration-test-results-%s.md", strings.ToLower(report.CSP)))
+	if err := os.WriteFile(path, []byte(maskSensitiveInfo(buildCSPMarkdown(report))), 0644); err != nil {
+		return err
+	}
+	log.Info().Str("file", path).Msg("✅ CSP test report generated and saved")
+	return nil
+}
+
+func buildCSPMarkdown(report *CSPTestReport) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("# CM-Beetle K8s Infra Migration Test Results — %s\n\n", report.DisplayName))
+	sb.WriteString("> [!NOTE]\n")
+	sb.WriteString("> Full lifecycle against a real CSP: recommend → migrate → list → get (verified against\n")
+	sb.WriteString("> the recommendation) → delete → residual resource check.\n\n")
+
+	sb.WriteString("## Environment\n\n")
+	sb.WriteString(fmt.Sprintf("- CSP / Region: %s / %s\n", report.CSP, report.Region))
+	sb.WriteString(fmt.Sprintf("- CM-Beetle URL: %s\n", report.BeetleURL))
+	sb.WriteString(fmt.Sprintf("- CM-Beetle Version: %s\n", report.BeetleVersion))
+	sb.WriteString(fmt.Sprintf("- Git Commit: %s\n", report.GitHash))
+	sb.WriteString(fmt.Sprintf("- Namespace: %s\n", report.NamespaceID))
+	sb.WriteString(fmt.Sprintf("- Test Date: %s\n", report.TestDateTime.Format("2006-01-02 15:04:05 MST")))
+	if report.ClusterID != "" {
+		sb.WriteString(fmt.Sprintf("- Cluster ID: %s\n", report.ClusterID))
+	}
+	sb.WriteString("\n")
+
+	passed, total := countSteps(report)
+	sb.WriteString("## Test Results Summary\n\n")
+	sb.WriteString("| Step | Description | Status | Duration |\n")
+	sb.WriteString("|------|-------------|--------|----------|\n")
+	var totalDuration time.Duration
+	for _, s := range report.Steps {
+		status := "✅ **PASS**"
+		switch {
+		case s.Skipped:
+			status = "⏭️ **SKIP**"
+		case !s.Success:
+			status = "❌ **FAIL**"
+		}
+		sb.WriteString(fmt.Sprintf("| %d | %s | %s | %v |\n", s.Number, s.Name, status, s.Duration.Truncate(time.Millisecond)))
+		totalDuration += s.Duration
+	}
+	sb.WriteString(fmt.Sprintf("\n**Overall Result**: %d/%d steps passed", passed, total))
+	if passed == total {
+		sb.WriteString(" ✅\n\n")
+	} else {
+		sb.WriteString(" ❌\n\n")
+	}
+	sb.WriteString(fmt.Sprintf("**Total Duration**: %v\n\n---\n\n", totalDuration.Truncate(time.Second)))
+
+	sb.WriteString("## Step Details\n\n")
+	for _, s := range report.Steps {
+		sb.WriteString(fmt.Sprintf("### Step %d — %s\n\n", s.Number, s.Name))
+		sb.WriteString(fmt.Sprintf("- **Duration**: %v\n", s.Duration.Truncate(time.Millisecond)))
+		if s.StatusCode != 0 {
+			sb.WriteString(fmt.Sprintf("- **Status Code**: %d\n", s.StatusCode))
+		}
+		if s.Error != "" {
+			sb.WriteString(fmt.Sprintf("- **Error**: %s\n", s.Error))
+		}
+		sb.WriteString("\n")
+		for _, n := range s.Notes {
+			sb.WriteString(fmt.Sprintf("- %s\n", n))
+		}
+		sb.WriteString("\n")
+	}
+
+	if report.Recommendation != nil {
+		sb.WriteString("## Recommendation (input to migration)\n\n")
+		sb.WriteString("<details>\n  <summary> <ins>Click to see the recommendation</ins> </summary>\n\n```json\n")
+		b, _ := json.MarshalIndent(report.Recommendation, "", "  ")
+		sb.WriteString(string(b))
+		sb.WriteString("\n```\n\n</details>\n\n")
+	}
+	if report.ClusterInfo != nil {
+		sb.WriteString("## Created Cluster\n\n")
+		sb.WriteString("<details>\n  <summary> <ins>Click to see the cluster info</ins> </summary>\n\n```json\n")
+		b, _ := json.MarshalIndent(report.ClusterInfo, "", "  ")
+		sb.WriteString(string(b))
+		sb.WriteString("\n```\n\n</details>\n\n")
+	}
+
+	return sb.String()
+}
+
+func generateSummaryReport(reports []*CSPTestReport) error {
+	dir, err := testResultDir()
+	if err != nil {
+		return err
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# CM-Beetle K8s Infra Migration Test Summary\n\n")
+	if len(reports) > 0 {
+		sb.WriteString(fmt.Sprintf("- CM-Beetle Version: %s\n", reports[0].BeetleVersion))
+		sb.WriteString(fmt.Sprintf("- Test Date: %s\n\n", reports[0].TestDateTime.Format("2006-01-02 15:04:05 MST")))
+	}
+
+	sb.WriteString("| Target | CSP / Region | Steps Passed | Cluster ID | Result |\n")
+	sb.WriteString("|--------|--------------|--------------|------------|--------|\n")
+	for _, r := range reports {
+		passed, total := countSteps(r)
+		result := "✅ PASS"
+		if passed != total {
+			result = "❌ FAIL"
+		}
+		clusterID := r.ClusterID
+		if clusterID == "" {
+			clusterID = "—"
+		}
+		sb.WriteString(fmt.Sprintf("| %s | %s / %s | %d/%d | `%s` | %s |\n",
+			r.DisplayName, r.CSP, r.Region, passed, total, clusterID, result))
+	}
+	sb.WriteString("\n## Per-CSP Reports\n\n")
+	for _, r := range reports {
+		sb.WriteString(fmt.Sprintf("- [%s](k8s-infra-migration-test-results-%s.md)\n", r.DisplayName, strings.ToLower(r.CSP)))
+	}
+
+	path := filepath.Join(dir, "k8s-infra-migration-test-summary-all.md")
+	if err := os.WriteFile(path, []byte(maskSensitiveInfo(sb.String())), 0644); err != nil {
+		return err
+	}
+	log.Info().Str("file", path).Msg("✅ Summary report generated and saved")
+	return nil
+}

--- a/cmd/test-cli/k8s-infra-migration/testconf/recommendation-request.json
+++ b/cmd/test-cli/k8s-infra-migration/testconf/recommendation-request.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-migration/testconf/template-auth-config.json
+++ b/cmd/test-cli/k8s-infra-migration/testconf/template-auth-config.json
@@ -1,0 +1,7 @@
+{
+  "beetleApiUsername": "your-beetle-api-username",
+  "beetleApiPassword": "your-beetle-api-password",
+  "tumblebugApiUsername": "your-tumblebug-username",
+  "tumblebugApiPassword": "your-tumblebug-password",
+  "tumblebugEndpoint": "http://localhost:1323"
+}

--- a/cmd/test-cli/k8s-infra-migration/testconf/template-test-config.yaml
+++ b/cmd/test-cli/k8s-infra-migration/testconf/template-test-config.yaml
@@ -1,0 +1,98 @@
+test:
+  set:
+    mode: parallel # parallel or sequential
+    # Stagger between parallel target starts, so concurrent runs do not burst
+    # Tumblebug's read APIs at once. See docs/tumblebug-call-pacer.md.
+    startDelaySeconds: 10
+
+  # WARNING: every enabled target provisions a real managed K8s cluster and incurs cost.
+  # Enable one CSP at a time until the flow is confirmed for it.
+  cases:
+    # Enable exactly the CSP you intend to provision. All disabled by default so that
+    # `make test-k8s-infra-migration` never provisions anything by accident.
+    - csp: aws
+      region: ap-northeast-2
+      name: AWS-Seoul
+      execute: false
+    - csp: azure
+      region: koreasouth
+      name: Azure-Busan
+      execute: false
+    - csp: gcp
+      region: asia-northeast3
+      name: GCP-Seoul
+      execute: false
+    - csp: alibaba
+      region: ap-northeast-2
+      name: Alibaba-Seoul
+      execute: false
+    - csp: tencent
+      region: ap-seoul
+      name: Tencent-Seoul
+      execute: false
+    - csp: ibm
+      region: au-syd
+      name: IBMCloud-Sydney
+      execute: false
+    - csp: ncp
+      region: kr
+      name: NCP-Seoul
+      execute: false
+    - csp: nhn
+      region: kr1
+      name: NHNCloud-Pangyo
+      execute: false
+
+beetle:
+  endpoint: http://localhost:8056
+  namespaceId: mig01
+  authConfigFile: testconf/auth-config.json
+  requestBodyFile: testconf/recommendation-request.json
+  # Prefix for every resource name, with a per-target suffix appended (mig -> mig01, mig02...).
+  # Recommendations produce fixed names, so without a seed a second target would collide with
+  # the first. Leave empty to keep the raw names (single-target runs only). Max 20 chars.
+  nameSeed: mig
+
+migration:
+  # async (default): Prefer: respond-async -> 202 -> poll GET /request/{reqId}.
+  #                  Keeps the HTTP connection short and prints progress while waiting.
+  # sync:            hold the connection until the cluster is Active. Exercises the
+  #                  blocking path; needs timeoutSec to exceed Beetle's own 40 min budget.
+  mode: async
+  timeoutSec: 3600
+
+poll:
+  intervalSec: 30
+  timeoutSec: 3600 # 60 min > Beetle's 40 min Active-polling budget
+
+delete:
+  # Deletion has no async mode and Beetle waits for node group teardown (up to 20 min).
+  timeoutSec: 1800
+  # Some CSPs reject deletion for minutes after reporting Active (observed on NCP),
+  # so failures are retried on a fixed backoff rather than matched on error strings.
+  retryIntervalSec: 60
+  maxRetries: 10
+
+verify:
+  # Report whether VNet/SecurityGroup/SshKey survive cluster deletion. Informational only:
+  # leftover prerequisites are current known behaviour, tracked as a Beetle improvement.
+  # Requires tumblebugEndpoint in auth-config.json.
+  residualResources: true
+
+workload:
+  # Verify the cluster is actually usable: fetch its kubeconfig from CB-Tumblebug, reach the
+  # K8s API server directly, run an nginx Deployment, then remove it. Runs before deletion.
+  # The K8s counterpart of the SSH connectivity check cmd/test-cli/infra does for VMs.
+  # Requires tumblebugEndpoint in auth-config.json. No Docker or kubectl needed.
+  enabled: true
+  kubeconfigTimeoutSec: 600 # kubeconfig lags the Active status on some CSPs
+  kubeconfigPollSec: 60
+  podReadyTimeoutSec: 180
+  podPollSec: 10
+  # Publish nginx through a LoadBalancer Service and fetch it from outside the cluster.
+  # Scheduling a pod proves the cluster runs work; this proves the work is reachable — a
+  # distinct failure mode seen on some CSPs. Adds roughly 2-6 minutes per target.
+  loadBalancerEnabled: true
+  lbAddressTimeoutSec: 900 # CSP load balancer provisioning is slow
+  lbAccessTimeoutSec: 300  # health checks and DNS settle after the address appears
+  lbPollSec: 15

--- a/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-aws.md
+++ b/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-aws.md
@@ -8,27 +8,27 @@
 
 - CSP / Region: aws / ap-northeast-2
 - CM-Beetle URL: http://localhost:8056
-- CM-Beetle Version: v0.6.0
-- Git Commit: 803afb4
+- CM-Beetle Version: v0.6.0+ (1cfe558)
+- Git Commit: 1cfe558
 - Namespace: mig01
-- Test Date: 2026-08-20 15:15:35 KST
+- Test Date: 2026-08-21 11:40:25 KST
 - Cluster ID: mig01-on-prem-k8s-cluster
 
 ## Test Results Summary
 
 | Step | Description | Status | Duration |
 |------|-------------|--------|----------|
-| 1 | POST /recommendation/k8sCluster | ✅ **PASS** | 931ms |
-| 2 | POST /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 7m30.093s |
+| 1 | POST /recommendation/k8sCluster | ✅ **PASS** | 23ms |
+| 2 | POST /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 9m0.231s |
 | 3 | GET /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 1ms |
-| 4 | GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation | ✅ **PASS** | 1.515s |
-| 5 | Workload verification (kubeconfig -> K8s API -> nginx) | ✅ **PASS** | 1m43.493s |
-| 6 | DELETE /migration/ns/{nsId}/k8sCluster/{id} | ✅ **PASS** | 9m16.536s |
+| 4 | GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation | ✅ **PASS** | 1.108s |
+| 5 | Workload verification (kubeconfig -> K8s API -> nginx) | ✅ **PASS** | 1m28.876s |
+| 6 | DELETE /migration/ns/{nsId}/k8sCluster/{id} | ✅ **PASS** | 9m5.627s |
 | 7 | Residual resource check (Tumblebug) | ✅ **PASS** | 3ms |
 
 **Overall Result**: 7/7 steps passed ✅
 
-**Total Duration**: 18m32s
+**Total Duration**: 19m35s
 
 ---
 
@@ -36,7 +36,7 @@
 
 ### Step 1 — POST /recommendation/k8sCluster
 
-- **Duration**: 931ms
+- **Duration**: 23ms
 - **Status Code**: 200
 
 - ℹ️  cluster: on-prem-k8s-cluster (version 1.33)
@@ -45,13 +45,13 @@
 
 ### Step 2 — POST /migration/ns/{nsId}/k8sCluster
 
-- **Duration**: 7m30.093s
+- **Duration**: 9m0.231s
 - **Status Code**: 202
 
 - ℹ️  nameSeed: mig01
-- ℹ️  async reqId: 1787206536789845713
+- ℹ️  async reqId: 1787280025463497959
 - ℹ️  cluster id: mig01-on-prem-k8s-cluster
-- ℹ️  elapsed: 7m30s
+- ℹ️  elapsed: 9m0s
 - ✅ status: Active
 
 ### Step 3 — GET /migration/ns/{nsId}/k8sCluster
@@ -59,11 +59,11 @@
 - **Duration**: 1ms
 - **Status Code**: 200
 
-- ✅ migrated cluster present in list (3 total)
+- ✅ migrated cluster present in list (1 total)
 
 ### Step 4 — GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation
 
-- **Duration**: 1.515s
+- **Duration**: 1.108s
 - **Status Code**: 200
 
 - ✅ status: Active
@@ -73,9 +73,9 @@
 
 ### Step 5 — Workload verification (kubeconfig -> K8s API -> nginx)
 
-- **Duration**: 1m43.493s
+- **Duration**: 1m28.876s
 
-- ✅ kubeconfig obtained (server: https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com)
+- ✅ kubeconfig obtained (server: https://A42C0404A862C06B0E9998C1EC42D7E1.gr7.ap-northeast-2.eks.amazonaws.com)
 - ℹ️  auth method: exec credential plugin
 - ✅ cluster token obtained from Tumblebug
 - ✅ API server reachable (v1.33.13-eks-bca9cf6)
@@ -83,17 +83,17 @@
 - ✅ nginx Deployment created
 - ✅ nginx pod Running (attempt 1)
 - ✅ LoadBalancer Service created
-- ✅ LoadBalancer address assigned: a744452d05ccb4780ba3bb83a48a7239-1969825577.ap-northeast-2.elb.amazonaws.com
-- ✅ nginx served over the LoadBalancer at http://a744452d05ccb4780ba3bb83a48a7239-1969825577.ap-northeast-2.elb.amazonaws.com/ (attempt 6)
+- ✅ LoadBalancer address assigned: a3916bbf5c64b4340b952386c3f11f25-1313336685.ap-northeast-2.elb.amazonaws.com
+- ✅ nginx served over the LoadBalancer at http://a3916bbf5c64b4340b952386c3f11f25-1313336685.ap-northeast-2.elb.amazonaws.com/ (attempt 5)
 - ✅ LoadBalancer Service removed
 - ✅ nginx Deployment removed
 
 ### Step 6 — DELETE /migration/ns/{nsId}/k8sCluster/{id}
 
-- **Duration**: 9m16.536s
+- **Duration**: 9m5.627s
 - **Status Code**: 200
 
-- ✅ deleted on attempt 1 (9m16s)
+- ✅ deleted on attempt 1 (9m5s)
 
 ### Step 7 — Residual resource check (Tumblebug)
 
@@ -233,7 +233,7 @@
 {
   "resourceType": "k8s",
   "id": "mig01-on-prem-k8s-cluster",
-  "uid": "tbdlsc18uvrh6drbdv70",
+  "uid": "tbqajlaplk30cjpsahc6",
   "name": "mig01-on-prem-k8s-cluster",
   "connectionName": "aws-ap-northeast-2",
   "connectionConfig": {
@@ -269,18 +269,18 @@
   "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
   "systemMessage": "",
   "label": {
-    "Name": "tbdlsc18uvrh6drbdv70",
+    "Name": "tbqajlaplk30cjpsahc6",
     "sys.connectionName": "aws-ap-northeast-2",
-    "sys.createdTime": "2026-08-20 06:15:41.284 +0000 UTC",
-    "sys.cspResourceId": "tbdlsc18uvrh6drbdv70",
-    "sys.cspResourceName": "tbdlsc18uvrh6drbdv70",
+    "sys.createdTime": "2026-08-21 02:40:28.745 +0000 UTC",
+    "sys.cspResourceId": "tbqajlaplk30cjpsahc6",
+    "sys.cspResourceName": "tbqajlaplk30cjpsahc6",
     "sys.description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
     "sys.id": "mig01-on-prem-k8s-cluster",
     "sys.labelType": "k8s",
     "sys.manager": "cb-tumblebug",
     "sys.name": "mig01-on-prem-k8s-cluster",
     "sys.namespace": "mig01",
-    "sys.uid": "tbdlsc18uvrh6drbdv70",
+    "sys.uid": "tbqajlaplk30cjpsahc6",
     "sys.version": "1.33"
   },
   "systemLabel": "",
@@ -297,7 +297,7 @@
     "keyValueList": [
       {
         "key": "ClusterSecurityGroupId",
-        "value": "sg-0335b04180c79d7ca"
+        "value": "sg-0467761160db4a2ff"
       },
       {
         "key": "EndpointPrivateAccess",
@@ -341,12 +341,12 @@
       "status": "Active",
       "k8sNodes": [
         {
-          "cspResourceName": "i-031447656bc5f8abf",
-          "cspResourceId": "i-031447656bc5f8abf"
+          "cspResourceName": "i-03dc94bf5dbd38c86",
+          "cspResourceId": "i-03dc94bf5dbd38c86"
         },
         {
-          "cspResourceName": "i-0e3c3fffd635b89bb",
-          "cspResourceId": "i-0e3c3fffd635b89bb"
+          "cspResourceName": "i-0bf3d6c84a78defb4",
+          "cspResourceId": "i-0bf3d6c84a78defb4"
         }
       ],
       "keyValueList": [
@@ -392,11 +392,11 @@
         },
         {
           "key": "Nodes",
-          "value": "{NameId:,SystemId:i-031447656bc5f8abf}; {NameId:,SystemId:i-0e3c3fffd635b89bb}"
+          "value": "{NameId:,SystemId:i-03dc94bf5dbd38c86}; {NameId:,SystemId:i-0bf3d6c84a78defb4}"
         },
         {
           "key": "KeyValueList",
-          "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbdlsc18uvrh6drbdv70}; {Key:CreatedAt,Value:2026-08-20T06:21:32.328Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-20T06:22:43.889Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbdlsc18uvrh6drbdv70/workers1/5cd00eea-7860-d7b8-7846-0ab62961a4b5}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-5cd00eea-7860-d7b8-7846-0ab62961a4b5}],RemoteAccessSecurityGroup:sg-074607780cfdd6b92}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
+          "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbqajlaplk30cjpsahc6}; {Key:CreatedAt,Value:2026-08-21T02:47:11.123Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-21T02:48:53.478Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbqajlaplk30cjpsahc6/workers1/8ed0111b-86ff-c035-79d7-ce32357dd95a}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-8ed0111b-86ff-c035-79d7-ce32357dd95a}],RemoteAccessSecurityGroup:sg-08bb5f8b9279adcc9}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
         }
       ],
       "cspResourceName": "workers1",
@@ -423,12 +423,12 @@
         "Status": "Active",
         "Nodes": [
           {
-            "NameId": "i-031447656bc5f8abf",
-            "SystemId": "i-031447656bc5f8abf"
+            "NameId": "i-03dc94bf5dbd38c86",
+            "SystemId": "i-03dc94bf5dbd38c86"
           },
           {
-            "NameId": "i-0e3c3fffd635b89bb",
-            "SystemId": "i-0e3c3fffd635b89bb"
+            "NameId": "i-0bf3d6c84a78defb4",
+            "SystemId": "i-0bf3d6c84a78defb4"
           }
         ],
         "KeyValueList": [
@@ -474,25 +474,25 @@
           },
           {
             "key": "Nodes",
-            "value": "{NameId:,SystemId:i-031447656bc5f8abf}; {NameId:,SystemId:i-0e3c3fffd635b89bb}"
+            "value": "{NameId:,SystemId:i-03dc94bf5dbd38c86}; {NameId:,SystemId:i-0bf3d6c84a78defb4}"
           },
           {
             "key": "KeyValueList",
-            "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbdlsc18uvrh6drbdv70}; {Key:CreatedAt,Value:2026-08-20T06:21:32.328Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-20T06:22:43.889Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbdlsc18uvrh6drbdv70/workers1/5cd00eea-7860-d7b8-7846-0ab62961a4b5}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-5cd00eea-7860-d7b8-7846-0ab62961a4b5}],RemoteAccessSecurityGroup:sg-074607780cfdd6b92}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
+            "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbqajlaplk30cjpsahc6}; {Key:CreatedAt,Value:2026-08-21T02:47:11.123Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-21T02:48:53.478Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbqajlaplk30cjpsahc6/workers1/8ed0111b-86ff-c035-79d7-ce32357dd95a}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-8ed0111b-86ff-c035-79d7-ce32357dd95a}],RemoteAccessSecurityGroup:sg-08bb5f8b9279adcc9}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
           }
         ]
       }
     }
   ],
   "accessInfo": {
-    "endpoint": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com",
-    "kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: tbdlsc18uvrh6drbdv70\ncontexts:\n- context:\n    cluster: tbdlsc18uvrh6drbdv70\n    user: aws-dynamic-token\n  name: tbdlsc18uvrh6drbdv70\ncurrent-context: tbdlsc18uvrh6drbdv70\nusers:\n- name: aws-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tbdlsc18uvrh6drbdv70/token?ConnectionName=aws-ap-northeast-2\\\"\"\n"
+    "endpoint": "https://A42C0404A862C06B0E9998C1EC42D7E1.gr7.ap-northeast-2.eks.amazonaws.com",
+    "kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://A42C0404A862C06B0E9998C1EC42D7E1.gr7.ap-northeast-2.eks.amazonaws.com\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRYk9HOENhQ05pQkU2UGVpTEFaYUE5VEFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1UQXlOREF6T1ZvWERUTXhNRGd5TURBeQpOREF6T1Zvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBTWpoc1puYnMrK1NoMEVvd2ROVzdJL2x2RHdIdTNjREIvTkY0NHJMeFJkZWlMTHMKQ2d6MnZkdWY0aHR4cWhJRU1lb0ZkTk9VMkZiR2kyeE9rNWlGdkhYQWtFV1VPTHgxdldxNzU2bUczTk9RRTBTaAorMzlqOGZJOUh1Yk9Qc2lLZlhJN1lxM3o4YWF3TzRFeE1lSFdxNlhIZlBvdnIzR29ZaFFyL2txK3NJUWFpYnQ2CncxL2N1bTJzejJXMFo3bXR1Vjlub2ZTWGxucEtIOTl1Q1ZXalIvamVEWUNMR0VudExkWnQ0THhxc0h5dWtpeEcKRFk2T2tXQ29jMFRRTlpSSWRzeVZ0MUZmRnV4dFdoVDQvRkhhMFlkL09OK2FGek1KZmhtV2ZIWkRaN1NzV1FwMgplR3ZpNHhtS0VCRzd4TUpyL0xtM2w4RFNjUEt4NEJjV2VuUi9JLzBDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkNjaWxHTGFCREo3MjYxM3ZDRloKdUtjQkJpMXNNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBSHIzUGZEcFZ0THplWDV1emJKRlFkUkNNa3ZJckx2WHg0UlhTa1lNc3B4Nld0U2RRMGE5Q2cyMlZrR1dtaGdNCnRjMXo2dmxNcHVZUGVhcS8wQ25RQTFhVlRQZWxndFRBakpFaVY3VzZlQWZiZWgvSGxLZW8vVEJnVmdudTRXaVIKTEZOWFl1L1RkUUJjanZ2WFE2MklUMzZkekNGb2pLN0E2U29hUnkydFFld0E2ZWxHekJOaUlEcmcyT0VOQldJagpDZXJoYkxIdDBSN0U2Y2t0Z3dZVHprV082QXdzRTAySjhqWWlRaEVQZWxJWTAzMGhKRHkrbzNQbDZTcC9FSldECjdDa1Z5KzVCTFlBbWszSUMyVjk0M0RJN1RPQUxYRUtIOXFYVHB6Q0Jld1lZOFpidURwM2N2OVc1VlBJdGtGUnAKL3p5VG9FTlZqVTVYSGJOcS9kZlhEMFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: tbqajlaplk30cjpsahc6\ncontexts:\n- context:\n    cluster: tbqajlaplk30cjpsahc6\n    user: aws-dynamic-token\n  name: tbqajlaplk30cjpsahc6\ncurrent-context: tbqajlaplk30cjpsahc6\nusers:\n- name: aws-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tbqajlaplk30cjpsahc6/token?ConnectionName=aws-ap-northeast-2\\\"\"\n"
   },
   "addons": {
     "keyValueList": [
       {
         "key": "AddonArn",
-        "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/aws-ebs-csi-driver/c4d00ee7-d2c7-dc8b-57d9-c1e0e7d04dc5"
+        "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbqajlaplk30cjpsahc6/aws-ebs-csi-driver/32d01118-7bee-835a-b742-59eb902f372c"
       },
       {
         "key": "AddonName",
@@ -504,11 +504,11 @@
       },
       {
         "key": "ClusterName",
-        "value": "tbdlsc18uvrh6drbdv70"
+        "value": "tbqajlaplk30cjpsahc6"
       },
       {
         "key": "CreatedAt",
-        "value": "2026-08-20T06:15:42.923Z"
+        "value": "2026-08-21T02:40:29.969Z"
       },
       {
         "key": "Health",
@@ -516,7 +516,7 @@
       },
       {
         "key": "ModifiedAt",
-        "value": "2026-08-20T06:15:42.94Z"
+        "value": "2026-08-21T02:40:30.04Z"
       },
       {
         "key": "Status",
@@ -524,7 +524,7 @@
       },
       {
         "key": "AddonArn",
-        "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/eks-pod-identity-agent/aed00ee7-d395-8f71-c953-1ddd85bae1aa"
+        "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbqajlaplk30cjpsahc6/eks-pod-identity-agent/68d01118-7d04-d95c-159d-92ab6f64aff9"
       },
       {
         "key": "AddonName",
@@ -536,11 +536,11 @@
       },
       {
         "key": "ClusterName",
-        "value": "tbdlsc18uvrh6drbdv70"
+        "value": "tbqajlaplk30cjpsahc6"
       },
       {
         "key": "CreatedAt",
-        "value": "2026-08-20T06:15:43.325Z"
+        "value": "2026-08-21T02:40:30.382Z"
       },
       {
         "key": "Health",
@@ -548,36 +548,36 @@
       },
       {
         "key": "ModifiedAt",
-        "value": "2026-08-20T06:15:43.34Z"
+        "value": "2026-08-21T02:48:13.224Z"
       },
       {
         "key": "Status",
-        "value": "CREATING"
+        "value": "ACTIVE"
       }
     ]
   },
   "status": "Active",
-  "createdTime": "2026-08-20T06:15:41.284Z",
+  "createdTime": "2026-08-21T02:40:28.745Z",
   "keyValueList": [
     {
       "key": "Arn",
-      "value": "arn:aws:eks:ap-northeast-2:635484366616:cluster/tbdlsc18uvrh6drbdv70"
+      "value": "arn:aws:eks:ap-northeast-2:635484366616:cluster/tbqajlaplk30cjpsahc6"
     },
     {
       "key": "CertificateAuthority",
-      "value": "{Data:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
+      "value": "{Data:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRYk9HOENhQ05pQkU2UGVpTEFaYUE5VEFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1UQXlOREF6T1ZvWERUTXhNRGd5TURBeQpOREF6T1Zvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBTWpoc1puYnMrK1NoMEVvd2ROVzdJL2x2RHdIdTNjREIvTkY0NHJMeFJkZWlMTHMKQ2d6MnZkdWY0aHR4cWhJRU1lb0ZkTk9VMkZiR2kyeE9rNWlGdkhYQWtFV1VPTHgxdldxNzU2bUczTk9RRTBTaAorMzlqOGZJOUh1Yk9Qc2lLZlhJN1lxM3o4YWF3TzRFeE1lSFdxNlhIZlBvdnIzR29ZaFFyL2txK3NJUWFpYnQ2CncxL2N1bTJzejJXMFo3bXR1Vjlub2ZTWGxucEtIOTl1Q1ZXalIvamVEWUNMR0VudExkWnQ0THhxc0h5dWtpeEcKRFk2T2tXQ29jMFRRTlpSSWRzeVZ0MUZmRnV4dFdoVDQvRkhhMFlkL09OK2FGek1KZmhtV2ZIWkRaN1NzV1FwMgplR3ZpNHhtS0VCRzd4TUpyL0xtM2w4RFNjUEt4NEJjV2VuUi9JLzBDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkNjaWxHTGFCREo3MjYxM3ZDRloKdUtjQkJpMXNNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBSHIzUGZEcFZ0THplWDV1emJKRlFkUkNNa3ZJckx2WHg0UlhTa1lNc3B4Nld0U2RRMGE5Q2cyMlZrR1dtaGdNCnRjMXo2dmxNcHVZUGVhcS8wQ25RQTFhVlRQZWxndFRBakpFaVY3VzZlQWZiZWgvSGxLZW8vVEJnVmdudTRXaVIKTEZOWFl1L1RkUUJjanZ2WFE2MklUMzZkekNGb2pLN0E2U29hUnkydFFld0E2ZWxHekJOaUlEcmcyT0VOQldJagpDZXJoYkxIdDBSN0U2Y2t0Z3dZVHprV082QXdzRTAySjhqWWlRaEVQZWxJWTAzMGhKRHkrbzNQbDZTcC9FSldECjdDa1Z5KzVCTFlBbWszSUMyVjk0M0RJN1RPQUxYRUtIOXFYVHB6Q0Jld1lZOFpidURwM2N2OVc1VlBJdGtGUnAKL3p5VG9FTlZqVTVYSGJOcS9kZlhEMFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
     },
     {
       "key": "CreatedAt",
-      "value": "2026-08-20T06:15:41.284Z"
+      "value": "2026-08-21T02:40:28.745Z"
     },
     {
       "key": "Endpoint",
-      "value": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com"
+      "value": "https://A42C0404A862C06B0E9998C1EC42D7E1.gr7.ap-northeast-2.eks.amazonaws.com"
     },
     {
       "key": "Identity",
-      "value": "{Oidc:{Issuer:https://oidc.eks.ap-northeast-2.amazonaws.com/id/A1E5A99B85D7AEE154F241C6E2E2D464}}"
+      "value": "{Oidc:{Issuer:https://oidc.eks.ap-northeast-2.amazonaws.com/id/A42C0404A862C06B0E9998C1EC42D7E1}}"
     },
     {
       "key": "KubernetesNetworkConfig",
@@ -589,7 +589,7 @@
     },
     {
       "key": "Name",
-      "value": "tbdlsc18uvrh6drbdv70"
+      "value": "tbqajlaplk30cjpsahc6"
     },
     {
       "key": "PlatformVersion",
@@ -597,7 +597,7 @@
     },
     {
       "key": "ResourcesVpcConfig",
-      "value": "{ClusterSecurityGroupId:sg-0335b04180c79d7ca,EndpointPrivateAccess:false,EndpointPublicAccess:true,PublicAccessCidrs:[0.0.0.0/0],SecurityGroupIds:[sg-00b0fa9c3c57c2cc5],SubnetIds:[subnet-05247863bd834f2df,subnet-0b020a2249bb6475b],VpcId:vpc-01af9f247d39edce6}"
+      "value": "{ClusterSecurityGroupId:sg-0467761160db4a2ff,EndpointPrivateAccess:false,EndpointPublicAccess:true,PublicAccessCidrs:[0.0.0.0/0],SecurityGroupIds:[sg-00b0fa9c3c57c2cc5],SubnetIds:[subnet-05247863bd834f2df,subnet-0b020a2249bb6475b],VpcId:vpc-01af9f247d39edce6}"
     },
     {
       "key": "RoleArn",
@@ -609,19 +609,19 @@
     },
     {
       "key": "Tags",
-      "value": "{Name:tbdlsc18uvrh6drbdv70,sys.id:mig01-on-prem-k8s-cluster,sys.uid:tbdlsc18uvrh6drbdv70}"
+      "value": "{Name:tbqajlaplk30cjpsahc6,sys.cspResourceId:tbqajlaplk30cjpsahc6,sys.cspResourceName:tbqajlaplk30cjpsahc6,sys.labelType:k8s,sys.namespace:mig01}"
     },
     {
       "key": "Version",
       "value": "1.33"
     }
   ],
-  "cspResourceName": "tbdlsc18uvrh6drbdv70",
-  "cspResourceId": "tbdlsc18uvrh6drbdv70",
+  "cspResourceName": "tbqajlaplk30cjpsahc6",
+  "cspResourceId": "tbqajlaplk30cjpsahc6",
   "spiderViewK8sClusterDetail": {
     "IId": {
-      "NameId": "tbdlsc18uvrh6drbdv70",
-      "SystemId": "tbdlsc18uvrh6drbdv70"
+      "NameId": "tbqajlaplk30cjpsahc6",
+      "SystemId": "tbqajlaplk30cjpsahc6"
     },
     "Version": "1.33",
     "Network": {
@@ -648,7 +648,7 @@
       "KeyValueList": [
         {
           "key": "ClusterSecurityGroupId",
-          "value": "sg-0335b04180c79d7ca"
+          "value": "sg-0467761160db4a2ff"
         },
         {
           "key": "EndpointPrivateAccess",
@@ -699,12 +699,12 @@
         "Status": "Active",
         "Nodes": [
           {
-            "NameId": "i-031447656bc5f8abf",
-            "SystemId": "i-031447656bc5f8abf"
+            "NameId": "i-03dc94bf5dbd38c86",
+            "SystemId": "i-03dc94bf5dbd38c86"
           },
           {
-            "NameId": "i-0e3c3fffd635b89bb",
-            "SystemId": "i-0e3c3fffd635b89bb"
+            "NameId": "i-0bf3d6c84a78defb4",
+            "SystemId": "i-0bf3d6c84a78defb4"
           }
         ],
         "KeyValueList": [
@@ -750,24 +750,24 @@
           },
           {
             "key": "Nodes",
-            "value": "{NameId:,SystemId:i-031447656bc5f8abf}; {NameId:,SystemId:i-0e3c3fffd635b89bb}"
+            "value": "{NameId:,SystemId:i-03dc94bf5dbd38c86}; {NameId:,SystemId:i-0bf3d6c84a78defb4}"
           },
           {
             "key": "KeyValueList",
-            "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbdlsc18uvrh6drbdv70}; {Key:CreatedAt,Value:2026-08-20T06:21:32.328Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-20T06:22:43.889Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbdlsc18uvrh6drbdv70/workers1/5cd00eea-7860-d7b8-7846-0ab62961a4b5}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-5cd00eea-7860-d7b8-7846-0ab62961a4b5}],RemoteAccessSecurityGroup:sg-074607780cfdd6b92}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
+            "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbqajlaplk30cjpsahc6}; {Key:CreatedAt,Value:2026-08-21T02:47:11.123Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-21T02:48:53.478Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbqajlaplk30cjpsahc6/workers1/8ed0111b-86ff-c035-79d7-ce32357dd95a}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-8ed0111b-86ff-c035-79d7-ce32357dd95a}],RemoteAccessSecurityGroup:sg-08bb5f8b9279adcc9}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
           }
         ]
       }
     ],
     "AccessInfo": {
-      "Endpoint": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com",
-      "Kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: tbdlsc18uvrh6drbdv70\ncontexts:\n- context:\n    cluster: tbdlsc18uvrh6drbdv70\n    user: aws-dynamic-token\n  name: tbdlsc18uvrh6drbdv70\ncurrent-context: tbdlsc18uvrh6drbdv70\nusers:\n- name: aws-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tbdlsc18uvrh6drbdv70/token?ConnectionName=aws-ap-northeast-2\\\"\"\n"
+      "Endpoint": "https://A42C0404A862C06B0E9998C1EC42D7E1.gr7.ap-northeast-2.eks.amazonaws.com",
+      "Kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://A42C0404A862C06B0E9998C1EC42D7E1.gr7.ap-northeast-2.eks.amazonaws.com\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRYk9HOENhQ05pQkU2UGVpTEFaYUE5VEFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1UQXlOREF6T1ZvWERUTXhNRGd5TURBeQpOREF6T1Zvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBTWpoc1puYnMrK1NoMEVvd2ROVzdJL2x2RHdIdTNjREIvTkY0NHJMeFJkZWlMTHMKQ2d6MnZkdWY0aHR4cWhJRU1lb0ZkTk9VMkZiR2kyeE9rNWlGdkhYQWtFV1VPTHgxdldxNzU2bUczTk9RRTBTaAorMzlqOGZJOUh1Yk9Qc2lLZlhJN1lxM3o4YWF3TzRFeE1lSFdxNlhIZlBvdnIzR29ZaFFyL2txK3NJUWFpYnQ2CncxL2N1bTJzejJXMFo3bXR1Vjlub2ZTWGxucEtIOTl1Q1ZXalIvamVEWUNMR0VudExkWnQ0THhxc0h5dWtpeEcKRFk2T2tXQ29jMFRRTlpSSWRzeVZ0MUZmRnV4dFdoVDQvRkhhMFlkL09OK2FGek1KZmhtV2ZIWkRaN1NzV1FwMgplR3ZpNHhtS0VCRzd4TUpyL0xtM2w4RFNjUEt4NEJjV2VuUi9JLzBDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkNjaWxHTGFCREo3MjYxM3ZDRloKdUtjQkJpMXNNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBSHIzUGZEcFZ0THplWDV1emJKRlFkUkNNa3ZJckx2WHg0UlhTa1lNc3B4Nld0U2RRMGE5Q2cyMlZrR1dtaGdNCnRjMXo2dmxNcHVZUGVhcS8wQ25RQTFhVlRQZWxndFRBakpFaVY3VzZlQWZiZWgvSGxLZW8vVEJnVmdudTRXaVIKTEZOWFl1L1RkUUJjanZ2WFE2MklUMzZkekNGb2pLN0E2U29hUnkydFFld0E2ZWxHekJOaUlEcmcyT0VOQldJagpDZXJoYkxIdDBSN0U2Y2t0Z3dZVHprV082QXdzRTAySjhqWWlRaEVQZWxJWTAzMGhKRHkrbzNQbDZTcC9FSldECjdDa1Z5KzVCTFlBbWszSUMyVjk0M0RJN1RPQUxYRUtIOXFYVHB6Q0Jld1lZOFpidURwM2N2OVc1VlBJdGtGUnAKL3p5VG9FTlZqVTVYSGJOcS9kZlhEMFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: tbqajlaplk30cjpsahc6\ncontexts:\n- context:\n    cluster: tbqajlaplk30cjpsahc6\n    user: aws-dynamic-token\n  name: tbqajlaplk30cjpsahc6\ncurrent-context: tbqajlaplk30cjpsahc6\nusers:\n- name: aws-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tbqajlaplk30cjpsahc6/token?ConnectionName=aws-ap-northeast-2\\\"\"\n"
     },
     "Addons": {
       "KeyValueList": [
         {
           "key": "AddonArn",
-          "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/aws-ebs-csi-driver/c4d00ee7-d2c7-dc8b-57d9-c1e0e7d04dc5"
+          "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbqajlaplk30cjpsahc6/aws-ebs-csi-driver/32d01118-7bee-835a-b742-59eb902f372c"
         },
         {
           "key": "AddonName",
@@ -779,11 +779,11 @@
         },
         {
           "key": "ClusterName",
-          "value": "tbdlsc18uvrh6drbdv70"
+          "value": "tbqajlaplk30cjpsahc6"
         },
         {
           "key": "CreatedAt",
-          "value": "2026-08-20T06:15:42.923Z"
+          "value": "2026-08-21T02:40:29.969Z"
         },
         {
           "key": "Health",
@@ -791,7 +791,7 @@
         },
         {
           "key": "ModifiedAt",
-          "value": "2026-08-20T06:15:42.94Z"
+          "value": "2026-08-21T02:40:30.04Z"
         },
         {
           "key": "Status",
@@ -799,7 +799,7 @@
         },
         {
           "key": "AddonArn",
-          "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/eks-pod-identity-agent/aed00ee7-d395-8f71-c953-1ddd85bae1aa"
+          "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbqajlaplk30cjpsahc6/eks-pod-identity-agent/68d01118-7d04-d95c-159d-92ab6f64aff9"
         },
         {
           "key": "AddonName",
@@ -811,11 +811,11 @@
         },
         {
           "key": "ClusterName",
-          "value": "tbdlsc18uvrh6drbdv70"
+          "value": "tbqajlaplk30cjpsahc6"
         },
         {
           "key": "CreatedAt",
-          "value": "2026-08-20T06:15:43.325Z"
+          "value": "2026-08-21T02:40:30.382Z"
         },
         {
           "key": "Health",
@@ -823,36 +823,36 @@
         },
         {
           "key": "ModifiedAt",
-          "value": "2026-08-20T06:15:43.34Z"
+          "value": "2026-08-21T02:48:13.224Z"
         },
         {
           "key": "Status",
-          "value": "CREATING"
+          "value": "ACTIVE"
         }
       ]
     },
     "Status": "Active",
-    "CreatedTime": "2026-08-20T06:15:41.284Z",
+    "CreatedTime": "2026-08-21T02:40:28.745Z",
     "KeyValueList": [
       {
         "key": "Arn",
-        "value": "arn:aws:eks:ap-northeast-2:635484366616:cluster/tbdlsc18uvrh6drbdv70"
+        "value": "arn:aws:eks:ap-northeast-2:635484366616:cluster/tbqajlaplk30cjpsahc6"
       },
       {
         "key": "CertificateAuthority",
-        "value": "{Data:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
+        "value": "{Data:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRYk9HOENhQ05pQkU2UGVpTEFaYUE5VEFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1UQXlOREF6T1ZvWERUTXhNRGd5TURBeQpOREF6T1Zvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBTWpoc1puYnMrK1NoMEVvd2ROVzdJL2x2RHdIdTNjREIvTkY0NHJMeFJkZWlMTHMKQ2d6MnZkdWY0aHR4cWhJRU1lb0ZkTk9VMkZiR2kyeE9rNWlGdkhYQWtFV1VPTHgxdldxNzU2bUczTk9RRTBTaAorMzlqOGZJOUh1Yk9Qc2lLZlhJN1lxM3o4YWF3TzRFeE1lSFdxNlhIZlBvdnIzR29ZaFFyL2txK3NJUWFpYnQ2CncxL2N1bTJzejJXMFo3bXR1Vjlub2ZTWGxucEtIOTl1Q1ZXalIvamVEWUNMR0VudExkWnQ0THhxc0h5dWtpeEcKRFk2T2tXQ29jMFRRTlpSSWRzeVZ0MUZmRnV4dFdoVDQvRkhhMFlkL09OK2FGek1KZmhtV2ZIWkRaN1NzV1FwMgplR3ZpNHhtS0VCRzd4TUpyL0xtM2w4RFNjUEt4NEJjV2VuUi9JLzBDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkNjaWxHTGFCREo3MjYxM3ZDRloKdUtjQkJpMXNNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBSHIzUGZEcFZ0THplWDV1emJKRlFkUkNNa3ZJckx2WHg0UlhTa1lNc3B4Nld0U2RRMGE5Q2cyMlZrR1dtaGdNCnRjMXo2dmxNcHVZUGVhcS8wQ25RQTFhVlRQZWxndFRBakpFaVY3VzZlQWZiZWgvSGxLZW8vVEJnVmdudTRXaVIKTEZOWFl1L1RkUUJjanZ2WFE2MklUMzZkekNGb2pLN0E2U29hUnkydFFld0E2ZWxHekJOaUlEcmcyT0VOQldJagpDZXJoYkxIdDBSN0U2Y2t0Z3dZVHprV082QXdzRTAySjhqWWlRaEVQZWxJWTAzMGhKRHkrbzNQbDZTcC9FSldECjdDa1Z5KzVCTFlBbWszSUMyVjk0M0RJN1RPQUxYRUtIOXFYVHB6Q0Jld1lZOFpidURwM2N2OVc1VlBJdGtGUnAKL3p5VG9FTlZqVTVYSGJOcS9kZlhEMFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
       },
       {
         "key": "CreatedAt",
-        "value": "2026-08-20T06:15:41.284Z"
+        "value": "2026-08-21T02:40:28.745Z"
       },
       {
         "key": "Endpoint",
-        "value": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com"
+        "value": "https://A42C0404A862C06B0E9998C1EC42D7E1.gr7.ap-northeast-2.eks.amazonaws.com"
       },
       {
         "key": "Identity",
-        "value": "{Oidc:{Issuer:https://oidc.eks.ap-northeast-2.amazonaws.com/id/A1E5A99B85D7AEE154F241C6E2E2D464}}"
+        "value": "{Oidc:{Issuer:https://oidc.eks.ap-northeast-2.amazonaws.com/id/A42C0404A862C06B0E9998C1EC42D7E1}}"
       },
       {
         "key": "KubernetesNetworkConfig",
@@ -864,7 +864,7 @@
       },
       {
         "key": "Name",
-        "value": "tbdlsc18uvrh6drbdv70"
+        "value": "tbqajlaplk30cjpsahc6"
       },
       {
         "key": "PlatformVersion",
@@ -872,7 +872,7 @@
       },
       {
         "key": "ResourcesVpcConfig",
-        "value": "{ClusterSecurityGroupId:sg-0335b04180c79d7ca,EndpointPrivateAccess:false,EndpointPublicAccess:true,PublicAccessCidrs:[0.0.0.0/0],SecurityGroupIds:[sg-00b0fa9c3c57c2cc5],SubnetIds:[subnet-05247863bd834f2df,subnet-0b020a2249bb6475b],VpcId:vpc-01af9f247d39edce6}"
+        "value": "{ClusterSecurityGroupId:sg-0467761160db4a2ff,EndpointPrivateAccess:false,EndpointPublicAccess:true,PublicAccessCidrs:[0.0.0.0/0],SecurityGroupIds:[sg-00b0fa9c3c57c2cc5],SubnetIds:[subnet-05247863bd834f2df,subnet-0b020a2249bb6475b],VpcId:vpc-01af9f247d39edce6}"
       },
       {
         "key": "RoleArn",
@@ -884,7 +884,7 @@
       },
       {
         "key": "Tags",
-        "value": "{Name:tbdlsc18uvrh6drbdv70,sys.id:mig01-on-prem-k8s-cluster,sys.uid:tbdlsc18uvrh6drbdv70}"
+        "value": "{Name:tbqajlaplk30cjpsahc6,sys.cspResourceId:tbqajlaplk30cjpsahc6,sys.cspResourceName:tbqajlaplk30cjpsahc6,sys.labelType:k8s,sys.namespace:mig01}"
       },
       {
         "key": "Version",

--- a/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-aws.md
+++ b/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-aws.md
@@ -1,0 +1,899 @@
+# CM-Beetle K8s Infra Migration Test Results — AWS-Seoul
+
+> [!NOTE]
+> Full lifecycle against a real CSP: recommend → migrate → list → get (verified against
+> the recommendation) → delete → residual resource check.
+
+## Environment
+
+- CSP / Region: aws / ap-northeast-2
+- CM-Beetle URL: http://localhost:8056
+- CM-Beetle Version: v0.6.0
+- Git Commit: 803afb4
+- Namespace: mig01
+- Test Date: 2026-08-20 15:15:35 KST
+- Cluster ID: mig01-on-prem-k8s-cluster
+
+## Test Results Summary
+
+| Step | Description | Status | Duration |
+|------|-------------|--------|----------|
+| 1 | POST /recommendation/k8sCluster | ✅ **PASS** | 931ms |
+| 2 | POST /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 7m30.093s |
+| 3 | GET /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 1ms |
+| 4 | GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation | ✅ **PASS** | 1.515s |
+| 5 | Workload verification (kubeconfig -> K8s API -> nginx) | ✅ **PASS** | 1m43.493s |
+| 6 | DELETE /migration/ns/{nsId}/k8sCluster/{id} | ✅ **PASS** | 9m16.536s |
+| 7 | Residual resource check (Tumblebug) | ✅ **PASS** | 3ms |
+
+**Overall Result**: 7/7 steps passed ✅
+
+**Total Duration**: 18m32s
+
+---
+
+## Step Details
+
+### Step 1 — POST /recommendation/k8sCluster
+
+- **Duration**: 931ms
+- **Status Code**: 200
+
+- ℹ️  cluster: on-prem-k8s-cluster (version 1.33)
+- ℹ️  node groups: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge nodes=2
+
+### Step 2 — POST /migration/ns/{nsId}/k8sCluster
+
+- **Duration**: 7m30.093s
+- **Status Code**: 202
+
+- ℹ️  nameSeed: mig01
+- ℹ️  async reqId: 1787206536789845713
+- ℹ️  cluster id: mig01-on-prem-k8s-cluster
+- ℹ️  elapsed: 7m30s
+- ✅ status: Active
+
+### Step 3 — GET /migration/ns/{nsId}/k8sCluster
+
+- **Duration**: 1ms
+- **Status Code**: 200
+
+- ✅ migrated cluster present in list (3 total)
+
+### Step 4 — GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation
+
+- **Duration**: 1.515s
+- **Status Code**: 200
+
+- ✅ status: Active
+- ✅ node group count matches recommendation: 1
+- ✅ node group "workers1" matches (spec=aws+ap-northeast-2+c5a.xlarge, nodes=2)
+- ✅ version: 1.33 (recommended 1.33)
+
+### Step 5 — Workload verification (kubeconfig -> K8s API -> nginx)
+
+- **Duration**: 1m43.493s
+
+- ✅ kubeconfig obtained (server: https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com)
+- ℹ️  auth method: exec credential plugin
+- ✅ cluster token obtained from Tumblebug
+- ✅ API server reachable (v1.33.13-eks-bca9cf6)
+- ✅ 2 node(s) Ready, matching the recommendation
+- ✅ nginx Deployment created
+- ✅ nginx pod Running (attempt 1)
+- ✅ LoadBalancer Service created
+- ✅ LoadBalancer address assigned: a744452d05ccb4780ba3bb83a48a7239-1969825577.ap-northeast-2.elb.amazonaws.com
+- ✅ nginx served over the LoadBalancer at http://a744452d05ccb4780ba3bb83a48a7239-1969825577.ap-northeast-2.elb.amazonaws.com/ (attempt 6)
+- ✅ LoadBalancer Service removed
+- ✅ nginx Deployment removed
+
+### Step 6 — DELETE /migration/ns/{nsId}/k8sCluster/{id}
+
+- **Duration**: 9m16.536s
+- **Status Code**: 200
+
+- ✅ deleted on attempt 1 (9m16s)
+
+### Step 7 — Residual resource check (Tumblebug)
+
+- **Duration**: 3ms
+
+- ℹ️  VNet mig01-k8s-vpc still exists (known gap)
+- ℹ️  SecurityGroup mig01-k8s-sg still exists (known gap)
+- ℹ️  SshKey mig01-k8s-sshkey still exists (known gap)
+
+## Recommendation (input to migration)
+
+<details>
+  <summary> <ins>Click to see the recommendation</ins> </summary>
+
+```json
+{
+  "status": "recommended",
+  "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+  "targetCloud": {
+    "csp": "aws",
+    "region": "ap-northeast-2"
+  },
+  "targetInfra": {
+    "name": "",
+    "installMonAgent": "",
+    "label": null,
+    "systemLabel": "",
+    "description": "",
+    "nodeGroups": null,
+    "policyOnPartialFailure": ""
+  },
+  "targetVNet": {
+    "name": "k8s-vpc",
+    "connectionName": "aws-ap-northeast-2",
+    "cidrBlock": "10.0.0.0/22",
+    "subnetInfoList": [
+      {
+        "name": "k8s-subnet-a",
+        "ipv4_CIDR": "10.0.1.0/24",
+        "zone": "ap-northeast-2a"
+      },
+      {
+        "name": "k8s-subnet-b",
+        "ipv4_CIDR": "10.0.2.0/24",
+        "zone": "ap-northeast-2b"
+      }
+    ],
+    "description": "VPC for migrated K8s cluster"
+  },
+  "targetSshKey": {
+    "name": "k8s-sshkey",
+    "connectionName": "aws-ap-northeast-2",
+    "description": "SSH key for K8s worker nodes",
+    "cspResourceId": "",
+    "fingerprint": "",
+    "username": "",
+    "verifiedUsername": "",
+    "publicKey": "",
+    "privateKey": ""
+  },
+  "targetSpecList": null,
+  "targetOsImageList": null,
+  "targetSecurityGroupList": [
+    {
+      "name": "k8s-sg",
+      "connectionName": "aws-ap-northeast-2",
+      "vNetId": "INSERT_YOUR_VNET_ID",
+      "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+      "firewallRules": [
+        {
+          "Ports": "22",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "0.0.0.0/0"
+        },
+        {
+          "Ports": "10250",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "10.0.0.0/24"
+        },
+        {
+          "Ports": "30000-32767",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "0.0.0.0/0"
+        },
+        {
+          "Ports": "1-65535",
+          "Protocol": "TCP",
+          "Direction": "outbound",
+          "CIDR": "0.0.0.0/0"
+        }
+      ],
+      "cspResourceId": ""
+    }
+  ],
+  "targetK8sCluster": {
+    "connectionName": "aws-ap-northeast-2",
+    "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+    "name": "on-prem-k8s-cluster",
+    "version": "1.33",
+    "vNetId": "",
+    "subnetIds": null,
+    "securityGroupIds": null,
+    "k8sNodeGroupList": [
+      {
+        "name": "workers1",
+        "imageId": "default",
+        "specId": "aws+ap-northeast-2+c5a.xlarge",
+        "rootDiskType": "default",
+        "rootDiskSize": 100,
+        "sshKeyId": "",
+        "onAutoScaling": "false",
+        "desiredNodeSize": 2,
+        "minNodeSize": 2,
+        "maxNodeSize": 2,
+        "label": null,
+        "description": "Worker node group migrated from on-premise (2 nodes)"
+      }
+    ],
+    "cspResourceId": "",
+    "label": null,
+    "systemLabel": ""
+  }
+}
+```
+
+</details>
+
+## Created Cluster
+
+<details>
+  <summary> <ins>Click to see the cluster info</ins> </summary>
+
+```json
+{
+  "resourceType": "k8s",
+  "id": "mig01-on-prem-k8s-cluster",
+  "uid": "tbdlsc18uvrh6drbdv70",
+  "name": "mig01-on-prem-k8s-cluster",
+  "connectionName": "aws-ap-northeast-2",
+  "connectionConfig": {
+    "configName": "aws-ap-northeast-2",
+    "providerName": "aws",
+    "driverName": "aws-driver-v1.0.so",
+    "credentialName": "aws",
+    "credentialHolder": "admin",
+    "regionZoneInfoName": "aws-ap-northeast-2",
+    "regionZoneInfo": {
+      "assignedRegion": "ap-northeast-2",
+      "assignedZone": "ap-northeast-2a"
+    },
+    "regionDetail": {
+      "regionId": "ap-northeast-2",
+      "regionName": "ap-northeast-2",
+      "description": "Asia Pacific (Seoul)",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.36,
+        "longitude": 126.78
+      },
+      "zones": [
+        "ap-northeast-2a",
+        "ap-northeast-2b",
+        "ap-northeast-2c",
+        "ap-northeast-2d"
+      ]
+    },
+    "regionRepresentative": true,
+    "verified": true
+  },
+  "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+  "systemMessage": "",
+  "label": {
+    "Name": "tbdlsc18uvrh6drbdv70",
+    "sys.connectionName": "aws-ap-northeast-2",
+    "sys.createdTime": "2026-08-20 06:15:41.284 +0000 UTC",
+    "sys.cspResourceId": "tbdlsc18uvrh6drbdv70",
+    "sys.cspResourceName": "tbdlsc18uvrh6drbdv70",
+    "sys.description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+    "sys.id": "mig01-on-prem-k8s-cluster",
+    "sys.labelType": "k8s",
+    "sys.manager": "cb-tumblebug",
+    "sys.name": "mig01-on-prem-k8s-cluster",
+    "sys.namespace": "mig01",
+    "sys.uid": "tbdlsc18uvrh6drbdv70",
+    "sys.version": "1.33"
+  },
+  "systemLabel": "",
+  "version": "1.33",
+  "network": {
+    "vNetId": "mig01-k8s-vpc",
+    "subnetIds": [
+      "mig01-k8s-subnet-a",
+      "mig01-k8s-subnet-b"
+    ],
+    "securityGroupIds": [
+      "mig01-k8s-sg"
+    ],
+    "keyValueList": [
+      {
+        "key": "ClusterSecurityGroupId",
+        "value": "sg-0335b04180c79d7ca"
+      },
+      {
+        "key": "EndpointPrivateAccess",
+        "value": "false"
+      },
+      {
+        "key": "EndpointPublicAccess",
+        "value": "true"
+      },
+      {
+        "key": "PublicAccessCidrs",
+        "value": "0.0.0.0/0"
+      },
+      {
+        "key": "SecurityGroupIds",
+        "value": "sg-00b0fa9c3c57c2cc5"
+      },
+      {
+        "key": "SubnetIds",
+        "value": "subnet-05247863bd834f2df; subnet-0b020a2249bb6475b"
+      },
+      {
+        "key": "VpcId",
+        "value": "vpc-01af9f247d39edce6"
+      }
+    ]
+  },
+  "k8sNodeGroupList": [
+    {
+      "id": "workers1",
+      "name": "workers1",
+      "imageId": "default",
+      "specId": "aws+ap-northeast-2+c5a.xlarge",
+      "rootDiskType": "",
+      "rootDiskSize": 100,
+      "sshKeyId": "mig01-k8s-sshkey",
+      "onAutoScaling": false,
+      "desiredNodeSize": 2,
+      "minNodeSize": 2,
+      "maxNodeSize": 2,
+      "status": "Active",
+      "k8sNodes": [
+        {
+          "cspResourceName": "i-031447656bc5f8abf",
+          "cspResourceId": "i-031447656bc5f8abf"
+        },
+        {
+          "cspResourceName": "i-0e3c3fffd635b89bb",
+          "cspResourceId": "i-0e3c3fffd635b89bb"
+        }
+      ],
+      "keyValueList": [
+        {
+          "key": "IId",
+          "value": "{NameId:workers1,SystemId:workers1}"
+        },
+        {
+          "key": "ImageIID",
+          "value": "{NameId:AL2023_x86_64_STANDARD,SystemId:}"
+        },
+        {
+          "key": "VMSpecName",
+          "value": "c5a.xlarge"
+        },
+        {
+          "key": "RootDiskSize",
+          "value": "100"
+        },
+        {
+          "key": "KeyPairIID",
+          "value": "{NameId:,SystemId:tbdn1fr85uqtviuhtgle}"
+        },
+        {
+          "key": "OnAutoScaling",
+          "value": "false"
+        },
+        {
+          "key": "DesiredNodeSize",
+          "value": "2"
+        },
+        {
+          "key": "MinNodeSize",
+          "value": "2"
+        },
+        {
+          "key": "MaxNodeSize",
+          "value": "2"
+        },
+        {
+          "key": "Status",
+          "value": "Active"
+        },
+        {
+          "key": "Nodes",
+          "value": "{NameId:,SystemId:i-031447656bc5f8abf}; {NameId:,SystemId:i-0e3c3fffd635b89bb}"
+        },
+        {
+          "key": "KeyValueList",
+          "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbdlsc18uvrh6drbdv70}; {Key:CreatedAt,Value:2026-08-20T06:21:32.328Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-20T06:22:43.889Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbdlsc18uvrh6drbdv70/workers1/5cd00eea-7860-d7b8-7846-0ab62961a4b5}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-5cd00eea-7860-d7b8-7846-0ab62961a4b5}],RemoteAccessSecurityGroup:sg-074607780cfdd6b92}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
+        }
+      ],
+      "cspResourceName": "workers1",
+      "cspResourceId": "workers1",
+      "spiderViewK8sNodeGroupDetail": {
+        "IId": {
+          "NameId": "workers1",
+          "SystemId": "workers1"
+        },
+        "ImageIID": {
+          "NameId": "",
+          "SystemId": ""
+        },
+        "VMSpecName": "c5a.xlarge",
+        "RootDiskSize": "100",
+        "KeyPairIID": {
+          "NameId": "tbdn1fr85uqtviuhtgle",
+          "SystemId": "tbdn1fr85uqtviuhtgle"
+        },
+        "OnAutoScaling": false,
+        "DesiredNodeSize": 2,
+        "MinNodeSize": 2,
+        "MaxNodeSize": 2,
+        "Status": "Active",
+        "Nodes": [
+          {
+            "NameId": "i-031447656bc5f8abf",
+            "SystemId": "i-031447656bc5f8abf"
+          },
+          {
+            "NameId": "i-0e3c3fffd635b89bb",
+            "SystemId": "i-0e3c3fffd635b89bb"
+          }
+        ],
+        "KeyValueList": [
+          {
+            "key": "IId",
+            "value": "{NameId:workers1,SystemId:workers1}"
+          },
+          {
+            "key": "ImageIID",
+            "value": "{NameId:AL2023_x86_64_STANDARD,SystemId:}"
+          },
+          {
+            "key": "VMSpecName",
+            "value": "c5a.xlarge"
+          },
+          {
+            "key": "RootDiskSize",
+            "value": "100"
+          },
+          {
+            "key": "KeyPairIID",
+            "value": "{NameId:,SystemId:tbdn1fr85uqtviuhtgle}"
+          },
+          {
+            "key": "OnAutoScaling",
+            "value": "false"
+          },
+          {
+            "key": "DesiredNodeSize",
+            "value": "2"
+          },
+          {
+            "key": "MinNodeSize",
+            "value": "2"
+          },
+          {
+            "key": "MaxNodeSize",
+            "value": "2"
+          },
+          {
+            "key": "Status",
+            "value": "Active"
+          },
+          {
+            "key": "Nodes",
+            "value": "{NameId:,SystemId:i-031447656bc5f8abf}; {NameId:,SystemId:i-0e3c3fffd635b89bb}"
+          },
+          {
+            "key": "KeyValueList",
+            "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbdlsc18uvrh6drbdv70}; {Key:CreatedAt,Value:2026-08-20T06:21:32.328Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-20T06:22:43.889Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbdlsc18uvrh6drbdv70/workers1/5cd00eea-7860-d7b8-7846-0ab62961a4b5}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-5cd00eea-7860-d7b8-7846-0ab62961a4b5}],RemoteAccessSecurityGroup:sg-074607780cfdd6b92}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
+          }
+        ]
+      }
+    }
+  ],
+  "accessInfo": {
+    "endpoint": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com",
+    "kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: tbdlsc18uvrh6drbdv70\ncontexts:\n- context:\n    cluster: tbdlsc18uvrh6drbdv70\n    user: aws-dynamic-token\n  name: tbdlsc18uvrh6drbdv70\ncurrent-context: tbdlsc18uvrh6drbdv70\nusers:\n- name: aws-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tbdlsc18uvrh6drbdv70/token?ConnectionName=aws-ap-northeast-2\\\"\"\n"
+  },
+  "addons": {
+    "keyValueList": [
+      {
+        "key": "AddonArn",
+        "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/aws-ebs-csi-driver/c4d00ee7-d2c7-dc8b-57d9-c1e0e7d04dc5"
+      },
+      {
+        "key": "AddonName",
+        "value": "aws-ebs-csi-driver"
+      },
+      {
+        "key": "AddonVersion",
+        "value": "v1.64.0-eksbuild.1"
+      },
+      {
+        "key": "ClusterName",
+        "value": "tbdlsc18uvrh6drbdv70"
+      },
+      {
+        "key": "CreatedAt",
+        "value": "2026-08-20T06:15:42.923Z"
+      },
+      {
+        "key": "Health",
+        "value": "{Issues:[]}"
+      },
+      {
+        "key": "ModifiedAt",
+        "value": "2026-08-20T06:15:42.94Z"
+      },
+      {
+        "key": "Status",
+        "value": "CREATING"
+      },
+      {
+        "key": "AddonArn",
+        "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/eks-pod-identity-agent/aed00ee7-d395-8f71-c953-1ddd85bae1aa"
+      },
+      {
+        "key": "AddonName",
+        "value": "eks-pod-identity-agent"
+      },
+      {
+        "key": "AddonVersion",
+        "value": "v1.3.10-eksbuild.3"
+      },
+      {
+        "key": "ClusterName",
+        "value": "tbdlsc18uvrh6drbdv70"
+      },
+      {
+        "key": "CreatedAt",
+        "value": "2026-08-20T06:15:43.325Z"
+      },
+      {
+        "key": "Health",
+        "value": "{Issues:[]}"
+      },
+      {
+        "key": "ModifiedAt",
+        "value": "2026-08-20T06:15:43.34Z"
+      },
+      {
+        "key": "Status",
+        "value": "CREATING"
+      }
+    ]
+  },
+  "status": "Active",
+  "createdTime": "2026-08-20T06:15:41.284Z",
+  "keyValueList": [
+    {
+      "key": "Arn",
+      "value": "arn:aws:eks:ap-northeast-2:635484366616:cluster/tbdlsc18uvrh6drbdv70"
+    },
+    {
+      "key": "CertificateAuthority",
+      "value": "{Data:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
+    },
+    {
+      "key": "CreatedAt",
+      "value": "2026-08-20T06:15:41.284Z"
+    },
+    {
+      "key": "Endpoint",
+      "value": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com"
+    },
+    {
+      "key": "Identity",
+      "value": "{Oidc:{Issuer:https://oidc.eks.ap-northeast-2.amazonaws.com/id/A1E5A99B85D7AEE154F241C6E2E2D464}}"
+    },
+    {
+      "key": "KubernetesNetworkConfig",
+      "value": "{ServiceIpv4Cidr:172.20.0.0/16}"
+    },
+    {
+      "key": "Logging",
+      "value": "{ClusterLogging:[{Enabled:false,Types:[api,audit,authenticator,controllerManager,scheduler]}]}"
+    },
+    {
+      "key": "Name",
+      "value": "tbdlsc18uvrh6drbdv70"
+    },
+    {
+      "key": "PlatformVersion",
+      "value": "eks.45"
+    },
+    {
+      "key": "ResourcesVpcConfig",
+      "value": "{ClusterSecurityGroupId:sg-0335b04180c79d7ca,EndpointPrivateAccess:false,EndpointPublicAccess:true,PublicAccessCidrs:[0.0.0.0/0],SecurityGroupIds:[sg-00b0fa9c3c57c2cc5],SubnetIds:[subnet-05247863bd834f2df,subnet-0b020a2249bb6475b],VpcId:vpc-01af9f247d39edce6}"
+    },
+    {
+      "key": "RoleArn",
+      "value": "arn:aws:iam::635484366616:role/cloud-barista-eks-cluster-role"
+    },
+    {
+      "key": "Status",
+      "value": "ACTIVE"
+    },
+    {
+      "key": "Tags",
+      "value": "{Name:tbdlsc18uvrh6drbdv70,sys.id:mig01-on-prem-k8s-cluster,sys.uid:tbdlsc18uvrh6drbdv70}"
+    },
+    {
+      "key": "Version",
+      "value": "1.33"
+    }
+  ],
+  "cspResourceName": "tbdlsc18uvrh6drbdv70",
+  "cspResourceId": "tbdlsc18uvrh6drbdv70",
+  "spiderViewK8sClusterDetail": {
+    "IId": {
+      "NameId": "tbdlsc18uvrh6drbdv70",
+      "SystemId": "tbdlsc18uvrh6drbdv70"
+    },
+    "Version": "1.33",
+    "Network": {
+      "VpcIID": {
+        "NameId": "tbdmgt1mbasrbltfs1e6",
+        "SystemId": "vpc-01af9f247d39edce6"
+      },
+      "SubnetIIDs": [
+        {
+          "NameId": "tbdoke7m88osrtd6dju7",
+          "SystemId": "subnet-05247863bd834f2df"
+        },
+        {
+          "NameId": "tbv8r1cvca834kh0g8lj",
+          "SystemId": "subnet-0b020a2249bb6475b"
+        }
+      ],
+      "SecurityGroupIIDs": [
+        {
+          "NameId": "tb73eajo8k7k082am4s1",
+          "SystemId": "sg-00b0fa9c3c57c2cc5"
+        }
+      ],
+      "KeyValueList": [
+        {
+          "key": "ClusterSecurityGroupId",
+          "value": "sg-0335b04180c79d7ca"
+        },
+        {
+          "key": "EndpointPrivateAccess",
+          "value": "false"
+        },
+        {
+          "key": "EndpointPublicAccess",
+          "value": "true"
+        },
+        {
+          "key": "PublicAccessCidrs",
+          "value": "0.0.0.0/0"
+        },
+        {
+          "key": "SecurityGroupIds",
+          "value": "sg-00b0fa9c3c57c2cc5"
+        },
+        {
+          "key": "SubnetIds",
+          "value": "subnet-05247863bd834f2df; subnet-0b020a2249bb6475b"
+        },
+        {
+          "key": "VpcId",
+          "value": "vpc-01af9f247d39edce6"
+        }
+      ]
+    },
+    "NodeGroupList": [
+      {
+        "IId": {
+          "NameId": "workers1",
+          "SystemId": "workers1"
+        },
+        "ImageIID": {
+          "NameId": "",
+          "SystemId": ""
+        },
+        "VMSpecName": "c5a.xlarge",
+        "RootDiskSize": "100",
+        "KeyPairIID": {
+          "NameId": "tbdn1fr85uqtviuhtgle",
+          "SystemId": "tbdn1fr85uqtviuhtgle"
+        },
+        "OnAutoScaling": false,
+        "DesiredNodeSize": 2,
+        "MinNodeSize": 2,
+        "MaxNodeSize": 2,
+        "Status": "Active",
+        "Nodes": [
+          {
+            "NameId": "i-031447656bc5f8abf",
+            "SystemId": "i-031447656bc5f8abf"
+          },
+          {
+            "NameId": "i-0e3c3fffd635b89bb",
+            "SystemId": "i-0e3c3fffd635b89bb"
+          }
+        ],
+        "KeyValueList": [
+          {
+            "key": "IId",
+            "value": "{NameId:workers1,SystemId:workers1}"
+          },
+          {
+            "key": "ImageIID",
+            "value": "{NameId:AL2023_x86_64_STANDARD,SystemId:}"
+          },
+          {
+            "key": "VMSpecName",
+            "value": "c5a.xlarge"
+          },
+          {
+            "key": "RootDiskSize",
+            "value": "100"
+          },
+          {
+            "key": "KeyPairIID",
+            "value": "{NameId:,SystemId:tbdn1fr85uqtviuhtgle}"
+          },
+          {
+            "key": "OnAutoScaling",
+            "value": "false"
+          },
+          {
+            "key": "DesiredNodeSize",
+            "value": "2"
+          },
+          {
+            "key": "MinNodeSize",
+            "value": "2"
+          },
+          {
+            "key": "MaxNodeSize",
+            "value": "2"
+          },
+          {
+            "key": "Status",
+            "value": "Active"
+          },
+          {
+            "key": "Nodes",
+            "value": "{NameId:,SystemId:i-031447656bc5f8abf}; {NameId:,SystemId:i-0e3c3fffd635b89bb}"
+          },
+          {
+            "key": "KeyValueList",
+            "value": "{Key:AmiType,Value:AL2023_x86_64_STANDARD}; {Key:CapacityType,Value:ON_DEMAND}; {Key:ClusterName,Value:tbdlsc18uvrh6drbdv70}; {Key:CreatedAt,Value:2026-08-20T06:21:32.328Z}; {Key:DiskSize,Value:100}; {Key:Health,Value:{Issues:[]}}; {Key:InstanceTypes,Value:c5a.xlarge}; {Key:ModifiedAt,Value:2026-08-20T06:22:43.889Z}; {Key:NodeRole,Value:arn:aws:iam::635484366616:role/cloud-barista-eks-nodegroup-role}; {Key:NodegroupArn,Value:arn:aws:eks:ap-northeast-2:635484366616:nodegroup/tbdlsc18uvrh6drbdv70/workers1/5cd00eea-7860-d7b8-7846-0ab62961a4b5}; {Key:NodegroupName,Value:workers1}; {Key:ReleaseVersion,Value:1.33.13-20260818}; {Key:RemoteAccess,Value:{Ec2SshKey:tbdn1fr85uqtviuhtgle,SourceSecurityGroups:[sg-00b0fa9c3c57c2cc5]}}; {Key:Resources,Value:{AutoScalingGroups:[{Name:eks-workers1-5cd00eea-7860-d7b8-7846-0ab62961a4b5}],RemoteAccessSecurityGroup:sg-074607780cfdd6b92}}; {Key:ScalingConfig,Value:{DesiredSize:2,MaxSize:2,MinSize:2}}; {Key:Status,Value:ACTIVE}; {Key:Subnets,Value:subnet-05247863bd834f2df; subnet-0b020a2249bb6475b}; {Key:Tags,Value:{key:nodegroup,value:workers1}}; {Key:UpdateConfig,Value:{MaxUnavailable:1,MaxUnavailablePercentage:null}}; {Key:Version,Value:1.33}"
+          }
+        ]
+      }
+    ],
+    "AccessInfo": {
+      "Endpoint": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com",
+      "Kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: tbdlsc18uvrh6drbdv70\ncontexts:\n- context:\n    cluster: tbdlsc18uvrh6drbdv70\n    user: aws-dynamic-token\n  name: tbdlsc18uvrh6drbdv70\ncurrent-context: tbdlsc18uvrh6drbdv70\nusers:\n- name: aws-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tbdlsc18uvrh6drbdv70/token?ConnectionName=aws-ap-northeast-2\\\"\"\n"
+    },
+    "Addons": {
+      "KeyValueList": [
+        {
+          "key": "AddonArn",
+          "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/aws-ebs-csi-driver/c4d00ee7-d2c7-dc8b-57d9-c1e0e7d04dc5"
+        },
+        {
+          "key": "AddonName",
+          "value": "aws-ebs-csi-driver"
+        },
+        {
+          "key": "AddonVersion",
+          "value": "v1.64.0-eksbuild.1"
+        },
+        {
+          "key": "ClusterName",
+          "value": "tbdlsc18uvrh6drbdv70"
+        },
+        {
+          "key": "CreatedAt",
+          "value": "2026-08-20T06:15:42.923Z"
+        },
+        {
+          "key": "Health",
+          "value": "{Issues:[]}"
+        },
+        {
+          "key": "ModifiedAt",
+          "value": "2026-08-20T06:15:42.94Z"
+        },
+        {
+          "key": "Status",
+          "value": "CREATING"
+        },
+        {
+          "key": "AddonArn",
+          "value": "arn:aws:eks:ap-northeast-2:635484366616:addon/tbdlsc18uvrh6drbdv70/eks-pod-identity-agent/aed00ee7-d395-8f71-c953-1ddd85bae1aa"
+        },
+        {
+          "key": "AddonName",
+          "value": "eks-pod-identity-agent"
+        },
+        {
+          "key": "AddonVersion",
+          "value": "v1.3.10-eksbuild.3"
+        },
+        {
+          "key": "ClusterName",
+          "value": "tbdlsc18uvrh6drbdv70"
+        },
+        {
+          "key": "CreatedAt",
+          "value": "2026-08-20T06:15:43.325Z"
+        },
+        {
+          "key": "Health",
+          "value": "{Issues:[]}"
+        },
+        {
+          "key": "ModifiedAt",
+          "value": "2026-08-20T06:15:43.34Z"
+        },
+        {
+          "key": "Status",
+          "value": "CREATING"
+        }
+      ]
+    },
+    "Status": "Active",
+    "CreatedTime": "2026-08-20T06:15:41.284Z",
+    "KeyValueList": [
+      {
+        "key": "Arn",
+        "value": "arn:aws:eks:ap-northeast-2:635484366616:cluster/tbdlsc18uvrh6drbdv70"
+      },
+      {
+        "key": "CertificateAuthority",
+        "value": "{Data:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lRS3pTV1A3ODE1VTFzdUpJOXFzWE1TakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEkyTURneU1EQTJNVFUxTTFvWERUTXhNRGd4T1RBMgpNVFUxTTFvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBT3czVjd0Zk44WU1FR1E1REE2Q0dvNEhMZGJnc3hJRzZNa29qV3RycWZsZGYwb3IKOWRZc1VDc3NISGhwRklWcmNOdmkwTmJ1UVlqQlBnMmFaZUwrNXlUU05SV1pOdXJFcHZiZ1h1MDFLVlJwdVBIdwpSQjdZQUh3cllRUSt4b0JtU1dVL3ZUaVh0SzRQRWhydjU5cjlhT0l3S0p5OTFiRGV6QXhVdFlVTld3TUNEU3hOClhSTk5OdC91SC9CaDN1YnN4Um9jVUlzN3VOWnViVjBhcDNpc0NJbExRdENYeTgyRVRQRmE5OU5xa0g2Rlhwc1IKRXhGTzhWSnQ2eW1KR1hmdTBvTVFBTjYxc1RzUkwxd1BUWmxEZjJhSFdJRmxwL2dDbSt4Z2xjUnkwNVRCZkV2dwphV1BUQ0FCdE4wVTR6Y3crYU5sUmFqU29NZTlGUlFVbjhlSzVzVVVDQXdFQUFhTlpNRmN3RGdZRFZSMFBBUUgvCkJBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRZVU1KdzBYNGNmUTBpV2I0encKc21GSzYwcHVNQlVHQTFVZEVRUU9NQXlDQ210MVltVnlibVYwWlhNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS3NPSmVseWxsMlJ2TmNRTDgxbnRLMjhSRGxHSWxqNm85L3V0clhnU2YzNlFaRENiZzdIWjA3VUx4aDRxcUNvCnFTK3ZvMWVSMDZIbkZTOWJlTGFKSjJhMjhSUUhLT2NzdUFBWVNsVTcxQ0taUjcxMWlRSlQxMTRRM2VkSW9qWGYKYVlHWCs0Q1lvc0lpazdmd2hNSkxzRWM5aTRIdnRlOHNYWGtHZDQ4RncxZHlOdk5lK0J2YW1jaXk1bHd2cXRtQQpJVmlVMVdnYXl6YzYraEkrTnZyTFpVSFc0a00ybXZwa0xCWXNVdElyL05kaXBmYTZjMEsyYjg3RHJtUU9nYjNMCk5QSlZxbGQvZnByNkExT3lMT1UwdlhCNjJEWktLdDJpcWdWcUFXRG9tY2FNKzZZUDhMMmJkc3dITlVIbEczQzUKSFNZVWhtUVR5akg1TkNEWXAxRjc4eXc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
+      },
+      {
+        "key": "CreatedAt",
+        "value": "2026-08-20T06:15:41.284Z"
+      },
+      {
+        "key": "Endpoint",
+        "value": "https://A1E5A99B85D7AEE154F241C6E2E2D464.yl4.ap-northeast-2.eks.amazonaws.com"
+      },
+      {
+        "key": "Identity",
+        "value": "{Oidc:{Issuer:https://oidc.eks.ap-northeast-2.amazonaws.com/id/A1E5A99B85D7AEE154F241C6E2E2D464}}"
+      },
+      {
+        "key": "KubernetesNetworkConfig",
+        "value": "{ServiceIpv4Cidr:172.20.0.0/16}"
+      },
+      {
+        "key": "Logging",
+        "value": "{ClusterLogging:[{Enabled:false,Types:[api,audit,authenticator,controllerManager,scheduler]}]}"
+      },
+      {
+        "key": "Name",
+        "value": "tbdlsc18uvrh6drbdv70"
+      },
+      {
+        "key": "PlatformVersion",
+        "value": "eks.45"
+      },
+      {
+        "key": "ResourcesVpcConfig",
+        "value": "{ClusterSecurityGroupId:sg-0335b04180c79d7ca,EndpointPrivateAccess:false,EndpointPublicAccess:true,PublicAccessCidrs:[0.0.0.0/0],SecurityGroupIds:[sg-00b0fa9c3c57c2cc5],SubnetIds:[subnet-05247863bd834f2df,subnet-0b020a2249bb6475b],VpcId:vpc-01af9f247d39edce6}"
+      },
+      {
+        "key": "RoleArn",
+        "value": "arn:aws:iam::635484366616:role/cloud-barista-eks-cluster-role"
+      },
+      {
+        "key": "Status",
+        "value": "ACTIVE"
+      },
+      {
+        "key": "Tags",
+        "value": "{Name:tbdlsc18uvrh6drbdv70,sys.id:mig01-on-prem-k8s-cluster,sys.uid:tbdlsc18uvrh6drbdv70}"
+      },
+      {
+        "key": "Version",
+        "value": "1.33"
+      }
+    ]
+  }
+}
+```
+
+</details>
+

--- a/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-azure.md
+++ b/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-azure.md
@@ -1,0 +1,517 @@
+# CM-Beetle K8s Infra Migration Test Results — Azure-Busan
+
+> [!NOTE]
+> Full lifecycle against a real CSP: recommend → migrate → list → get (verified against
+> the recommendation) → delete → residual resource check.
+
+## Environment
+
+- CSP / Region: azure / koreasouth
+- CM-Beetle URL: http://localhost:8056
+- CM-Beetle Version: v0.6.0
+- Git Commit: 803afb4
+- Namespace: mig01
+- Test Date: 2026-08-20 15:15:45 KST
+- Cluster ID: mig02-on-prem-k8s-cluster
+
+## Test Results Summary
+
+| Step | Description | Status | Duration |
+|------|-------------|--------|----------|
+| 1 | POST /recommendation/k8sCluster | ✅ **PASS** | 19ms |
+| 2 | POST /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 5m0.055s |
+| 3 | GET /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 2ms |
+| 4 | GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation | ✅ **PASS** | 5.781s |
+| 5 | Workload verification (kubeconfig -> K8s API -> nginx) | ✅ **PASS** | 38.004s |
+| 6 | DELETE /migration/ns/{nsId}/k8sCluster/{id} | ✅ **PASS** | 5m32.187s |
+| 7 | Residual resource check (Tumblebug) | ✅ **PASS** | 3ms |
+
+**Overall Result**: 7/7 steps passed ✅
+
+**Total Duration**: 11m16s
+
+---
+
+## Step Details
+
+### Step 1 — POST /recommendation/k8sCluster
+
+- **Duration**: 19ms
+- **Status Code**: 200
+
+- ℹ️  cluster: on-prem-k8s-cluster (version 1.34.8)
+- ℹ️  node groups: 1
+- ℹ️  node group[0] "workers1" spec=azure+koreasouth+standard_b4as_v2 nodes=2
+
+### Step 2 — POST /migration/ns/{nsId}/k8sCluster
+
+- **Duration**: 5m0.055s
+- **Status Code**: 202
+
+- ℹ️  nameSeed: mig02
+- ℹ️  async reqId: 1787206545868968035
+- ℹ️  cluster id: mig02-on-prem-k8s-cluster
+- ℹ️  elapsed: 5m0s
+- ✅ status: Active
+
+### Step 3 — GET /migration/ns/{nsId}/k8sCluster
+
+- **Duration**: 2ms
+- **Status Code**: 200
+
+- ✅ migrated cluster present in list (3 total)
+
+### Step 4 — GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation
+
+- **Duration**: 5.781s
+- **Status Code**: 200
+
+- ✅ status: Active
+- ✅ node group count matches recommendation: 1
+- ✅ node group "workers1" matches (spec=azure+koreasouth+standard_b4as_v2, nodes=2)
+- ✅ version: 1.34.8 (recommended 1.34.8)
+
+### Step 5 — Workload verification (kubeconfig -> K8s API -> nginx)
+
+- **Duration**: 38.004s
+
+- ✅ kubeconfig obtained (server: https://dns-1787206565697750064-yka2fsje.hcp.koreasouth.azmk8s.io:443)
+- ℹ️  auth method: static token in kubeconfig
+- ✅ API server reachable (v1.34.8)
+- ✅ 2 node(s) Ready, matching the recommendation
+- ✅ nginx Deployment created
+- ✅ nginx pod Running (attempt 1)
+- ✅ LoadBalancer Service created
+- ✅ LoadBalancer address assigned: 52.147.121.158
+- ✅ nginx served over the LoadBalancer at http://52.147.121.158/ (attempt 1)
+- ✅ LoadBalancer Service removed
+- ✅ nginx Deployment removed
+
+### Step 6 — DELETE /migration/ns/{nsId}/k8sCluster/{id}
+
+- **Duration**: 5m32.187s
+- **Status Code**: 200
+
+- ✅ deleted on attempt 1 (5m32s)
+
+### Step 7 — Residual resource check (Tumblebug)
+
+- **Duration**: 3ms
+
+- ℹ️  VNet mig02-k8s-vpc still exists (known gap)
+- ℹ️  SecurityGroup mig02-k8s-sg still exists (known gap)
+- ℹ️  SshKey mig02-k8s-sshkey still exists (known gap)
+
+## Recommendation (input to migration)
+
+<details>
+  <summary> <ins>Click to see the recommendation</ins> </summary>
+
+```json
+{
+  "status": "recommended",
+  "description": "K8s cluster recommendation for azure koreasouth (source: v1.32.3 → target: v1.34.8)",
+  "targetCloud": {
+    "csp": "azure",
+    "region": "koreasouth"
+  },
+  "targetInfra": {
+    "name": "",
+    "installMonAgent": "",
+    "label": null,
+    "systemLabel": "",
+    "description": "",
+    "nodeGroups": null,
+    "policyOnPartialFailure": ""
+  },
+  "targetVNet": {
+    "name": "k8s-vpc",
+    "connectionName": "azure-koreasouth",
+    "cidrBlock": "10.0.0.0/22",
+    "subnetInfoList": [
+      {
+        "name": "k8s-subnet-a",
+        "ipv4_CIDR": "10.0.1.0/24"
+      }
+    ],
+    "description": "VPC for migrated K8s cluster"
+  },
+  "targetSshKey": {
+    "name": "k8s-sshkey",
+    "connectionName": "azure-koreasouth",
+    "description": "SSH key for K8s worker nodes",
+    "cspResourceId": "",
+    "fingerprint": "",
+    "username": "",
+    "verifiedUsername": "",
+    "publicKey": "",
+    "privateKey": ""
+  },
+  "targetSpecList": null,
+  "targetOsImageList": null,
+  "targetSecurityGroupList": [
+    {
+      "name": "k8s-sg",
+      "connectionName": "azure-koreasouth",
+      "vNetId": "INSERT_YOUR_VNET_ID",
+      "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+      "firewallRules": [
+        {
+          "Ports": "22",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "0.0.0.0/0"
+        },
+        {
+          "Ports": "10250",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "10.0.0.0/24"
+        },
+        {
+          "Ports": "30000-32767",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "0.0.0.0/0"
+        },
+        {
+          "Ports": "1-65535",
+          "Protocol": "TCP",
+          "Direction": "outbound",
+          "CIDR": "0.0.0.0/0"
+        }
+      ],
+      "cspResourceId": ""
+    }
+  ],
+  "targetK8sCluster": {
+    "connectionName": "azure-koreasouth",
+    "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+    "name": "on-prem-k8s-cluster",
+    "version": "1.34.8",
+    "vNetId": "",
+    "subnetIds": null,
+    "securityGroupIds": null,
+    "k8sNodeGroupList": [
+      {
+        "name": "workers1",
+        "imageId": "default",
+        "specId": "azure+koreasouth+standard_b4as_v2",
+        "rootDiskType": "default",
+        "rootDiskSize": 100,
+        "sshKeyId": "",
+        "onAutoScaling": "false",
+        "desiredNodeSize": 2,
+        "minNodeSize": 0,
+        "maxNodeSize": 0,
+        "label": null,
+        "description": "Worker node group migrated from on-premise (2 nodes)"
+      }
+    ],
+    "cspResourceId": "",
+    "label": null,
+    "systemLabel": ""
+  }
+}
+```
+
+</details>
+
+## Created Cluster
+
+<details>
+  <summary> <ins>Click to see the cluster info</ins> </summary>
+
+```json
+{
+  "resourceType": "k8s",
+  "id": "mig02-on-prem-k8s-cluster",
+  "uid": "tbkpeno23hnamhgbrptu",
+  "name": "mig02-on-prem-k8s-cluster",
+  "connectionName": "azure-koreasouth",
+  "connectionConfig": {
+    "configName": "azure-koreasouth",
+    "providerName": "azure",
+    "driverName": "azure-driver-v1.0.so",
+    "credentialName": "azure",
+    "credentialHolder": "admin",
+    "regionZoneInfoName": "azure-koreasouth",
+    "regionZoneInfo": {
+      "assignedRegion": "koreasouth",
+      "assignedZone": ""
+    },
+    "regionDetail": {
+      "regionId": "koreasouth",
+      "regionName": "koreasouth",
+      "description": "Korea South",
+      "location": {
+        "display": "Korea South",
+        "latitude": 35.1796,
+        "longitude": 129.0756
+      },
+      "zones": []
+    },
+    "regionRepresentative": true,
+    "verified": true
+  },
+  "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+  "systemMessage": "",
+  "label": {
+    "createdAt": "1787206557",
+    "ownerCluster": "tbkpeno23hnamhgbrptu",
+    "sshkey": "tbh9oq28l3i7cb1062kn",
+    "sys.connectionName": "azure-koreasouth",
+    "sys.createdTime": "2026-08-20 06:15:57 +0000 UTC",
+    "sys.cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu",
+    "sys.cspResourceName": "tbkpeno23hnamhgbrptu",
+    "sys.description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+    "sys.id": "mig02-on-prem-k8s-cluster",
+    "sys.labelType": "k8s",
+    "sys.manager": "cb-tumblebug",
+    "sys.name": "mig02-on-prem-k8s-cluster",
+    "sys.namespace": "mig01",
+    "sys.uid": "tbkpeno23hnamhgbrptu",
+    "sys.version": "1.34.8"
+  },
+  "systemLabel": "",
+  "version": "1.34.8",
+  "network": {
+    "vNetId": "mig02-k8s-vpc",
+    "subnetIds": [
+      "mig02-k8s-subnet-a"
+    ],
+    "securityGroupIds": [
+      "mig02-k8s-sg"
+    ],
+    "keyValueList": null
+  },
+  "k8sNodeGroupList": [
+    {
+      "id": "workers1",
+      "name": "workers1",
+      "imageId": "default",
+      "specId": "azure+koreasouth+standard_b4as_v2",
+      "rootDiskType": "PremiumSSD",
+      "rootDiskSize": 100,
+      "sshKeyId": "mig02-k8s-sshkey",
+      "onAutoScaling": false,
+      "desiredNodeSize": 2,
+      "minNodeSize": 0,
+      "maxNodeSize": 0,
+      "status": "Updating",
+      "k8sNodes": [
+        {
+          "cspResourceName": "aks-workers1-34776577-vmss_0",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workers1-34776577-vmss/virtualMachines/0"
+        },
+        {
+          "cspResourceName": "aks-workers1-34776577-vmss_1",
+          "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workers1-34776577-vmss/virtualMachines/1"
+        }
+      ],
+      "keyValueList": null,
+      "cspResourceName": "workers1",
+      "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu/agentPools/workers1",
+      "spiderViewK8sNodeGroupDetail": {
+        "IId": {
+          "NameId": "workers1",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu/agentPools/workers1"
+        },
+        "ImageIID": {
+          "NameId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/AKS-Ubuntu/providers/Microsoft.Compute/galleries/AKSUbuntu/images/2204gen2containerd/versions/202608.06.1",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/AKS-Ubuntu/providers/Microsoft.Compute/galleries/AKSUbuntu/images/2204gen2containerd/versions/202608.06.1"
+        },
+        "VMSpecName": "Standard_B4as_v2",
+        "RootDiskType": "PremiumSSD",
+        "RootDiskSize": "100",
+        "KeyPairIID": {
+          "NameId": "",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbh9oq28l3i7cb1062kn"
+        },
+        "OnAutoScaling": false,
+        "DesiredNodeSize": 2,
+        "MinNodeSize": 0,
+        "MaxNodeSize": 0,
+        "Status": "Updating",
+        "Nodes": [
+          {
+            "NameId": "aks-workers1-34776577-vmss_0",
+            "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workers1-34776577-vmss/virtualMachines/0"
+          },
+          {
+            "NameId": "aks-workers1-34776577-vmss_1",
+            "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workers1-34776577-vmss/virtualMachines/1"
+          }
+        ]
+      }
+    }
+  ],
+  "accessInfo": {
+    "endpoint": "https://dns-1787206565697750064-yka2fsje.hcp.koreasouth.azmk8s.io:443",
+    "kubeconfig": "apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUU2RENDQXRDZ0F3SUJBZ0lRZDB5Tm1qRmJwcEZ4TEFMcEV1cVprekFOQmdrcWhraUc5dzBCQVFzRkFEQU4KTVFzd0NRWURWUVFERXdKallUQWdGdzB5TmpBNE1qQXdOakEyTkRsYUdBOHlNRFUyTURneU1EQTJNVFkwT1ZvdwpEVEVMTUFrR0ExVUVBeE1DWTJFd2dnSWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUNEd0F3Z2dJS0FvSUNBUUMzCmZtMGR6YUJvdnVWb3FoWlJTUlcxS0x1RHM4ZFk5M05qUXdHaGdhNUV6R1YzZ0UwcHptbHZMdlRqRVh2aFhjaEQKUDYxV2VPb1d6N3laSFpraUsyaEZGV09PbmV5NGdTMDdUTDQ3bTFPT1pzTzF4R09sN3JoM005VCt0TGdmVjhobApMblJOMWJmMEliM3N3cHhRd1MxVlh4K203Z2MxaEZkaFh6QW11NWwzWkhWY0pCVWlkVjZKdjFMU3lMc2NSL3V5CnFVcTQxYXFITllXQ0xKZFc5OFg1K1BBdUtteWRkM0w0R0w4SXhKaDZORXdvWmloYXhFTkhaRnlnK0JJMC9OTXEKU0psb0s1U1RFUWdPendiT2h5eFEzRUMyZnhZcG5VUm5rR05lUW1VckdWUk92UmphSEJrcUpid2ptOGo1ZVhmTQpSVGpnMG5rVTYwL1NBejRUazdFdjErakJhN3B1emdCMm8vQ0lnY3lpV3Y4aldvYXVsNnNUcEhLQit3eEFZaUdVCmtPR0Fsbldmc3RyTGRDTmFOMUs2Y2p3R24wajhvaXhxUXNkRjNPTWRqT3MyVHM3eUJRV2VZbFNhblNjYk5uYisKenZpeFZ5TE1DT1J4dWdYNi8yS0p3ZC8vUEhnVUJHS20xQzlXZDdHYm9uOW1MK21ObGZzb004dURYbmdoRnlhWgp2ZVVGMEpNZjNHTWJCNi9Cc29oK1V0bUlTb3Y0ejI0eGl4d25ub1Z2OTRoQjFjOFA5UTZ3MDNKRE91Wms3QjRBCjJ2NzNWYWRYRzYxZjluTXFkUlFGcXUyU2RmRDdmVVhPeG9lVnYzeUxmbllyOFdCTmJKNTdYdE9lVmVLS3g0Z1oKQU95MzJEb2d4ZFYwam9lMTZmWVdNa2NFNEt3NXlUQTdwMTF0cSsxSXJ3SURBUUFCbzBJd1FEQU9CZ05WSFE4QgpBZjhFQkFNQ0FxUXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVqYTRuTEJzVzIvUTk3NU5qCkhmQnArUkttVkRzd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dJQkFBRGpuZWVreWQ4SVlranlWSWc0ZXpkSmVHemEKclo1RlJteDFNZVlsVW02c3ViN3ZrRmFYM3pPSHZ0anZBeEp1TytrNjFVVmw4eUUvQXVVSG11c2NlaFY4WlpQRAozRjcvSU4zeUxkSUx6L0lsdkJrS09xUk5sWW5wZmYvRmxFWS9uY2Jkajg4UytwVzJaMDY4U2o0VnkvTGJrczFzCmMwTis5RVcxdjlMekZEOUtaNG16ckVKRXV2all0YUZOOUo5cTdJNGtnRVJEcEdwa1ZCSlQvNUN0NGlCSG50V3MKWVAwU2J2QmgyQ0hJTVZSVEVoQ2l6ZmN3UmlWekpCYTNVNXRlTDk5T1NaRDJ0Q0paSUlQREU0bjBXcWsrK3JSdgowU25QUzdiTHUrWFQ0eExVb3pyUlRsUVN0bzB6RjJHMXRpNlUyVTNjU3Nod2xYSHpXbkpxd0ZBZDFGcHdncU9uCnFDU25TRGx2dnlKRmF6WnBBUi8yM01iRGlUQ2tLckpoM3BhOUpieHVnaUVkcXJVWTd2SGtPTFdsaXNuLzJHMTYKcExXRk5DYVBveWxWc2QvNTQxQWpUS3ExSDduK0llM09RTTJ6TmFZbzZTMnc5SnlWNE1mMm5CNUsyNFN1UXNOegpTTnJpRVlrNGE4UW9OV0xxakluNkpLTGZ0c2ZNZTIxTCtpVDFKSnJEQVMyZVlOU28yOUJPd2tQSGx0VFpNUmtoCnBwYU5CZy82Y1l6MkkwZjlOYU02WHZ5Y2ovcGhldzdTbDllVkp4OW84N205cWo4ZjREYXBSRlp1ekwxdWVPc24KVTNJL0tTUUZxTkV1TXlFanY1Z0IyMng4RFh6OVRLSWNTSDJiTWhkemd3eG4wcW9PdTdlV0FURUt0NEFMQ01KMgpJeVVVLzlnb0FyZnR1aVNtCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n    server: https://dns-1787206565697750064-yka2fsje.hcp.koreasouth.azmk8s.io:443\n  name: tbkpeno23hnamhgbrptu\ncontexts:\n- context:\n    cluster: tbkpeno23hnamhgbrptu\n    user: clusterAdmin_koreasouth_tbkpeno23hnamhgbrptu\n  name: tbkpeno23hnamhgbrptu\ncurrent-context: tbkpeno23hnamhgbrptu\nkind: Config\nusers:\n- name: clusterAdmin_koreasouth_tbkpeno23hnamhgbrptu\n  user:\n    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZIakNDQXdhZ0F3SUJBZ0lSQU1OeXpjWWs4dVBWWWxQSGZiUXkzSUV3RFFZSktvWklodmNOQVFFTEJRQXcKRFRFTE1Ba0dBMVVFQXhNQ1kyRXdIaGNOTWpZd09ESXdNRFl3TmpVd1doY05Namd3T0RJd01EWXhOalV3V2pBdwpNUmN3RlFZRFZRUUtFdzV6ZVhOMFpXMDZiV0Z6ZEdWeWN6RVZNQk1HQTFVRUF4TU1iV0Z6ZEdWeVkyeHBaVzUwCk1JSUNJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBMk9NaGRNM2loTEJFdGx6bzNkbC8KWHNHUEd4UEJLRWg1VDZxcEhoVXZCV1praVdTK1FoRm9KOHpzU3JRTmgvZjR2a3JnK0dnQURKTGNVcEhmQXl5RApBRjdCOG93bDN6TEVyTkt1R2h3ajBDUUFRYkZ5czl0YjVqRVE1dm1QRDd3MkZpWE0xUWJySnBmNVE4UmluT3A0ClpIVXpiRGR0bnZLdEpobmJiM1doSHBDUm9iSEdZZVNxeW0zaWZ1SGRseUIwbTVlcHptcU41N0pxbWFXT2cyRUEKcEVZY2xxNnJnV2sycXhoNjBicFRnOXV2NjFKZ0ZGQStVcTQ1THcvdDdmM1VLRFpxVnBVMDlIdGdURnZZNGVRZQorZFdnOFNLMEE0M082YU1jM1E3Ynhkcmw4aEZRSkRML1RWZDdwaS9VMmk5MUdYMHhMYW9lNkpyQmhERnZad3hJCm1xTFoyVDZPbElTV2NaN3ByY3VqTUUrbE1IQXBIVGRIWkpoRVFnRjc1RVlxMXUwRkRZQUVDUll2OGlKUUtVQ0gKTkxWZVlGNlRwOW92YnlGUWdpM3hJcXNiVWpaNGgzdmU0ei9Nc2JYVWVYYTh4WUlQakkremJpb0JrWjV3T1BpMwpQaE5jLzVpRXB6dEkzOUdLeERGUldYNXlHb0ZYd0VXbloxWVRlL2JJZ21vMHRuK1lmaldCUWRXVFhGYmN4bFllCnpCY0NoMFRIN1llUHd1MWZqYUZQK05IanBaZHNQSERYbkVPU2ZFSHN4cUhDc3NtbzNQWWRUaFNzdEJ1SmlnZDMKZlJKK3VMUDcvT3o0ZkRKUjQ1ek9UTHhncnBZQlZVeUlJZmwrM2xUcEpaek5KR3dtRFZLQkFlZ1FkY3BkMElxUgpFblh2dmdnZzdIckIvSmFmSnhISVZDTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdXZ01CTUdBMVVkCkpRUU1NQW9HQ0NzR0FRVUZCd01DTUF3R0ExVWRFd0VCL3dRQ01BQXdId1lEVlIwakJCZ3dGb0FVamE0bkxCc1cKMi9ROTc1TmpIZkJwK1JLbVZEc3dEUVlKS29aSWh2Y05BUUVMQlFBRGdnSUJBSFh4T2s5WHI3K2U3T01TclhMTwptZFNVQWdPaFpDTXFSL014b1FiWHkvOUYwZHBsSkZINjlJVzh6TEo0ZDhWdnphUGNNZTQ4YmdHUDdIbko0SVJRCktZYjk2Y3cvZENuUjdRQ0xkM2VPNEd2dG1xV2dWQmIwdzN3WDYzSnFHL1ZQUkdqd0d4aFEvQmJ2clJpa1BESTMKeEpDdWRLNmdYSmJYN1NFUkFIemhiTnR0dnRwYkFFSWdjWVVLSjVaaDdvZTFYZHlqSzhJYmtjVkg1aXlPb2dTbApjaktBUExDbWVSVWVsdlZMWFVHVC9LaDk0ZGVIMzJkdGF0aUdoY0N3d1pYK2pvVXlEY2RSdWdDUHJsRVE1VzNzClg0bU90aUNNa2Y3MzB4ck9CaGNtWWNPM2tEWkNsWDdsYml3V2hpV20rTVZ2ODdXWnZrcS9QcWVzaVFVOEkzc3AKMTJJSUw4N0h2UkhUZEw3RGJTN2JCY2FlTksySjQvSitNaStpVkRoOXNpY2VzMnd1Znd0RWdOZlY5NDlPbklweApQQlkwUC94c1lZN3Naa2JaLzNKRzBqQWp4TDRjaU53NmlSSmhqVEQ2cFQ3K0JXNUlKQzAxbkU0L0tJaXhOclkyCkduL0pyVFJRWVRzRTNUcWFyeHVlMTJRQ3phZEN4M1pKV0R4bUNzSWpTdTVKV1dKaHBtUDl5amowaEFnUS9KSkoKNWY2Y3QvV05mR2pQVysxYllmNjhpUDQraWVpK2FReVNEaEtiOGhhTW4zcXE2K0FFbzVRbXh6ZmhxVytROHQzNgo5UnRKNElSOThqVzJqemYwR2VVQko3d1hyYnZyRFJTNXJOTjdYOUNVRlI1UWJjcWNsV21XWjhPQnNEZEdzTGVSCmNnN05OTkwzVkpvSEZlelJMdVZZK3JwNQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\n    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlKS1FJQkFBS0NBZ0VBMk9NaGRNM2loTEJFdGx6bzNkbC9Yc0dQR3hQQktFaDVUNnFwSGhVdkJXWmtpV1MrClFoRm9KOHpzU3JRTmgvZjR2a3JnK0dnQURKTGNVcEhmQXl5REFGN0I4b3dsM3pMRXJOS3VHaHdqMENRQVFiRnkKczl0YjVqRVE1dm1QRDd3MkZpWE0xUWJySnBmNVE4UmluT3A0WkhVemJEZHRudkt0SmhuYmIzV2hIcENSb2JIRwpZZVNxeW0zaWZ1SGRseUIwbTVlcHptcU41N0pxbWFXT2cyRUFwRVljbHE2cmdXazJxeGg2MGJwVGc5dXY2MUpnCkZGQStVcTQ1THcvdDdmM1VLRFpxVnBVMDlIdGdURnZZNGVRZStkV2c4U0swQTQzTzZhTWMzUTdieGRybDhoRlEKSkRML1RWZDdwaS9VMmk5MUdYMHhMYW9lNkpyQmhERnZad3hJbXFMWjJUNk9sSVNXY1o3cHJjdWpNRStsTUhBcApIVGRIWkpoRVFnRjc1RVlxMXUwRkRZQUVDUll2OGlKUUtVQ0hOTFZlWUY2VHA5b3ZieUZRZ2kzeElxc2JValo0CmgzdmU0ei9Nc2JYVWVYYTh4WUlQakkremJpb0JrWjV3T1BpM1BoTmMvNWlFcHp0STM5R0t4REZSV1g1eUdvRlgKd0VXbloxWVRlL2JJZ21vMHRuK1lmaldCUWRXVFhGYmN4bFllekJjQ2gwVEg3WWVQd3UxZmphRlArTkhqcFpkcwpQSERYbkVPU2ZFSHN4cUhDc3NtbzNQWWRUaFNzdEJ1SmlnZDNmUkordUxQNy9PejRmREpSNDV6T1RMeGdycFlCClZVeUlJZmwrM2xUcEpaek5KR3dtRFZLQkFlZ1FkY3BkMElxUkVuWHZ2Z2dnN0hyQi9KYWZKeEhJVkNNQ0F3RUEKQVFLQ0FnQkI3RWV2Q1NWZ3ozTVRPd3BNNUY4aW5oS3hXRC9OenJtUXpYNjU5aFprdmNxeE9EM2NOdzVCaXJnSAp2TktnRVc4NTUraVptSUxyVDNoSVlLNDRlTDhZemJTRjFMTnVOREF6bDVYenVibm8rZ2haNzJXOTVWNzVpTkJxClpGQm5wLzJJbmRTMHEzV3VOV00raGVLemIxRkl0NWI1dlo5RVFOOEFSYnU5RlRQejVsMWRtSHVFSmMwRDJvS04Kcm5sOEJoRnJlWjNUYisvU0RSajV1cWltcGtWYnFUUG5XUkFvTmFLNFBxaVdOdHhMcCtyQXpEa0g4NXY5NVpiYwpCeXQ2dXp4UlBMajF1RVJ3UzAvcDVjRDJhREJDSC96YlRvRUkwNEdnNGtOVHJjQi9VeG14aWpHaHp4NXFrN3l4CnRyZ3IyV0R1Ym04VVFqRkM0a2NQdHpiMVMzYUZldHZlaks1ZkJubTIzcjcvNlpUenhsek9Vd0VBcmtZejVJZkoKYTE3Wkt0b2wyOWNrRmsvaGNyb0R5b0ZCUTlGTUZ5MGxYM1VmRkh3T1FvazVrVjNFQmhJK2NMbUR4YXZaN3cweQptdXlpWnZLYjlEQ0lEdlIxQ2hxTGVuVzBTd1M1dTV0WHhiYWFTVlQzV3h2VDZYSDFxYTc1alpKVEJjNG1kdzkvCjNGbjlQQ2RZUVdsNHZKWEJsdUtFSVJOYktlNWhPSnVwVmMrK0hJSnd5clg3cm1aS3lkS1RpeEFYZUlleitnNmIKWFVmZFZQdEJTMW5ZUXhTaVg1RFhTUjdBNUJ0TE02VUR4K0xUVlBXNjIvYXJKcUNqcjlSM2F4eHhHUnVOVTJvcApyMGp6UDJtdElKMVVVcUlDQ3dGTTFjeEFrUHBOUTMzSzBneVJmeU1INTBCMkVDaEhnUUtDQVFFQTYxQjhJalJFClJqOWsyQVA0TEh6VGN6WFRtdGVISGFQRXdraXJxMUdPTXljc0xyWDZUNWpMU05JK1p4bWprdnNFZ1o5SFFnQUIKYVAxSDNsSndHZWdONmg2UnkyN1hwUlFuTlJTK1o5VTlET3VzNEtRMDhMc2pOOUErRWlMYXlnVkt0V21BMExuWAozc05VQ2Y0dkZvNGhyRHdtUDlnMkhYM0FpNXN1TUswaDBhMytpUEYxNXdsWUFGeUxCMzZKRmdxK2ZyUjA3bGdYClVHak1YN1k4d0JubUFVaFBQSVFENDZlK1gwNEpuWE12VC9tZEw2Z1I2MDhBQmt4RmRMVkprcmM4SWJlN1h2dUYKckQzMnBpMmNUZm5mM0prdm5YclZhUlYwendjbGJyaGRsK0JVZ0ZwUE9SbmI5K3NEOTlzUGE1UHYzNEZOV2NHVAp1RjVCWnBBZXdEWDhad0tDQVFFQTYvUDErK2RzOStlaSttN2dmSXJ5TkFYUmJIVzZnUzgyMUpsVGQveWhOUnJrCnB1Z1BIQUxrSGdkQndpT294akI3V2QraGU2VWxtVnJVMHo1R1lEb24wOUx6eVJ4WE9lZ2t4T3UrK09FTE9UbTQKaEhqQmhlM0JNbzdRRjBtdXh2SUxOd1gxTkpaZ1UzdmZkNFZsOHdDQlNNdWJEMkVaazdBdE0zZGtjaFlkRXB0dQpDRkJWdjVTRXRiTjlLZzNqb2o1RW5LbkJHUXR4VFk3V1RxZGlHSCtSZWhMV2ZQNWxSRE9jNUhDV1JKMEhBMVU4Ci93YTFzbTJYblhMWnB5bXBmZzJUblVxeXV4eDk4RGE0VUgzV3FWdVhveml6YVBPSE9EVWMxUW5BWXNPUU1DVXkKZk5TNS9MMXpGYnR5d2xyOHlZUUx5cmthVWwwK3MxSXByalFVUEo2VTVRS0NBUUFZd2NQOW1VQWhuK1BOTWtXMgo4SDhTblBRaFUxR2MxYkVLdTdpTDhxMmlSaG5JNUU1c2QyZlR4b0xZT0FOVW9HSXQvUUx6TjZydVQ4OXkzWHQ3CnprVkFmMnpaV1ZVSXdpRUozWi9XcnNHWWpXY0h6MTdlZ09ISXFua05VV3R4VzdNcmVPa2JqS0hnaHU1ZGlzZUwKZVBLaiswUU83WUZzQXVIeURpYUM2b1FuV2tYd1JHOGlHb0tPcnkzVllRT3ROUDRydUhLZzdOV3ZHUWQvZmwzUAozQ210c3R6YlFneGl0REE4T0txY1RSVUtOZm5Lbk1VZDI1Ym1Fcm92K0M3QVo5VEV1MTdVTkdRdzVlZ0FQY1kzCkVmWHljSTlvNHhaMjB0SVNRZTgzUWVCZTdUUVd1T21pMlV5aVBiQ1NNQkxrUDVFNkU1Rit3dlgyckx2MnZXenUKemY4N0FvSUJBUUNFbUhOcW5WSUtPbHpIT1Zua0F6MDY2TzRZY2t4ZDNvZUVqNmx0YTBXNGp5VmhlbFZMVzRDUQpNMm5MekxoQ3Irb1J4bTk4Q1lHSW5aZXVJbmZ3Q1o1cUZra3pnajZ1WnZ1S3dpUnV2aUROaHRkZmNuRG1iNGE3CmY3QUc5anhHeHF4d3ZtTmVxd2IwdzA4QVhyRzlEbEtZOHZwdmVSU2pmMFRYZ0VldEtTb3JVN2RRNnJ4VlRnUUsKREJUUmRqNnU1U2t2bE9IVHppOWM4MkVSa0ZTN0NhMWFHWTM1YmdqQWUvUzJGMk1LcWVmUUFxMmxiMExhUTJZSgpjQXBLTzBwcGNQMjhUY2NGQ1d6b2VnZTREQTkrMnQ3ck5hajAySzNyYzBXQm50cERaano0SVY4dThXaVhWR3VCCkVmYmFxOEVWQ2FTS3h0eTQzbmVtMUF4aVBoZ0ZQT1RWQW9JQkFRRGNwUlpXWkRvMEVnU2haWG5HQ0NaYUQxNlQKVXA0eFRZRmg2NmZsQThJdHBKUDVWdWJ4eER5YURRanJnbDFZYXovNTdyUXdLUk92czdDQ3YvUUZVN2hkcEZOTAoxVHdkTjgrS2Q5VmtnKzR0YjBJQ2h5cDJacW9VMmpsRkVMMjBlSUdRWTdLUGhJREtYMisvcVQ2bEZOWGdxQVZyClBWbmJuWUl0SGd3ZWtBZjVPbHFreDV2SjMvaHVERDRnRVg3NElGemMwVnVqS3pZZmxoZ2xxSVd1TDdQd1V3M1kKSTBQZVdtVjRZejJSVnI1amd3T3M5eFd1QWxXNUVUdHQrUysreEpZVVpQYytlL0FpSGg3SElaTHFrMU5KSk1VUAo4YklnaTNIS2Eza21HajVMbHQ1Kzl4WG4vTzgvY0Z3ak9nSHFqNTJRL09teDdnWTcvNkRwVmdaOUxVZm8KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K\n    token: o3f9fxe7v3k0fgtdxt5wa0bi7gcwv1jmqtje43z1wk8qh8385a7yw8ccnai5gm7ee7o6b95mvsdvw2skjatcn1rfptoevq2j5urzwv03klst997cpo7y7dei6s961qam\n"
+  },
+  "addons": {
+    "keyValueList": null
+  },
+  "status": "Active",
+  "createdTime": "2026-08-20T06:15:57Z",
+  "keyValueList": [
+    {
+      "key": "Location",
+      "value": "koreasouth"
+    },
+    {
+      "key": "Identity",
+      "value": "{principalId:af8b295b-80f2-4e28-b34b-11a597b8a6d4,tenantId:fb98dda1-32ff-48eb-a489-62777cd9ccd8,type:SystemAssigned}"
+    },
+    {
+      "key": "Kind",
+      "value": "Base"
+    },
+    {
+      "key": "Properties",
+      "value": "{agentPoolProfiles:[{count:2,currentOrchestratorVersion:1.34.8,eTag:9235cebc-da3f-4363-9ea7-3b0097a130f9,enableAutoScaling:false,enableFIPS:false,enableNodePublicIP:true,kubeletDiskType:OS,maxPods:110,mode:System,name:workers1,nodeImageVersion:AKSUbuntu-2204gen2containerd-202608.06.1,orchestratorVersion:1.34.8,osDiskSizeGB:100,osDiskType:Managed,osSKU:Ubuntu,osType:Linux,powerState:{code:Running},provisioningState:Succeeded,scaleDownMode:Delete,securityProfile:{enableSecureBoot:false,enableVTPM:false,sshAccess:LocalUser},type:VirtualMachineScaleSets,upgradeSettings:{maxSurge:10%,maxUnavailable:0},vmSize:Standard_B4as_v2,vnetSubnetID:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbjvs627fsvq9c8qjdmm/subnets/tbi5s3q7etm8cahfjubo}],autoUpgradeProfile:{nodeOSUpgradeChannel:NodeImage},azurePortalFQDN:dns-1787206565697750064-yka2fsje.portal.hcp.koreasouth.azmk8s.io,bootstrapProfile:{artifactSource:Direct},currentKubernetesVersion:1.34.8,dnsPrefix:dns-1787206565697750064,enableRBAC:true,fqdn:dns-1787206565697750064-yka2fsje.hcp.koreasouth.azmk8s.io,identityProfile:{kubeletidentity:{clientId:abd41f07-a701-4feb-ba6b-1285f8ab81da,objectId:7a46f1bd-30fb-4ee8-bf99-b27c0e72e658,resourceId:/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.ManagedIdentity/userAssignedIdentities/tbkpeno23hnamhgbrptu-agentpool}},ingressProfile:{webAppRouting:{dnsZoneResourceIds:[/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/dnszones/tbkpeno23hnamhgbrptu.com],enabled:true,gatewayAPIImplementations:{appRoutingIstio:{mode:Disabled}},identity:{clientId:75ca6f0a-bac5-4065-99b8-62477be438c6,objectId:383c4ad1-bd05-49bd-a902-ecb08d20c4e3,resourceId:/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.ManagedIdentity/userAssignedIdentities/webapprouting-tbkpeno23hnamhgbrptu},nginx:{defaultIngressControllerType:AnnotationControlled}}},kubernetesVersion:1.34.8,linuxProfile:{adminUsername:cb-user,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDA7EqTWJv+hdZCkyjquj4TaYf5mYZQ4lsvvjLwuWaFV6BKS0Owt/B+rMl4PYS6zuK2hBjBFFYVY/hmPyhUiSzyX93wWSrHk2axbJyL++kJSVQ0dmO8Tcnr47K8Tp6WI+Ex72s5vIeKnltDbjLIsYHcisuB0bPNfDREFO3aUkKjub3l40Nowq2SmlOV4pB1MpUigKUPrh4QVrRhF0vdcXSzZ1wYCfWiPzF/fU0d+7f7raTwc8bDgHRSYsOQ7r4Je8XV2HPyG4kMU1z55l1RZkWE4Nhn2Ojy+H2nq/PGt+LB9M10U7f1iykdIG7N40SoyGnTekyPDZ9/o8E8yOjaMMAhBLFy9xs1VTARi2ZhJUKF/8MQRV/hZYMEZclYH8CGCiFvDBsU0xCgKjtsso8WO2zoGcmdZTDQb4+gy/wvvHRFGQPnTY79MfKPLtUu3B7c0uDVGtS5reeDlDsU2Is2e7pFX29sMZ3r9C8w61raTlUUagTLNbiHkTPiXgU4MFHDIeDpqKP5dBF6FW/qq4whuwQJSpjVg7H/m529RCo+5WgtnoZNEbvVZbXi5R69AEemoEvanua+ThwtytrE2yOsu7hVo0kvMjezxgodoyZLxwxYi8trvvNJxen3Ck2c6r/AzVx0slcjguz3uNi0RQf0hQQ30gva4VzDVjZwLWQx5Ngz6Q==\\n}]}},maxAgentPools:100,metricsProfile:{costAnalysis:{enabled:false}},networkProfile:{dnsServiceIP:10.1.0.10,ipFamilies:[IPv4],loadBalancerProfile:{backendPoolType:nodeIPConfiguration,effectiveOutboundIPs:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Network/publicIPAddresses/3db7c26c-f4e9-4809-8c72-397081fa2272}],managedOutboundIPs:{count:1}},loadBalancerSku:standard,networkDataplane:azure,networkPlugin:azure,networkPolicy:azure,outboundType:loadBalancer,serviceCidr:10.1.0.0/16,serviceCidrs:[10.1.0.0/16]},nodeProvisioningProfile:{mode:Manual},nodeResourceGroup:CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth,oidcIssuerProfile:{enabled:true,issuerURL:https://koreasouth.oic.prod-aks.azure.com/fb98dda1-32ff-48eb-a489-62777cd9ccd8/56872a0b-9f7c-48ba-9126-59931441f480/},powerState:{code:Running},provisioningState:Succeeded,resourceUID:6a869bac954cc2000164bc4f,securityProfile:{},servicePrincipalProfile:{clientId:msi},storageProfile:{diskCSIDriver:{enabled:true},fileCSIDriver:{enabled:true},snapshotController:{enabled:true}},supportPlan:KubernetesOfficial,windowsProfile:{adminUsername:azureuser,enableCSIProxy:true},workloadAutoScalerProfile:{}}"
+    },
+    {
+      "key": "SKU",
+      "value": "{name:Base,tier:Standard}"
+    },
+    {
+      "key": "Tags",
+      "value": "{createdAt:1787206557,ownerCluster:tbkpeno23hnamhgbrptu,sshkey:tbh9oq28l3i7cb1062kn,sys.connectionName:azure-koreasouth,sys.createdTime:2026-08-20 06:15:57 +0000 UTC,sys.cspResourceId:/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu,sys.cspResourceName:tbkpeno23hnamhgbrptu,sys.description:Migrated from on-premise K8s cluster (v1.32.3, 2 workers),sys.id:mig02-on-prem-k8s-cluster,sys.labelType:k8s,sys.manager:cb-tumblebug,sys.name:mig02-on-prem-k8s-cluster,sys.namespace:mig01,sys.uid:tbkpeno23hnamhgbrptu,sys.version:1.34.8}"
+    },
+    {
+      "key": "ETag",
+      "value": "b754aaf9-c1eb-4055-8256-4a1942a7e032"
+    },
+    {
+      "key": "ID",
+      "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu"
+    },
+    {
+      "key": "Name",
+      "value": "tbkpeno23hnamhgbrptu"
+    },
+    {
+      "key": "Type",
+      "value": "Microsoft.ContainerService/ManagedClusters"
+    }
+  ],
+  "cspResourceName": "tbkpeno23hnamhgbrptu",
+  "cspResourceId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu",
+  "spiderViewK8sClusterDetail": {
+    "IId": {
+      "NameId": "tbkpeno23hnamhgbrptu",
+      "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu"
+    },
+    "Version": "1.34.8",
+    "Network": {
+      "VpcIID": {
+        "NameId": "tbjvs627fsvq9c8qjdmm",
+        "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbjvs627fsvq9c8qjdmm"
+      },
+      "SubnetIIDs": [
+        {
+          "NameId": "tbi5s3q7etm8cahfjubo",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbjvs627fsvq9c8qjdmm/subnets/tbi5s3q7etm8cahfjubo"
+        }
+      ],
+      "SecurityGroupIIDs": [
+        {
+          "NameId": "#aks-agentpool-15876628-nsg",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/cb_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-15876628-nsg"
+        }
+      ],
+      "KeyValueList": null
+    },
+    "NodeGroupList": [
+      {
+        "IId": {
+          "NameId": "workers1",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu/agentPools/workers1"
+        },
+        "ImageIID": {
+          "NameId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/AKS-Ubuntu/providers/Microsoft.Compute/galleries/AKSUbuntu/images/2204gen2containerd/versions/202608.06.1",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/AKS-Ubuntu/providers/Microsoft.Compute/galleries/AKSUbuntu/images/2204gen2containerd/versions/202608.06.1"
+        },
+        "VMSpecName": "Standard_B4as_v2",
+        "RootDiskType": "PremiumSSD",
+        "RootDiskSize": "100",
+        "KeyPairIID": {
+          "NameId": "",
+          "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Compute/sshPublicKeys/tbh9oq28l3i7cb1062kn"
+        },
+        "OnAutoScaling": false,
+        "DesiredNodeSize": 2,
+        "MinNodeSize": 0,
+        "MaxNodeSize": 0,
+        "Status": "Updating",
+        "Nodes": [
+          {
+            "NameId": "aks-workers1-34776577-vmss_0",
+            "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workers1-34776577-vmss/virtualMachines/0"
+          },
+          {
+            "NameId": "aks-workers1-34776577-vmss_1",
+            "SystemId": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workers1-34776577-vmss/virtualMachines/1"
+          }
+        ]
+      }
+    ],
+    "AccessInfo": {
+      "Endpoint": "https://dns-1787206565697750064-yka2fsje.hcp.koreasouth.azmk8s.io:443",
+      "Kubeconfig": "apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUU2RENDQXRDZ0F3SUJBZ0lRZDB5Tm1qRmJwcEZ4TEFMcEV1cVprekFOQmdrcWhraUc5dzBCQVFzRkFEQU4KTVFzd0NRWURWUVFERXdKallUQWdGdzB5TmpBNE1qQXdOakEyTkRsYUdBOHlNRFUyTURneU1EQTJNVFkwT1ZvdwpEVEVMTUFrR0ExVUVBeE1DWTJFd2dnSWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUNEd0F3Z2dJS0FvSUNBUUMzCmZtMGR6YUJvdnVWb3FoWlJTUlcxS0x1RHM4ZFk5M05qUXdHaGdhNUV6R1YzZ0UwcHptbHZMdlRqRVh2aFhjaEQKUDYxV2VPb1d6N3laSFpraUsyaEZGV09PbmV5NGdTMDdUTDQ3bTFPT1pzTzF4R09sN3JoM005VCt0TGdmVjhobApMblJOMWJmMEliM3N3cHhRd1MxVlh4K203Z2MxaEZkaFh6QW11NWwzWkhWY0pCVWlkVjZKdjFMU3lMc2NSL3V5CnFVcTQxYXFITllXQ0xKZFc5OFg1K1BBdUtteWRkM0w0R0w4SXhKaDZORXdvWmloYXhFTkhaRnlnK0JJMC9OTXEKU0psb0s1U1RFUWdPendiT2h5eFEzRUMyZnhZcG5VUm5rR05lUW1VckdWUk92UmphSEJrcUpid2ptOGo1ZVhmTQpSVGpnMG5rVTYwL1NBejRUazdFdjErakJhN3B1emdCMm8vQ0lnY3lpV3Y4aldvYXVsNnNUcEhLQit3eEFZaUdVCmtPR0Fsbldmc3RyTGRDTmFOMUs2Y2p3R24wajhvaXhxUXNkRjNPTWRqT3MyVHM3eUJRV2VZbFNhblNjYk5uYisKenZpeFZ5TE1DT1J4dWdYNi8yS0p3ZC8vUEhnVUJHS20xQzlXZDdHYm9uOW1MK21ObGZzb004dURYbmdoRnlhWgp2ZVVGMEpNZjNHTWJCNi9Cc29oK1V0bUlTb3Y0ejI0eGl4d25ub1Z2OTRoQjFjOFA5UTZ3MDNKRE91Wms3QjRBCjJ2NzNWYWRYRzYxZjluTXFkUlFGcXUyU2RmRDdmVVhPeG9lVnYzeUxmbllyOFdCTmJKNTdYdE9lVmVLS3g0Z1oKQU95MzJEb2d4ZFYwam9lMTZmWVdNa2NFNEt3NXlUQTdwMTF0cSsxSXJ3SURBUUFCbzBJd1FEQU9CZ05WSFE4QgpBZjhFQkFNQ0FxUXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVqYTRuTEJzVzIvUTk3NU5qCkhmQnArUkttVkRzd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dJQkFBRGpuZWVreWQ4SVlranlWSWc0ZXpkSmVHemEKclo1RlJteDFNZVlsVW02c3ViN3ZrRmFYM3pPSHZ0anZBeEp1TytrNjFVVmw4eUUvQXVVSG11c2NlaFY4WlpQRAozRjcvSU4zeUxkSUx6L0lsdkJrS09xUk5sWW5wZmYvRmxFWS9uY2Jkajg4UytwVzJaMDY4U2o0VnkvTGJrczFzCmMwTis5RVcxdjlMekZEOUtaNG16ckVKRXV2all0YUZOOUo5cTdJNGtnRVJEcEdwa1ZCSlQvNUN0NGlCSG50V3MKWVAwU2J2QmgyQ0hJTVZSVEVoQ2l6ZmN3UmlWekpCYTNVNXRlTDk5T1NaRDJ0Q0paSUlQREU0bjBXcWsrK3JSdgowU25QUzdiTHUrWFQ0eExVb3pyUlRsUVN0bzB6RjJHMXRpNlUyVTNjU3Nod2xYSHpXbkpxd0ZBZDFGcHdncU9uCnFDU25TRGx2dnlKRmF6WnBBUi8yM01iRGlUQ2tLckpoM3BhOUpieHVnaUVkcXJVWTd2SGtPTFdsaXNuLzJHMTYKcExXRk5DYVBveWxWc2QvNTQxQWpUS3ExSDduK0llM09RTTJ6TmFZbzZTMnc5SnlWNE1mMm5CNUsyNFN1UXNOegpTTnJpRVlrNGE4UW9OV0xxakluNkpLTGZ0c2ZNZTIxTCtpVDFKSnJEQVMyZVlOU28yOUJPd2tQSGx0VFpNUmtoCnBwYU5CZy82Y1l6MkkwZjlOYU02WHZ5Y2ovcGhldzdTbDllVkp4OW84N205cWo4ZjREYXBSRlp1ekwxdWVPc24KVTNJL0tTUUZxTkV1TXlFanY1Z0IyMng4RFh6OVRLSWNTSDJiTWhkemd3eG4wcW9PdTdlV0FURUt0NEFMQ01KMgpJeVVVLzlnb0FyZnR1aVNtCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n    server: https://dns-1787206565697750064-yka2fsje.hcp.koreasouth.azmk8s.io:443\n  name: tbkpeno23hnamhgbrptu\ncontexts:\n- context:\n    cluster: tbkpeno23hnamhgbrptu\n    user: clusterAdmin_koreasouth_tbkpeno23hnamhgbrptu\n  name: tbkpeno23hnamhgbrptu\ncurrent-context: tbkpeno23hnamhgbrptu\nkind: Config\nusers:\n- name: clusterAdmin_koreasouth_tbkpeno23hnamhgbrptu\n  user:\n    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZIakNDQXdhZ0F3SUJBZ0lSQU1OeXpjWWs4dVBWWWxQSGZiUXkzSUV3RFFZSktvWklodmNOQVFFTEJRQXcKRFRFTE1Ba0dBMVVFQXhNQ1kyRXdIaGNOTWpZd09ESXdNRFl3TmpVd1doY05Namd3T0RJd01EWXhOalV3V2pBdwpNUmN3RlFZRFZRUUtFdzV6ZVhOMFpXMDZiV0Z6ZEdWeWN6RVZNQk1HQTFVRUF4TU1iV0Z6ZEdWeVkyeHBaVzUwCk1JSUNJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBMk9NaGRNM2loTEJFdGx6bzNkbC8KWHNHUEd4UEJLRWg1VDZxcEhoVXZCV1praVdTK1FoRm9KOHpzU3JRTmgvZjR2a3JnK0dnQURKTGNVcEhmQXl5RApBRjdCOG93bDN6TEVyTkt1R2h3ajBDUUFRYkZ5czl0YjVqRVE1dm1QRDd3MkZpWE0xUWJySnBmNVE4UmluT3A0ClpIVXpiRGR0bnZLdEpobmJiM1doSHBDUm9iSEdZZVNxeW0zaWZ1SGRseUIwbTVlcHptcU41N0pxbWFXT2cyRUEKcEVZY2xxNnJnV2sycXhoNjBicFRnOXV2NjFKZ0ZGQStVcTQ1THcvdDdmM1VLRFpxVnBVMDlIdGdURnZZNGVRZQorZFdnOFNLMEE0M082YU1jM1E3Ynhkcmw4aEZRSkRML1RWZDdwaS9VMmk5MUdYMHhMYW9lNkpyQmhERnZad3hJCm1xTFoyVDZPbElTV2NaN3ByY3VqTUUrbE1IQXBIVGRIWkpoRVFnRjc1RVlxMXUwRkRZQUVDUll2OGlKUUtVQ0gKTkxWZVlGNlRwOW92YnlGUWdpM3hJcXNiVWpaNGgzdmU0ei9Nc2JYVWVYYTh4WUlQakkremJpb0JrWjV3T1BpMwpQaE5jLzVpRXB6dEkzOUdLeERGUldYNXlHb0ZYd0VXbloxWVRlL2JJZ21vMHRuK1lmaldCUWRXVFhGYmN4bFllCnpCY0NoMFRIN1llUHd1MWZqYUZQK05IanBaZHNQSERYbkVPU2ZFSHN4cUhDc3NtbzNQWWRUaFNzdEJ1SmlnZDMKZlJKK3VMUDcvT3o0ZkRKUjQ1ek9UTHhncnBZQlZVeUlJZmwrM2xUcEpaek5KR3dtRFZLQkFlZ1FkY3BkMElxUgpFblh2dmdnZzdIckIvSmFmSnhISVZDTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdXZ01CTUdBMVVkCkpRUU1NQW9HQ0NzR0FRVUZCd01DTUF3R0ExVWRFd0VCL3dRQ01BQXdId1lEVlIwakJCZ3dGb0FVamE0bkxCc1cKMi9ROTc1TmpIZkJwK1JLbVZEc3dEUVlKS29aSWh2Y05BUUVMQlFBRGdnSUJBSFh4T2s5WHI3K2U3T01TclhMTwptZFNVQWdPaFpDTXFSL014b1FiWHkvOUYwZHBsSkZINjlJVzh6TEo0ZDhWdnphUGNNZTQ4YmdHUDdIbko0SVJRCktZYjk2Y3cvZENuUjdRQ0xkM2VPNEd2dG1xV2dWQmIwdzN3WDYzSnFHL1ZQUkdqd0d4aFEvQmJ2clJpa1BESTMKeEpDdWRLNmdYSmJYN1NFUkFIemhiTnR0dnRwYkFFSWdjWVVLSjVaaDdvZTFYZHlqSzhJYmtjVkg1aXlPb2dTbApjaktBUExDbWVSVWVsdlZMWFVHVC9LaDk0ZGVIMzJkdGF0aUdoY0N3d1pYK2pvVXlEY2RSdWdDUHJsRVE1VzNzClg0bU90aUNNa2Y3MzB4ck9CaGNtWWNPM2tEWkNsWDdsYml3V2hpV20rTVZ2ODdXWnZrcS9QcWVzaVFVOEkzc3AKMTJJSUw4N0h2UkhUZEw3RGJTN2JCY2FlTksySjQvSitNaStpVkRoOXNpY2VzMnd1Znd0RWdOZlY5NDlPbklweApQQlkwUC94c1lZN3Naa2JaLzNKRzBqQWp4TDRjaU53NmlSSmhqVEQ2cFQ3K0JXNUlKQzAxbkU0L0tJaXhOclkyCkduL0pyVFJRWVRzRTNUcWFyeHVlMTJRQ3phZEN4M1pKV0R4bUNzSWpTdTVKV1dKaHBtUDl5amowaEFnUS9KSkoKNWY2Y3QvV05mR2pQVysxYllmNjhpUDQraWVpK2FReVNEaEtiOGhhTW4zcXE2K0FFbzVRbXh6ZmhxVytROHQzNgo5UnRKNElSOThqVzJqemYwR2VVQko3d1hyYnZyRFJTNXJOTjdYOUNVRlI1UWJjcWNsV21XWjhPQnNEZEdzTGVSCmNnN05OTkwzVkpvSEZlelJMdVZZK3JwNQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\n    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlKS1FJQkFBS0NBZ0VBMk9NaGRNM2loTEJFdGx6bzNkbC9Yc0dQR3hQQktFaDVUNnFwSGhVdkJXWmtpV1MrClFoRm9KOHpzU3JRTmgvZjR2a3JnK0dnQURKTGNVcEhmQXl5REFGN0I4b3dsM3pMRXJOS3VHaHdqMENRQVFiRnkKczl0YjVqRVE1dm1QRDd3MkZpWE0xUWJySnBmNVE4UmluT3A0WkhVemJEZHRudkt0SmhuYmIzV2hIcENSb2JIRwpZZVNxeW0zaWZ1SGRseUIwbTVlcHptcU41N0pxbWFXT2cyRUFwRVljbHE2cmdXazJxeGg2MGJwVGc5dXY2MUpnCkZGQStVcTQ1THcvdDdmM1VLRFpxVnBVMDlIdGdURnZZNGVRZStkV2c4U0swQTQzTzZhTWMzUTdieGRybDhoRlEKSkRML1RWZDdwaS9VMmk5MUdYMHhMYW9lNkpyQmhERnZad3hJbXFMWjJUNk9sSVNXY1o3cHJjdWpNRStsTUhBcApIVGRIWkpoRVFnRjc1RVlxMXUwRkRZQUVDUll2OGlKUUtVQ0hOTFZlWUY2VHA5b3ZieUZRZ2kzeElxc2JValo0CmgzdmU0ei9Nc2JYVWVYYTh4WUlQakkremJpb0JrWjV3T1BpM1BoTmMvNWlFcHp0STM5R0t4REZSV1g1eUdvRlgKd0VXbloxWVRlL2JJZ21vMHRuK1lmaldCUWRXVFhGYmN4bFllekJjQ2gwVEg3WWVQd3UxZmphRlArTkhqcFpkcwpQSERYbkVPU2ZFSHN4cUhDc3NtbzNQWWRUaFNzdEJ1SmlnZDNmUkordUxQNy9PejRmREpSNDV6T1RMeGdycFlCClZVeUlJZmwrM2xUcEpaek5KR3dtRFZLQkFlZ1FkY3BkMElxUkVuWHZ2Z2dnN0hyQi9KYWZKeEhJVkNNQ0F3RUEKQVFLQ0FnQkI3RWV2Q1NWZ3ozTVRPd3BNNUY4aW5oS3hXRC9OenJtUXpYNjU5aFprdmNxeE9EM2NOdzVCaXJnSAp2TktnRVc4NTUraVptSUxyVDNoSVlLNDRlTDhZemJTRjFMTnVOREF6bDVYenVibm8rZ2haNzJXOTVWNzVpTkJxClpGQm5wLzJJbmRTMHEzV3VOV00raGVLemIxRkl0NWI1dlo5RVFOOEFSYnU5RlRQejVsMWRtSHVFSmMwRDJvS04Kcm5sOEJoRnJlWjNUYisvU0RSajV1cWltcGtWYnFUUG5XUkFvTmFLNFBxaVdOdHhMcCtyQXpEa0g4NXY5NVpiYwpCeXQ2dXp4UlBMajF1RVJ3UzAvcDVjRDJhREJDSC96YlRvRUkwNEdnNGtOVHJjQi9VeG14aWpHaHp4NXFrN3l4CnRyZ3IyV0R1Ym04VVFqRkM0a2NQdHpiMVMzYUZldHZlaks1ZkJubTIzcjcvNlpUenhsek9Vd0VBcmtZejVJZkoKYTE3Wkt0b2wyOWNrRmsvaGNyb0R5b0ZCUTlGTUZ5MGxYM1VmRkh3T1FvazVrVjNFQmhJK2NMbUR4YXZaN3cweQptdXlpWnZLYjlEQ0lEdlIxQ2hxTGVuVzBTd1M1dTV0WHhiYWFTVlQzV3h2VDZYSDFxYTc1alpKVEJjNG1kdzkvCjNGbjlQQ2RZUVdsNHZKWEJsdUtFSVJOYktlNWhPSnVwVmMrK0hJSnd5clg3cm1aS3lkS1RpeEFYZUlleitnNmIKWFVmZFZQdEJTMW5ZUXhTaVg1RFhTUjdBNUJ0TE02VUR4K0xUVlBXNjIvYXJKcUNqcjlSM2F4eHhHUnVOVTJvcApyMGp6UDJtdElKMVVVcUlDQ3dGTTFjeEFrUHBOUTMzSzBneVJmeU1INTBCMkVDaEhnUUtDQVFFQTYxQjhJalJFClJqOWsyQVA0TEh6VGN6WFRtdGVISGFQRXdraXJxMUdPTXljc0xyWDZUNWpMU05JK1p4bWprdnNFZ1o5SFFnQUIKYVAxSDNsSndHZWdONmg2UnkyN1hwUlFuTlJTK1o5VTlET3VzNEtRMDhMc2pOOUErRWlMYXlnVkt0V21BMExuWAozc05VQ2Y0dkZvNGhyRHdtUDlnMkhYM0FpNXN1TUswaDBhMytpUEYxNXdsWUFGeUxCMzZKRmdxK2ZyUjA3bGdYClVHak1YN1k4d0JubUFVaFBQSVFENDZlK1gwNEpuWE12VC9tZEw2Z1I2MDhBQmt4RmRMVkprcmM4SWJlN1h2dUYKckQzMnBpMmNUZm5mM0prdm5YclZhUlYwendjbGJyaGRsK0JVZ0ZwUE9SbmI5K3NEOTlzUGE1UHYzNEZOV2NHVAp1RjVCWnBBZXdEWDhad0tDQVFFQTYvUDErK2RzOStlaSttN2dmSXJ5TkFYUmJIVzZnUzgyMUpsVGQveWhOUnJrCnB1Z1BIQUxrSGdkQndpT294akI3V2QraGU2VWxtVnJVMHo1R1lEb24wOUx6eVJ4WE9lZ2t4T3UrK09FTE9UbTQKaEhqQmhlM0JNbzdRRjBtdXh2SUxOd1gxTkpaZ1UzdmZkNFZsOHdDQlNNdWJEMkVaazdBdE0zZGtjaFlkRXB0dQpDRkJWdjVTRXRiTjlLZzNqb2o1RW5LbkJHUXR4VFk3V1RxZGlHSCtSZWhMV2ZQNWxSRE9jNUhDV1JKMEhBMVU4Ci93YTFzbTJYblhMWnB5bXBmZzJUblVxeXV4eDk4RGE0VUgzV3FWdVhveml6YVBPSE9EVWMxUW5BWXNPUU1DVXkKZk5TNS9MMXpGYnR5d2xyOHlZUUx5cmthVWwwK3MxSXByalFVUEo2VTVRS0NBUUFZd2NQOW1VQWhuK1BOTWtXMgo4SDhTblBRaFUxR2MxYkVLdTdpTDhxMmlSaG5JNUU1c2QyZlR4b0xZT0FOVW9HSXQvUUx6TjZydVQ4OXkzWHQ3CnprVkFmMnpaV1ZVSXdpRUozWi9XcnNHWWpXY0h6MTdlZ09ISXFua05VV3R4VzdNcmVPa2JqS0hnaHU1ZGlzZUwKZVBLaiswUU83WUZzQXVIeURpYUM2b1FuV2tYd1JHOGlHb0tPcnkzVllRT3ROUDRydUhLZzdOV3ZHUWQvZmwzUAozQ210c3R6YlFneGl0REE4T0txY1RSVUtOZm5Lbk1VZDI1Ym1Fcm92K0M3QVo5VEV1MTdVTkdRdzVlZ0FQY1kzCkVmWHljSTlvNHhaMjB0SVNRZTgzUWVCZTdUUVd1T21pMlV5aVBiQ1NNQkxrUDVFNkU1Rit3dlgyckx2MnZXenUKemY4N0FvSUJBUUNFbUhOcW5WSUtPbHpIT1Zua0F6MDY2TzRZY2t4ZDNvZUVqNmx0YTBXNGp5VmhlbFZMVzRDUQpNMm5MekxoQ3Irb1J4bTk4Q1lHSW5aZXVJbmZ3Q1o1cUZra3pnajZ1WnZ1S3dpUnV2aUROaHRkZmNuRG1iNGE3CmY3QUc5anhHeHF4d3ZtTmVxd2IwdzA4QVhyRzlEbEtZOHZwdmVSU2pmMFRYZ0VldEtTb3JVN2RRNnJ4VlRnUUsKREJUUmRqNnU1U2t2bE9IVHppOWM4MkVSa0ZTN0NhMWFHWTM1YmdqQWUvUzJGMk1LcWVmUUFxMmxiMExhUTJZSgpjQXBLTzBwcGNQMjhUY2NGQ1d6b2VnZTREQTkrMnQ3ck5hajAySzNyYzBXQm50cERaano0SVY4dThXaVhWR3VCCkVmYmFxOEVWQ2FTS3h0eTQzbmVtMUF4aVBoZ0ZQT1RWQW9JQkFRRGNwUlpXWkRvMEVnU2haWG5HQ0NaYUQxNlQKVXA0eFRZRmg2NmZsQThJdHBKUDVWdWJ4eER5YURRanJnbDFZYXovNTdyUXdLUk92czdDQ3YvUUZVN2hkcEZOTAoxVHdkTjgrS2Q5VmtnKzR0YjBJQ2h5cDJacW9VMmpsRkVMMjBlSUdRWTdLUGhJREtYMisvcVQ2bEZOWGdxQVZyClBWbmJuWUl0SGd3ZWtBZjVPbHFreDV2SjMvaHVERDRnRVg3NElGemMwVnVqS3pZZmxoZ2xxSVd1TDdQd1V3M1kKSTBQZVdtVjRZejJSVnI1amd3T3M5eFd1QWxXNUVUdHQrUysreEpZVVpQYytlL0FpSGg3SElaTHFrMU5KSk1VUAo4YklnaTNIS2Eza21HajVMbHQ1Kzl4WG4vTzgvY0Z3ak9nSHFqNTJRL09teDdnWTcvNkRwVmdaOUxVZm8KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K\n    token: o3f9fxe7v3k0fgtdxt5wa0bi7gcwv1jmqtje43z1wk8qh8385a7yw8ccnai5gm7ee7o6b95mvsdvw2skjatcn1rfptoevq2j5urzwv03klst997cpo7y7dei6s961qam\n"
+    },
+    "Addons": {
+      "KeyValueList": null
+    },
+    "Status": "Active",
+    "CreatedTime": "2026-08-20T06:15:57Z",
+    "KeyValueList": [
+      {
+        "key": "Location",
+        "value": "koreasouth"
+      },
+      {
+        "key": "Identity",
+        "value": "{principalId:af8b295b-80f2-4e28-b34b-11a597b8a6d4,tenantId:fb98dda1-32ff-48eb-a489-62777cd9ccd8,type:SystemAssigned}"
+      },
+      {
+        "key": "Kind",
+        "value": "Base"
+      },
+      {
+        "key": "Properties",
+        "value": "{agentPoolProfiles:[{count:2,currentOrchestratorVersion:1.34.8,eTag:9235cebc-da3f-4363-9ea7-3b0097a130f9,enableAutoScaling:false,enableFIPS:false,enableNodePublicIP:true,kubeletDiskType:OS,maxPods:110,mode:System,name:workers1,nodeImageVersion:AKSUbuntu-2204gen2containerd-202608.06.1,orchestratorVersion:1.34.8,osDiskSizeGB:100,osDiskType:Managed,osSKU:Ubuntu,osType:Linux,powerState:{code:Running},provisioningState:Succeeded,scaleDownMode:Delete,securityProfile:{enableSecureBoot:false,enableVTPM:false,sshAccess:LocalUser},type:VirtualMachineScaleSets,upgradeSettings:{maxSurge:10%,maxUnavailable:0},vmSize:Standard_B4as_v2,vnetSubnetID:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/virtualNetworks/tbjvs627fsvq9c8qjdmm/subnets/tbi5s3q7etm8cahfjubo}],autoUpgradeProfile:{nodeOSUpgradeChannel:NodeImage},azurePortalFQDN:dns-1787206565697750064-yka2fsje.portal.hcp.koreasouth.azmk8s.io,bootstrapProfile:{artifactSource:Direct},currentKubernetesVersion:1.34.8,dnsPrefix:dns-1787206565697750064,enableRBAC:true,fqdn:dns-1787206565697750064-yka2fsje.hcp.koreasouth.azmk8s.io,identityProfile:{kubeletidentity:{clientId:abd41f07-a701-4feb-ba6b-1285f8ab81da,objectId:7a46f1bd-30fb-4ee8-bf99-b27c0e72e658,resourceId:/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.ManagedIdentity/userAssignedIdentities/tbkpeno23hnamhgbrptu-agentpool}},ingressProfile:{webAppRouting:{dnsZoneResourceIds:[/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/koreasouth/providers/Microsoft.Network/dnszones/tbkpeno23hnamhgbrptu.com],enabled:true,gatewayAPIImplementations:{appRoutingIstio:{mode:Disabled}},identity:{clientId:75ca6f0a-bac5-4065-99b8-62477be438c6,objectId:383c4ad1-bd05-49bd-a902-ecb08d20c4e3,resourceId:/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.ManagedIdentity/userAssignedIdentities/webapprouting-tbkpeno23hnamhgbrptu},nginx:{defaultIngressControllerType:AnnotationControlled}}},kubernetesVersion:1.34.8,linuxProfile:{adminUsername:cb-user,ssh:{publicKeys:[{keyData:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDA7EqTWJv+hdZCkyjquj4TaYf5mYZQ4lsvvjLwuWaFV6BKS0Owt/B+rMl4PYS6zuK2hBjBFFYVY/hmPyhUiSzyX93wWSrHk2axbJyL++kJSVQ0dmO8Tcnr47K8Tp6WI+Ex72s5vIeKnltDbjLIsYHcisuB0bPNfDREFO3aUkKjub3l40Nowq2SmlOV4pB1MpUigKUPrh4QVrRhF0vdcXSzZ1wYCfWiPzF/fU0d+7f7raTwc8bDgHRSYsOQ7r4Je8XV2HPyG4kMU1z55l1RZkWE4Nhn2Ojy+H2nq/PGt+LB9M10U7f1iykdIG7N40SoyGnTekyPDZ9/o8E8yOjaMMAhBLFy9xs1VTARi2ZhJUKF/8MQRV/hZYMEZclYH8CGCiFvDBsU0xCgKjtsso8WO2zoGcmdZTDQb4+gy/wvvHRFGQPnTY79MfKPLtUu3B7c0uDVGtS5reeDlDsU2Is2e7pFX29sMZ3r9C8w61raTlUUagTLNbiHkTPiXgU4MFHDIeDpqKP5dBF6FW/qq4whuwQJSpjVg7H/m529RCo+5WgtnoZNEbvVZbXi5R69AEemoEvanua+ThwtytrE2yOsu7hVo0kvMjezxgodoyZLxwxYi8trvvNJxen3Ck2c6r/AzVx0slcjguz3uNi0RQf0hQQ30gva4VzDVjZwLWQx5Ngz6Q==\\n}]}},maxAgentPools:100,metricsProfile:{costAnalysis:{enabled:false}},networkProfile:{dnsServiceIP:10.1.0.10,ipFamilies:[IPv4],loadBalancerProfile:{backendPoolType:nodeIPConfiguration,effectiveOutboundIPs:[{id:/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth/providers/Microsoft.Network/publicIPAddresses/3db7c26c-f4e9-4809-8c72-397081fa2272}],managedOutboundIPs:{count:1}},loadBalancerSku:standard,networkDataplane:azure,networkPlugin:azure,networkPolicy:azure,outboundType:loadBalancer,serviceCidr:10.1.0.0/16,serviceCidrs:[10.1.0.0/16]},nodeProvisioningProfile:{mode:Manual},nodeResourceGroup:CB_koreasouth_tbkpeno23hnamhgbrptu_koreasouth,oidcIssuerProfile:{enabled:true,issuerURL:https://koreasouth.oic.prod-aks.azure.com/fb98dda1-32ff-48eb-a489-62777cd9ccd8/56872a0b-9f7c-48ba-9126-59931441f480/},powerState:{code:Running},provisioningState:Succeeded,resourceUID:6a869bac954cc2000164bc4f,securityProfile:{},servicePrincipalProfile:{clientId:msi},storageProfile:{diskCSIDriver:{enabled:true},fileCSIDriver:{enabled:true},snapshotController:{enabled:true}},supportPlan:KubernetesOfficial,windowsProfile:{adminUsername:azureuser,enableCSIProxy:true},workloadAutoScalerProfile:{}}"
+      },
+      {
+        "key": "SKU",
+        "value": "{name:Base,tier:Standard}"
+      },
+      {
+        "key": "Tags",
+        "value": "{createdAt:1787206557,ownerCluster:tbkpeno23hnamhgbrptu,sshkey:tbh9oq28l3i7cb1062kn,sys.connectionName:azure-koreasouth,sys.createdTime:2026-08-20 06:15:57 +0000 UTC,sys.cspResourceId:/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu,sys.cspResourceName:tbkpeno23hnamhgbrptu,sys.description:Migrated from on-premise K8s cluster (v1.32.3, 2 workers),sys.id:mig02-on-prem-k8s-cluster,sys.labelType:k8s,sys.manager:cb-tumblebug,sys.name:mig02-on-prem-k8s-cluster,sys.namespace:mig01,sys.uid:tbkpeno23hnamhgbrptu,sys.version:1.34.8}"
+      },
+      {
+        "key": "ETag",
+        "value": "b754aaf9-c1eb-4055-8256-4a1942a7e032"
+      },
+      {
+        "key": "ID",
+        "value": "/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/koreasouth/providers/Microsoft.ContainerService/managedClusters/tbkpeno23hnamhgbrptu"
+      },
+      {
+        "key": "Name",
+        "value": "tbkpeno23hnamhgbrptu"
+      },
+      {
+        "key": "Type",
+        "value": "Microsoft.ContainerService/ManagedClusters"
+      }
+    ]
+  }
+}
+```
+
+</details>
+

--- a/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-gcp.md
+++ b/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-results-gcp.md
@@ -1,0 +1,1093 @@
+# CM-Beetle K8s Infra Migration Test Results — GCP-Seoul
+
+> [!NOTE]
+> Full lifecycle against a real CSP: recommend → migrate → list → get (verified against
+> the recommendation) → delete → residual resource check.
+
+## Environment
+
+- CSP / Region: gcp / asia-northeast3
+- CM-Beetle URL: http://localhost:8056
+- CM-Beetle Version: v0.6.0
+- Git Commit: 803afb4
+- Namespace: mig01
+- Test Date: 2026-08-20 15:15:55 KST
+- Cluster ID: mig03-on-prem-k8s-cluster
+
+## Test Results Summary
+
+| Step | Description | Status | Duration |
+|------|-------------|--------|----------|
+| 1 | POST /recommendation/k8sCluster | ✅ **PASS** | 17ms |
+| 2 | POST /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 5m0.057s |
+| 3 | GET /migration/ns/{nsId}/k8sCluster | ✅ **PASS** | 1ms |
+| 4 | GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation | ✅ **PASS** | 6.698s |
+| 5 | Workload verification (kubeconfig -> K8s API -> nginx) | ✅ **PASS** | 1m4.399s |
+| 6 | DELETE /migration/ns/{nsId}/k8sCluster/{id} | ✅ **PASS** | 9m14.565s |
+| 7 | Residual resource check (Tumblebug) | ✅ **PASS** | 2ms |
+
+**Overall Result**: 7/7 steps passed ✅
+
+**Total Duration**: 15m25s
+
+---
+
+## Step Details
+
+### Step 1 — POST /recommendation/k8sCluster
+
+- **Duration**: 17ms
+- **Status Code**: 200
+
+- ℹ️  cluster: on-prem-k8s-cluster (version 1.33.12-gke.1000000)
+- ℹ️  node groups: 1
+- ℹ️  node group[0] "workers1" spec=gcp+asia-northeast3+e2-standard-4 nodes=2
+
+### Step 2 — POST /migration/ns/{nsId}/k8sCluster
+
+- **Duration**: 5m0.057s
+- **Status Code**: 202
+
+- ℹ️  nameSeed: mig03
+- ℹ️  async reqId: 1787206555862907371
+- ℹ️  cluster id: mig03-on-prem-k8s-cluster
+- ℹ️  elapsed: 5m0s
+- ✅ status: Active
+
+### Step 3 — GET /migration/ns/{nsId}/k8sCluster
+
+- **Duration**: 1ms
+- **Status Code**: 200
+
+- ✅ migrated cluster present in list (3 total)
+
+### Step 4 — GET /migration/ns/{nsId}/k8sCluster/{id} + verify vs recommendation
+
+- **Duration**: 6.698s
+- **Status Code**: 200
+
+- ✅ status: Active
+- ✅ node group count matches recommendation: 1
+- ✅ node group "workers1" matches (spec=gcp+asia-northeast3+e2-standard-4, nodes=2)
+- ✅ version: 1.33.12-gke.1000000 (recommended 1.33.12-gke.1000000)
+
+### Step 5 — Workload verification (kubeconfig -> K8s API -> nginx)
+
+- **Duration**: 1m4.399s
+
+- ✅ kubeconfig obtained (server: https://34.47.85.231)
+- ℹ️  auth method: exec credential plugin
+- ✅ cluster token obtained from Tumblebug
+- ✅ API server reachable (v1.33.12-gke.1000000)
+- ✅ 2 node(s) Ready, matching the recommendation
+- ✅ nginx Deployment created
+- ✅ nginx pod Running (attempt 1)
+- ✅ LoadBalancer Service created
+- ✅ LoadBalancer address assigned: 34.50.39.250
+- ✅ nginx served over the LoadBalancer at http://34.50.39.250/ (attempt 1)
+- ✅ LoadBalancer Service removed
+- ✅ nginx Deployment removed
+
+### Step 6 — DELETE /migration/ns/{nsId}/k8sCluster/{id}
+
+- **Duration**: 9m14.565s
+- **Status Code**: 200
+
+- ✅ deleted on attempt 1 (9m14s)
+
+### Step 7 — Residual resource check (Tumblebug)
+
+- **Duration**: 2ms
+
+- ℹ️  VNet mig03-k8s-vpc still exists (known gap)
+- ℹ️  SecurityGroup mig03-k8s-sg still exists (known gap)
+- ℹ️  SshKey mig03-k8s-sshkey still exists (known gap)
+
+## Recommendation (input to migration)
+
+<details>
+  <summary> <ins>Click to see the recommendation</ins> </summary>
+
+```json
+{
+  "status": "recommended",
+  "description": "K8s cluster recommendation for gcp asia-northeast3 (source: v1.32.3 → target: v1.33.12-gke.1000000)",
+  "targetCloud": {
+    "csp": "gcp",
+    "region": "asia-northeast3"
+  },
+  "targetInfra": {
+    "name": "",
+    "installMonAgent": "",
+    "label": null,
+    "systemLabel": "",
+    "description": "",
+    "nodeGroups": null,
+    "policyOnPartialFailure": ""
+  },
+  "targetVNet": {
+    "name": "k8s-vpc",
+    "connectionName": "gcp-asia-northeast3",
+    "cidrBlock": "10.0.0.0/22",
+    "subnetInfoList": [
+      {
+        "name": "k8s-subnet-a",
+        "ipv4_CIDR": "10.0.1.0/24"
+      }
+    ],
+    "description": "VPC for migrated K8s cluster"
+  },
+  "targetSshKey": {
+    "name": "k8s-sshkey",
+    "connectionName": "gcp-asia-northeast3",
+    "description": "SSH key for K8s worker nodes",
+    "cspResourceId": "",
+    "fingerprint": "",
+    "username": "",
+    "verifiedUsername": "",
+    "publicKey": "",
+    "privateKey": ""
+  },
+  "targetSpecList": null,
+  "targetOsImageList": null,
+  "targetSecurityGroupList": [
+    {
+      "name": "k8s-sg",
+      "connectionName": "gcp-asia-northeast3",
+      "vNetId": "INSERT_YOUR_VNET_ID",
+      "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+      "firewallRules": [
+        {
+          "Ports": "22",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "0.0.0.0/0"
+        },
+        {
+          "Ports": "10250",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "10.0.0.0/24"
+        },
+        {
+          "Ports": "30000-32767",
+          "Protocol": "TCP",
+          "Direction": "inbound",
+          "CIDR": "0.0.0.0/0"
+        },
+        {
+          "Ports": "1-65535",
+          "Protocol": "TCP",
+          "Direction": "outbound",
+          "CIDR": "0.0.0.0/0"
+        }
+      ],
+      "cspResourceId": ""
+    }
+  ],
+  "targetK8sCluster": {
+    "connectionName": "gcp-asia-northeast3",
+    "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+    "name": "on-prem-k8s-cluster",
+    "version": "1.33.12-gke.1000000",
+    "vNetId": "",
+    "subnetIds": null,
+    "securityGroupIds": null,
+    "k8sNodeGroupList": [
+      {
+        "name": "workers1",
+        "imageId": "default",
+        "specId": "gcp+asia-northeast3+e2-standard-4",
+        "rootDiskType": "default",
+        "rootDiskSize": 100,
+        "sshKeyId": "",
+        "onAutoScaling": "false",
+        "desiredNodeSize": 2,
+        "minNodeSize": 0,
+        "maxNodeSize": 0,
+        "label": null,
+        "description": "Worker node group migrated from on-premise (2 nodes)"
+      }
+    ],
+    "cspResourceId": "",
+    "label": null,
+    "systemLabel": ""
+  }
+}
+```
+
+</details>
+
+## Created Cluster
+
+<details>
+  <summary> <ins>Click to see the cluster info</ins> </summary>
+
+```json
+{
+  "resourceType": "k8s",
+  "id": "mig03-on-prem-k8s-cluster",
+  "uid": "tb4376joq2qqrv47qau4",
+  "name": "mig03-on-prem-k8s-cluster",
+  "connectionName": "gcp-asia-northeast3",
+  "connectionConfig": {
+    "configName": "gcp-asia-northeast3",
+    "providerName": "gcp",
+    "driverName": "gcp-driver-v1.0.so",
+    "credentialName": "gcp",
+    "credentialHolder": "admin",
+    "regionZoneInfoName": "gcp-asia-northeast3",
+    "regionZoneInfo": {
+      "assignedRegion": "asia-northeast3",
+      "assignedZone": "asia-northeast3-a"
+    },
+    "regionDetail": {
+      "regionId": "asia-northeast3",
+      "regionName": "asia-northeast3",
+      "description": "Seoul South Korea",
+      "location": {
+        "display": "South Korea (Seoul)",
+        "latitude": 37.2,
+        "longitude": 127
+      },
+      "zones": [
+        "asia-northeast3-a",
+        "asia-northeast3-b",
+        "asia-northeast3-c"
+      ]
+    },
+    "regionRepresentative": true,
+    "verified": true
+  },
+  "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+  "systemMessage": "",
+  "label": {
+    "cb-spider-pmks-securitygroup-0": "tb5vuo31rrnng9587m1n",
+    "sys.connectionName": "gcp-asia-northeast3",
+    "sys.createdTime": "2026-08-20 06:15:59 +0000 UTC",
+    "sys.cspResourceId": "tb4376joq2qqrv47qau4",
+    "sys.cspResourceName": "tb4376joq2qqrv47qau4",
+    "sys.description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+    "sys.id": "mig03-on-prem-k8s-cluster",
+    "sys.labelType": "k8s",
+    "sys.manager": "cb-tumblebug",
+    "sys.name": "mig03-on-prem-k8s-cluster",
+    "sys.namespace": "mig01",
+    "sys.uid": "tb4376joq2qqrv47qau4",
+    "sys.version": "1.33.12-gke.1000000"
+  },
+  "systemLabel": "",
+  "version": "1.33.12-gke.1000000",
+  "network": {
+    "vNetId": "mig03-k8s-vpc",
+    "subnetIds": [
+      "mig03-k8s-subnet-a"
+    ],
+    "securityGroupIds": [
+      "mig03-k8s-sg"
+    ],
+    "keyValueList": null
+  },
+  "k8sNodeGroupList": [
+    {
+      "id": "workers1",
+      "name": "workers1",
+      "imageId": "default",
+      "specId": "gcp+asia-northeast3+e2-standard-4",
+      "rootDiskType": "pd-balanced",
+      "rootDiskSize": 100,
+      "sshKeyId": "mig03-k8s-sshkey",
+      "onAutoScaling": false,
+      "desiredNodeSize": 2,
+      "minNodeSize": 0,
+      "maxNodeSize": 0,
+      "status": "Active",
+      "k8sNodes": [
+        {
+          "cspResourceName": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-631x",
+          "cspResourceId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-631x"
+        },
+        {
+          "cspResourceName": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-szqw",
+          "cspResourceId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-szqw"
+        }
+      ],
+      "keyValueList": [
+        {
+          "key": "Config",
+          "value": "{bootDisk:{diskType:pd-balanced,sizeGb:100},diskSizeGb:100,diskType:pd-balanced,effectiveCgroupMode:EFFECTIVE_CGROUP_MODE_V2,imageType:COS_CONTAINERD,kubeletConfig:{maxParallelImagePulls:2},labels:{keypair:tb4jmnhc0vlt4svljbps},machineType:e2-standard-4,metadata:{disable-legacy-endpoints:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],resourceLabels:{goog-gke-node-pool-provisioning-model:on-demand},serviceAccount:default,shieldedInstanceConfig:{enableIntegrityMonitoring:true},tags:[tb5vuo31rrnng9587m1n],windowsNodeConfig:{}}"
+        },
+        {
+          "key": "Etag",
+          "value": "d9c380dd-9dd4-4d32-8d99-abfb1c62ba68"
+        },
+        {
+          "key": "InitialNodeCount",
+          "value": "2"
+        },
+        {
+          "key": "InstanceGroupUrls",
+          "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instanceGroupManagers/gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+        },
+        {
+          "key": "Locations",
+          "value": "asia-northeast3-a"
+        },
+        {
+          "key": "Management",
+          "value": "{autoRepair:true,autoUpgrade:true}"
+        },
+        {
+          "key": "MaxPodsConstraint",
+          "value": "{maxPodsPerNode:110}"
+        },
+        {
+          "key": "Name",
+          "value": "workers1"
+        },
+        {
+          "key": "NetworkConfig",
+          "value": "{networkTierConfig:{networkTier:NETWORK_TIER_DEFAULT},podIpv4CidrBlock:10.8.0.0/14,podIpv4RangeUtilization:0.002,podRange:gke-tb4376joq2qqrv47qau4-pods-331fc160,subnetwork:projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbf74se4bdd1ilmjkavo}"
+        },
+        {
+          "key": "PodIpv4CidrSize",
+          "value": "24"
+        },
+        {
+          "key": "SelfLink",
+          "value": "https://container.googleapis.com/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/clusters/tb4376joq2qqrv47qau4/nodePools/workers1"
+        },
+        {
+          "key": "Status",
+          "value": "RUNNING"
+        },
+        {
+          "key": "UpgradeSettings",
+          "value": "{maxSurge:1,strategy:SURGE}"
+        },
+        {
+          "key": "Version",
+          "value": "1.33.12-gke.1000000"
+        },
+        {
+          "key": "InstanceGroup_0",
+          "value": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+        },
+        {
+          "key": "keypair",
+          "value": "tb4jmnhc0vlt4svljbps"
+        }
+      ],
+      "cspResourceName": "workers1",
+      "cspResourceId": "workers1",
+      "spiderViewK8sNodeGroupDetail": {
+        "IId": {
+          "NameId": "workers1",
+          "SystemId": "workers1"
+        },
+        "ImageIID": {
+          "NameId": "COS_CONTAINERD",
+          "SystemId": "COS_CONTAINERD"
+        },
+        "VMSpecName": "e2-standard-4",
+        "RootDiskType": "pd-balanced",
+        "RootDiskSize": "100",
+        "KeyPairIID": {
+          "NameId": "tb4jmnhc0vlt4svljbps",
+          "SystemId": "tb4jmnhc0vlt4svljbps"
+        },
+        "OnAutoScaling": false,
+        "DesiredNodeSize": 2,
+        "MinNodeSize": 0,
+        "MaxNodeSize": 0,
+        "Status": "Active",
+        "Nodes": [
+          {
+            "NameId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-631x",
+            "SystemId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-631x"
+          },
+          {
+            "NameId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-szqw",
+            "SystemId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-szqw"
+          }
+        ],
+        "KeyValueList": [
+          {
+            "key": "Config",
+            "value": "{bootDisk:{diskType:pd-balanced,sizeGb:100},diskSizeGb:100,diskType:pd-balanced,effectiveCgroupMode:EFFECTIVE_CGROUP_MODE_V2,imageType:COS_CONTAINERD,kubeletConfig:{maxParallelImagePulls:2},labels:{keypair:tb4jmnhc0vlt4svljbps},machineType:e2-standard-4,metadata:{disable-legacy-endpoints:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],resourceLabels:{goog-gke-node-pool-provisioning-model:on-demand},serviceAccount:default,shieldedInstanceConfig:{enableIntegrityMonitoring:true},tags:[tb5vuo31rrnng9587m1n],windowsNodeConfig:{}}"
+          },
+          {
+            "key": "Etag",
+            "value": "d9c380dd-9dd4-4d32-8d99-abfb1c62ba68"
+          },
+          {
+            "key": "InitialNodeCount",
+            "value": "2"
+          },
+          {
+            "key": "InstanceGroupUrls",
+            "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instanceGroupManagers/gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+          },
+          {
+            "key": "Locations",
+            "value": "asia-northeast3-a"
+          },
+          {
+            "key": "Management",
+            "value": "{autoRepair:true,autoUpgrade:true}"
+          },
+          {
+            "key": "MaxPodsConstraint",
+            "value": "{maxPodsPerNode:110}"
+          },
+          {
+            "key": "Name",
+            "value": "workers1"
+          },
+          {
+            "key": "NetworkConfig",
+            "value": "{networkTierConfig:{networkTier:NETWORK_TIER_DEFAULT},podIpv4CidrBlock:10.8.0.0/14,podIpv4RangeUtilization:0.002,podRange:gke-tb4376joq2qqrv47qau4-pods-331fc160,subnetwork:projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbf74se4bdd1ilmjkavo}"
+          },
+          {
+            "key": "PodIpv4CidrSize",
+            "value": "24"
+          },
+          {
+            "key": "SelfLink",
+            "value": "https://container.googleapis.com/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/clusters/tb4376joq2qqrv47qau4/nodePools/workers1"
+          },
+          {
+            "key": "Status",
+            "value": "RUNNING"
+          },
+          {
+            "key": "UpgradeSettings",
+            "value": "{maxSurge:1,strategy:SURGE}"
+          },
+          {
+            "key": "Version",
+            "value": "1.33.12-gke.1000000"
+          },
+          {
+            "key": "InstanceGroup_0",
+            "value": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+          },
+          {
+            "key": "keypair",
+            "value": "tb4jmnhc0vlt4svljbps"
+          }
+        ]
+      }
+    }
+  ],
+  "accessInfo": {
+    "endpoint": "34.47.85.231",
+    "kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://34.47.85.231\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxJZTRTMTBNaTBFcWFRK3ZoZzlqUVV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1l6RXdZVFprTldZdFpUTm1PQzAwTVRka0xXRmtPVGd0T1dRNE0yRTROVEV6T1RBegpNQ0FYRFRJMk1EZ3lNREExTVRZd01Gb1lEekl3TlRZd09ERXlNRFl4TmpBd1dqQXZNUzB3S3dZRFZRUURFeVJqCk1UQmhObVExWmkxbE0yWTRMVFF4TjJRdFlXUTVPQzA1WkRnellUZzFNVE01TURNd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDaCtzWlRYTFJ0bk5hY284V1h5dmhuUUw3L1NKUmd2T042QnRZTQo0SjdBVSsyNE1IWlhQdEdXdVdYaU96dDV2Njh0c1I3TUZMcnFOaEp4M05uY21IbFRBbmI2TDgzcDBFNXhKeTBOCmZkSDdSSkdEKzJ5dmFCMGRVQTZPTkZQTjQ1YTduY1ZvOEowSnI4aTkxdUVyYzE3N3pxdlo1WWh0c0VxS1dMM2kKY3hrVVZhdkJxS2pNQi9hOFpQUC90eDRaeDBwNWxudDBKVUcyMWZWYlZiKytYUjc4OE5zbkVONkZWdWw1R2NwWgpkSVlGVE1IUjJtbkx1VnlFb3d1eFk2YnBoSVJaendFRnJvdmxaK1Z5Z1F3czlURnlyMWc1VHVhVTd0S1dXbVpoCmx2bnY1amNuVlBFeGZ4MXR1RXdNM0xDZGZCMngyYUIrSDRnelBWTUZlakE1THRDcnhtM3llR2I1aStNZlpGYWYKNHViNWM2R1llUnUwWGZFekQ4dXFyT0JVVm9HTHNtT25CTW16d1hEeFE5MDVmU3g2bGxWTXRpbmoyMFkvYklrRwpmc0pSek44cDBUWTV0cUN5bGJsc3E3WUJiMXA5UHpZZUE0clBjNERvTmJMM3E5SXJqeXdpc0poRHo2ZGZ1dVlwCkZpSHhweWlXaGNKMVlzam1iTmtQcmRjVlhJc0NBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGUHpKYi9pZis2TzFISnJLeHNaemFaeDhqQTljTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQlNsajJDaXZKa0x5REZHZThHN0ZuY1BvMXdhS3NPaktmZE5pRGpXZjNNCk9Hc1d6QWgxYW5DTVB2d3o0NzNEUHRuYzJQU3pBWDJ6aGxGYWVwcUJSSlgzeDJLOXZPbHhTaUtkRzMyeXA2alcKSVRjd21QcWx4N0NrV0tNSzJGZFBaQ2IyUm9nS3Fwc2lLN2dLbng3UGtMNzdINnpWSGJ2SUlWVHM2QjA0RVNYcQprZEZTLzhOWDhxbFoxd0V4TjNkOVFEYVVrRjBUUk90REVNdDJ0NWowRGtzMzQwcXhlNlVJZDArL0pvSDRXMXk3CnZDM0FuV0lJc3BKTDZ3dDEwN09CbUdsaEJpSC8vUHlrYjNwbzdERzEzdk9TYXhFVGJObjVHZjMzQ2hoVEthVGQKM2p2OC92cU4wQXRDY3ZoRWY0SHI2YmlUY2R2ZXBFenY5Z2dWajVXVzA3eEVPVlRlbko1MGxNZnpNaGtGYUFYRApLaVduckNlRUg1anhNUDZIRVI4MGtOVmd0bk5HZDJyeHdqS21naUFKN25nUnEybGNhQmhwMzI3YVFadmt0T3V4CmFpQ28yT3VHbllLWkV2OUNyMVdpaERMNW1INm4rMHZTbGdwdkZqdVl0ZDkvR25uNnJoTy9CZ3Q1Z2dWcFFuTzkKQTVXZnU1dmZFaTBXcjlrb2xxYWxWdFE9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\ncontexts:\n- context:\n    cluster: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\n    user: gcp-dynamic-token\n  name: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\ncurrent-context: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\nusers:\n- name: gcp-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tb4376joq2qqrv47qau4/token?ConnectionName=gcp-asia-northeast3\\\"\"\n"
+  },
+  "addons": {
+    "keyValueList": null
+  },
+  "status": "Active",
+  "createdTime": "2026-08-20T06:15:59Z",
+  "keyValueList": [
+    {
+      "key": "AddonsConfig",
+      "value": "{gcePersistentDiskCsiDriverConfig:{enabled:true},kubernetesDashboard:{disabled:true},networkPolicyConfig:{disabled:true}}"
+    },
+    {
+      "key": "AnonymousAuthenticationConfig",
+      "value": "{mode:ENABLED}"
+    },
+    {
+      "key": "Autopilot",
+      "value": "{}"
+    },
+    {
+      "key": "Autoscaling",
+      "value": "{autoprovisioningNodePoolDefaults:{imageType:COS_CONTAINERD,management:{autoRepair:true,autoUpgrade:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],serviceAccount:default},autoscalingProfile:BALANCED}"
+    },
+    {
+      "key": "ClusterIpv4Cidr",
+      "value": "10.8.0.0/14"
+    },
+    {
+      "key": "ControlPlaneEndpointsConfig",
+      "value": "{dnsEndpointConfig:{endpoint:gke-331fc160950b490f8aa57aa47d944bf5b40b-1064665102650.asia-northeast3-a.gke.goog},ipEndpointsConfig:{authorizedNetworksConfig:{},enablePublicEndpoint:true,enabled:true,privateEndpoint:10.0.1.8,publicEndpoint:34.47.85.231}}"
+    },
+    {
+      "key": "CreateTime",
+      "value": "2026-08-20T06:15:59+00:00"
+    },
+    {
+      "key": "CurrentMasterVersion",
+      "value": "1.33.12-gke.1000000"
+    },
+    {
+      "key": "CurrentNodeCount",
+      "value": "2"
+    },
+    {
+      "key": "CurrentNodeVersion",
+      "value": "1.33.12-gke.1000000"
+    },
+    {
+      "key": "DatabaseEncryption",
+      "value": "{currentState:CURRENT_STATE_DECRYPTED,state:DECRYPTED}"
+    },
+    {
+      "key": "DefaultMaxPodsConstraint",
+      "value": "{maxPodsPerNode:110}"
+    },
+    {
+      "key": "EnableKubernetesAlpha",
+      "value": "false"
+    },
+    {
+      "key": "EnableTpu",
+      "value": "false"
+    },
+    {
+      "key": "Endpoint",
+      "value": "34.47.85.231"
+    },
+    {
+      "key": "EnterpriseConfig",
+      "value": "{clusterTier:STANDARD}"
+    },
+    {
+      "key": "Etag",
+      "value": "fb3b6858-b12a-4c44-b14d-d17d2f1e2744"
+    },
+    {
+      "key": "Id",
+      "value": "331fc160950b490f8aa57aa47d944bf5b40b2562089242069dca40971400e3ab"
+    },
+    {
+      "key": "InitialClusterVersion",
+      "value": "1.33.12-gke.1000000"
+    },
+    {
+      "key": "InitialNodeCount",
+      "value": "0"
+    },
+    {
+      "key": "InstanceGroupUrls",
+      "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instanceGroupManagers/gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+    },
+    {
+      "key": "IpAllocationPolicy",
+      "value": "{clusterIpv4Cidr:10.8.0.0/14,clusterIpv4CidrBlock:10.8.0.0/14,clusterSecondaryRangeName:gke-tb4376joq2qqrv47qau4-pods-331fc160,defaultPodIpv4RangeUtilization:0.002,networkTierConfig:{networkTier:NETWORK_TIER_DEFAULT},podCidrOverprovisionConfig:{},servicesIpv4Cidr:34.118.224.0/20,servicesIpv4CidrBlock:34.118.224.0/20,stackType:IPV4,useIpAliases:true}"
+    },
+    {
+      "key": "LabelFingerprint",
+      "value": "17c2404d"
+    },
+    {
+      "key": "LegacyAbac",
+      "value": "{}"
+    },
+    {
+      "key": "Location",
+      "value": "asia-northeast3-a"
+    },
+    {
+      "key": "Locations",
+      "value": "asia-northeast3-a"
+    },
+    {
+      "key": "LoggingConfig",
+      "value": "{componentConfig:{enableComponents:[SYSTEM_COMPONENTS,WORKLOADS]}}"
+    },
+    {
+      "key": "LoggingService",
+      "value": "logging.googleapis.com/kubernetes"
+    },
+    {
+      "key": "MaintenancePolicy",
+      "value": "{resourceVersion:e3b0c442}"
+    },
+    {
+      "key": "MasterAuth",
+      "value": "{clientCertificateConfig:{},clusterCaCertificate:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxJZTRTMTBNaTBFcWFRK3ZoZzlqUVV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1l6RXdZVFprTldZdFpUTm1PQzAwTVRka0xXRmtPVGd0T1dRNE0yRTROVEV6T1RBegpNQ0FYRFRJMk1EZ3lNREExTVRZd01Gb1lEekl3TlRZd09ERXlNRFl4TmpBd1dqQXZNUzB3S3dZRFZRUURFeVJqCk1UQmhObVExWmkxbE0yWTRMVFF4TjJRdFlXUTVPQzA1WkRnellUZzFNVE01TURNd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDaCtzWlRYTFJ0bk5hY284V1h5dmhuUUw3L1NKUmd2T042QnRZTQo0SjdBVSsyNE1IWlhQdEdXdVdYaU96dDV2Njh0c1I3TUZMcnFOaEp4M05uY21IbFRBbmI2TDgzcDBFNXhKeTBOCmZkSDdSSkdEKzJ5dmFCMGRVQTZPTkZQTjQ1YTduY1ZvOEowSnI4aTkxdUVyYzE3N3pxdlo1WWh0c0VxS1dMM2kKY3hrVVZhdkJxS2pNQi9hOFpQUC90eDRaeDBwNWxudDBKVUcyMWZWYlZiKytYUjc4OE5zbkVONkZWdWw1R2NwWgpkSVlGVE1IUjJtbkx1VnlFb3d1eFk2YnBoSVJaendFRnJvdmxaK1Z5Z1F3czlURnlyMWc1VHVhVTd0S1dXbVpoCmx2bnY1amNuVlBFeGZ4MXR1RXdNM0xDZGZCMngyYUIrSDRnelBWTUZlakE1THRDcnhtM3llR2I1aStNZlpGYWYKNHViNWM2R1llUnUwWGZFekQ4dXFyT0JVVm9HTHNtT25CTW16d1hEeFE5MDVmU3g2bGxWTXRpbmoyMFkvYklrRwpmc0pSek44cDBUWTV0cUN5bGJsc3E3WUJiMXA5UHpZZUE0clBjNERvTmJMM3E5SXJqeXdpc0poRHo2ZGZ1dVlwCkZpSHhweWlXaGNKMVlzam1iTmtQcmRjVlhJc0NBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGUHpKYi9pZis2TzFISnJLeHNaemFaeDhqQTljTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQlNsajJDaXZKa0x5REZHZThHN0ZuY1BvMXdhS3NPaktmZE5pRGpXZjNNCk9Hc1d6QWgxYW5DTVB2d3o0NzNEUHRuYzJQU3pBWDJ6aGxGYWVwcUJSSlgzeDJLOXZPbHhTaUtkRzMyeXA2alcKSVRjd21QcWx4N0NrV0tNSzJGZFBaQ2IyUm9nS3Fwc2lLN2dLbng3UGtMNzdINnpWSGJ2SUlWVHM2QjA0RVNYcQprZEZTLzhOWDhxbFoxd0V4TjNkOVFEYVVrRjBUUk90REVNdDJ0NWowRGtzMzQwcXhlNlVJZDArL0pvSDRXMXk3CnZDM0FuV0lJc3BKTDZ3dDEwN09CbUdsaEJpSC8vUHlrYjNwbzdERzEzdk9TYXhFVGJObjVHZjMzQ2hoVEthVGQKM2p2OC92cU4wQXRDY3ZoRWY0SHI2YmlUY2R2ZXBFenY5Z2dWajVXVzA3eEVPVlRlbko1MGxNZnpNaGtGYUFYRApLaVduckNlRUg1anhNUDZIRVI4MGtOVmd0bk5HZDJyeHdqS21naUFKN25nUnEybGNhQmhwMzI3YVFadmt0T3V4CmFpQ28yT3VHbllLWkV2OUNyMVdpaERMNW1INm4rMHZTbGdwdkZqdVl0ZDkvR25uNnJoTy9CZ3Q1Z2dWcFFuTzkKQTVXZnU1dmZFaTBXcjlrb2xxYWxWdFE9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
+    },
+    {
+      "key": "MasterAuthorizedNetworksConfig",
+      "value": "{}"
+    },
+    {
+      "key": "MonitoringConfig",
+      "value": "{advancedDatapathObservabilityConfig:{},componentConfig:{enableComponents:[SYSTEM_COMPONENTS,STATEFULSET,JOBSET,STORAGE,HPA,POD,DAEMONSET,DEPLOYMENT,CADVISOR,KUBELET,DCGM]},managedPrometheusConfig:{enabled:true}}"
+    },
+    {
+      "key": "MonitoringService",
+      "value": "monitoring.googleapis.com/kubernetes"
+    },
+    {
+      "key": "Name",
+      "value": "tb4376joq2qqrv47qau4"
+    },
+    {
+      "key": "Network",
+      "value": "tb8e4ivjhph8tj8eq3c5"
+    },
+    {
+      "key": "NetworkConfig",
+      "value": "{network:projects/GCP_PROJECT_ID/global/networks/tb8e4ivjhph8tj8eq3c5,serviceExternalIpsConfig:{},subnetwork:projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbf74se4bdd1ilmjkavo}"
+    },
+    {
+      "key": "NodeConfig",
+      "value": "{bootDisk:{diskType:pd-balanced,sizeGb:100},diskSizeGb:100,diskType:pd-balanced,effectiveCgroupMode:EFFECTIVE_CGROUP_MODE_V2,imageType:COS_CONTAINERD,kubeletConfig:{maxParallelImagePulls:2},labels:{keypair:tb4jmnhc0vlt4svljbps},machineType:e2-standard-4,metadata:{disable-legacy-endpoints:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],resourceLabels:{goog-gke-node-pool-provisioning-model:on-demand},serviceAccount:default,shieldedInstanceConfig:{enableIntegrityMonitoring:true},tags:[tb5vuo31rrnng9587m1n],windowsNodeConfig:{}}"
+    },
+    {
+      "key": "NodeIpv4CidrSize",
+      "value": "0"
+    },
+    {
+      "key": "NodePoolAutoConfig",
+      "value": "{nodeKubeletConfig:{}}"
+    },
+    {
+      "key": "NodePoolDefaults",
+      "value": "{nodeConfigDefaults:{loggingConfig:{variantConfig:{variant:DEFAULT}},nodeKubeletConfig:{}}}"
+    },
+    {
+      "key": "NodePools",
+      "value": "{config:{bootDisk:{diskType:pd-balanced,sizeGb:100},diskSizeGb:100,diskType:pd-balanced,effectiveCgroupMode:EFFECTIVE_CGROUP_MODE_V2,imageType:COS_CONTAINERD,kubeletConfig:{maxParallelImagePulls:2},labels:{keypair:tb4jmnhc0vlt4svljbps},machineType:e2-standard-4,metadata:{disable-legacy-endpoints:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],resourceLabels:{goog-gke-node-pool-provisioning-model:on-demand},serviceAccount:default,shieldedInstanceConfig:{enableIntegrityMonitoring:true},tags:[tb5vuo31rrnng9587m1n],windowsNodeConfig:{}},etag:d9c380dd-9dd4-4d32-8d99-abfb1c62ba68,initialNodeCount:2,instanceGroupUrls:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instanceGroupManagers/gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp],locations:[asia-northeast3-a],management:{autoRepair:true,autoUpgrade:true},maxPodsConstraint:{maxPodsPerNode:110},name:workers1,networkConfig:{networkTierConfig:{networkTier:NETWORK_TIER_DEFAULT},podIpv4CidrBlock:10.8.0.0/14,podIpv4RangeUtilization:0.002,podRange:gke-tb4376joq2qqrv47qau4-pods-331fc160,subnetwork:projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbf74se4bdd1ilmjkavo},podIpv4CidrSize:24,selfLink:https://container.googleapis.com/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/clusters/tb4376joq2qqrv47qau4/nodePools/workers1,status:RUNNING,upgradeSettings:{maxSurge:1,strategy:SURGE},version:1.33.12-gke.1000000}"
+    },
+    {
+      "key": "NotificationConfig",
+      "value": "{pubsub:{}}"
+    },
+    {
+      "key": "PodAutoscaling",
+      "value": "{hpaProfile:PERFORMANCE}"
+    },
+    {
+      "key": "PrivateClusterConfig",
+      "value": "{privateEndpoint:10.0.1.8,publicEndpoint:34.47.85.231}"
+    },
+    {
+      "key": "RbacBindingConfig",
+      "value": "{enableInsecureBindingSystemAuthenticated:true,enableInsecureBindingSystemUnauthenticated:true}"
+    },
+    {
+      "key": "ReleaseChannel",
+      "value": "{channel:STABLE}"
+    },
+    {
+      "key": "ResourceLabels",
+      "value": "{cb-spider-pmks-securitygroup-0:tb5vuo31rrnng9587m1n}"
+    },
+    {
+      "key": "SatisfiesPzi",
+      "value": "false"
+    },
+    {
+      "key": "SatisfiesPzs",
+      "value": "false"
+    },
+    {
+      "key": "SecurityPostureConfig",
+      "value": "{mode:BASIC,vulnerabilityMode:VULNERABILITY_MODE_UNSPECIFIED}"
+    },
+    {
+      "key": "SelfLink",
+      "value": "https://container.googleapis.com/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/clusters/tb4376joq2qqrv47qau4"
+    },
+    {
+      "key": "ServicesIpv4Cidr",
+      "value": "34.118.224.0/20"
+    },
+    {
+      "key": "ShieldedNodes",
+      "value": "{enabled:true}"
+    },
+    {
+      "key": "Status",
+      "value": "RUNNING"
+    },
+    {
+      "key": "Subnetwork",
+      "value": "tbf74se4bdd1ilmjkavo"
+    },
+    {
+      "key": "UserManagedKeysConfig",
+      "value": "{}"
+    },
+    {
+      "key": "Zone",
+      "value": "asia-northeast3-a"
+    }
+  ],
+  "cspResourceName": "tb4376joq2qqrv47qau4",
+  "cspResourceId": "tb4376joq2qqrv47qau4",
+  "spiderViewK8sClusterDetail": {
+    "IId": {
+      "NameId": "tb4376joq2qqrv47qau4",
+      "SystemId": "tb4376joq2qqrv47qau4"
+    },
+    "Version": "1.33.12-gke.1000000",
+    "Network": {
+      "VpcIID": {
+        "NameId": "tb8e4ivjhph8tj8eq3c5",
+        "SystemId": "tb8e4ivjhph8tj8eq3c5"
+      },
+      "SubnetIIDs": [
+        {
+          "NameId": "tbf74se4bdd1ilmjkavo",
+          "SystemId": "tbf74se4bdd1ilmjkavo"
+        }
+      ],
+      "SecurityGroupIIDs": [
+        {
+          "NameId": "tb5vuo31rrnng9587m1n",
+          "SystemId": "tb5vuo31rrnng9587m1n"
+        }
+      ],
+      "KeyValueList": null
+    },
+    "NodeGroupList": [
+      {
+        "IId": {
+          "NameId": "workers1",
+          "SystemId": "workers1"
+        },
+        "ImageIID": {
+          "NameId": "COS_CONTAINERD",
+          "SystemId": "COS_CONTAINERD"
+        },
+        "VMSpecName": "e2-standard-4",
+        "RootDiskType": "pd-balanced",
+        "RootDiskSize": "100",
+        "KeyPairIID": {
+          "NameId": "tb4jmnhc0vlt4svljbps",
+          "SystemId": "tb4jmnhc0vlt4svljbps"
+        },
+        "OnAutoScaling": false,
+        "DesiredNodeSize": 2,
+        "MinNodeSize": 0,
+        "MaxNodeSize": 0,
+        "Status": "Active",
+        "Nodes": [
+          {
+            "NameId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-631x",
+            "SystemId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-631x"
+          },
+          {
+            "NameId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-szqw",
+            "SystemId": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-szqw"
+          }
+        ],
+        "KeyValueList": [
+          {
+            "key": "Config",
+            "value": "{bootDisk:{diskType:pd-balanced,sizeGb:100},diskSizeGb:100,diskType:pd-balanced,effectiveCgroupMode:EFFECTIVE_CGROUP_MODE_V2,imageType:COS_CONTAINERD,kubeletConfig:{maxParallelImagePulls:2},labels:{keypair:tb4jmnhc0vlt4svljbps},machineType:e2-standard-4,metadata:{disable-legacy-endpoints:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],resourceLabels:{goog-gke-node-pool-provisioning-model:on-demand},serviceAccount:default,shieldedInstanceConfig:{enableIntegrityMonitoring:true},tags:[tb5vuo31rrnng9587m1n],windowsNodeConfig:{}}"
+          },
+          {
+            "key": "Etag",
+            "value": "d9c380dd-9dd4-4d32-8d99-abfb1c62ba68"
+          },
+          {
+            "key": "InitialNodeCount",
+            "value": "2"
+          },
+          {
+            "key": "InstanceGroupUrls",
+            "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instanceGroupManagers/gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+          },
+          {
+            "key": "Locations",
+            "value": "asia-northeast3-a"
+          },
+          {
+            "key": "Management",
+            "value": "{autoRepair:true,autoUpgrade:true}"
+          },
+          {
+            "key": "MaxPodsConstraint",
+            "value": "{maxPodsPerNode:110}"
+          },
+          {
+            "key": "Name",
+            "value": "workers1"
+          },
+          {
+            "key": "NetworkConfig",
+            "value": "{networkTierConfig:{networkTier:NETWORK_TIER_DEFAULT},podIpv4CidrBlock:10.8.0.0/14,podIpv4RangeUtilization:0.002,podRange:gke-tb4376joq2qqrv47qau4-pods-331fc160,subnetwork:projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbf74se4bdd1ilmjkavo}"
+          },
+          {
+            "key": "PodIpv4CidrSize",
+            "value": "24"
+          },
+          {
+            "key": "SelfLink",
+            "value": "https://container.googleapis.com/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/clusters/tb4376joq2qqrv47qau4/nodePools/workers1"
+          },
+          {
+            "key": "Status",
+            "value": "RUNNING"
+          },
+          {
+            "key": "UpgradeSettings",
+            "value": "{maxSurge:1,strategy:SURGE}"
+          },
+          {
+            "key": "Version",
+            "value": "1.33.12-gke.1000000"
+          },
+          {
+            "key": "InstanceGroup_0",
+            "value": "gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+          },
+          {
+            "key": "keypair",
+            "value": "tb4jmnhc0vlt4svljbps"
+          }
+        ]
+      }
+    ],
+    "AccessInfo": {
+      "Endpoint": "34.47.85.231",
+      "Kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://34.47.85.231\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxJZTRTMTBNaTBFcWFRK3ZoZzlqUVV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1l6RXdZVFprTldZdFpUTm1PQzAwTVRka0xXRmtPVGd0T1dRNE0yRTROVEV6T1RBegpNQ0FYRFRJMk1EZ3lNREExTVRZd01Gb1lEekl3TlRZd09ERXlNRFl4TmpBd1dqQXZNUzB3S3dZRFZRUURFeVJqCk1UQmhObVExWmkxbE0yWTRMVFF4TjJRdFlXUTVPQzA1WkRnellUZzFNVE01TURNd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDaCtzWlRYTFJ0bk5hY284V1h5dmhuUUw3L1NKUmd2T042QnRZTQo0SjdBVSsyNE1IWlhQdEdXdVdYaU96dDV2Njh0c1I3TUZMcnFOaEp4M05uY21IbFRBbmI2TDgzcDBFNXhKeTBOCmZkSDdSSkdEKzJ5dmFCMGRVQTZPTkZQTjQ1YTduY1ZvOEowSnI4aTkxdUVyYzE3N3pxdlo1WWh0c0VxS1dMM2kKY3hrVVZhdkJxS2pNQi9hOFpQUC90eDRaeDBwNWxudDBKVUcyMWZWYlZiKytYUjc4OE5zbkVONkZWdWw1R2NwWgpkSVlGVE1IUjJtbkx1VnlFb3d1eFk2YnBoSVJaendFRnJvdmxaK1Z5Z1F3czlURnlyMWc1VHVhVTd0S1dXbVpoCmx2bnY1amNuVlBFeGZ4MXR1RXdNM0xDZGZCMngyYUIrSDRnelBWTUZlakE1THRDcnhtM3llR2I1aStNZlpGYWYKNHViNWM2R1llUnUwWGZFekQ4dXFyT0JVVm9HTHNtT25CTW16d1hEeFE5MDVmU3g2bGxWTXRpbmoyMFkvYklrRwpmc0pSek44cDBUWTV0cUN5bGJsc3E3WUJiMXA5UHpZZUE0clBjNERvTmJMM3E5SXJqeXdpc0poRHo2ZGZ1dVlwCkZpSHhweWlXaGNKMVlzam1iTmtQcmRjVlhJc0NBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGUHpKYi9pZis2TzFISnJLeHNaemFaeDhqQTljTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQlNsajJDaXZKa0x5REZHZThHN0ZuY1BvMXdhS3NPaktmZE5pRGpXZjNNCk9Hc1d6QWgxYW5DTVB2d3o0NzNEUHRuYzJQU3pBWDJ6aGxGYWVwcUJSSlgzeDJLOXZPbHhTaUtkRzMyeXA2alcKSVRjd21QcWx4N0NrV0tNSzJGZFBaQ2IyUm9nS3Fwc2lLN2dLbng3UGtMNzdINnpWSGJ2SUlWVHM2QjA0RVNYcQprZEZTLzhOWDhxbFoxd0V4TjNkOVFEYVVrRjBUUk90REVNdDJ0NWowRGtzMzQwcXhlNlVJZDArL0pvSDRXMXk3CnZDM0FuV0lJc3BKTDZ3dDEwN09CbUdsaEJpSC8vUHlrYjNwbzdERzEzdk9TYXhFVGJObjVHZjMzQ2hoVEthVGQKM2p2OC92cU4wQXRDY3ZoRWY0SHI2YmlUY2R2ZXBFenY5Z2dWajVXVzA3eEVPVlRlbko1MGxNZnpNaGtGYUFYRApLaVduckNlRUg1anhNUDZIRVI4MGtOVmd0bk5HZDJyeHdqS21naUFKN25nUnEybGNhQmhwMzI3YVFadmt0T3V4CmFpQ28yT3VHbllLWkV2OUNyMVdpaERMNW1INm4rMHZTbGdwdkZqdVl0ZDkvR25uNnJoTy9CZ3Q1Z2dWcFFuTzkKQTVXZnU1dmZFaTBXcjlrb2xxYWxWdFE9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n  name: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\ncontexts:\n- context:\n    cluster: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\n    user: gcp-dynamic-token\n  name: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\ncurrent-context: gke_asia-northeast3-a_tb4376joq2qqrv47qau4\nusers:\n- name: gcp-dynamic-token\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1\n      interactiveMode: Never\n      command: sh\n      args:\n      - -c\n      - \". ~/.cb-spider/.spider-credential \u0026\u0026 curl -s -u \\\"$SPIDER_USERNAME:$SPIDER_PASSWORD\\\" \\\"http://0.0.0.0:1024/spider/cluster/tb4376joq2qqrv47qau4/token?ConnectionName=gcp-asia-northeast3\\\"\"\n"
+    },
+    "Addons": {
+      "KeyValueList": null
+    },
+    "Status": "Active",
+    "CreatedTime": "2026-08-20T06:15:59Z",
+    "KeyValueList": [
+      {
+        "key": "AddonsConfig",
+        "value": "{gcePersistentDiskCsiDriverConfig:{enabled:true},kubernetesDashboard:{disabled:true},networkPolicyConfig:{disabled:true}}"
+      },
+      {
+        "key": "AnonymousAuthenticationConfig",
+        "value": "{mode:ENABLED}"
+      },
+      {
+        "key": "Autopilot",
+        "value": "{}"
+      },
+      {
+        "key": "Autoscaling",
+        "value": "{autoprovisioningNodePoolDefaults:{imageType:COS_CONTAINERD,management:{autoRepair:true,autoUpgrade:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],serviceAccount:default},autoscalingProfile:BALANCED}"
+      },
+      {
+        "key": "ClusterIpv4Cidr",
+        "value": "10.8.0.0/14"
+      },
+      {
+        "key": "ControlPlaneEndpointsConfig",
+        "value": "{dnsEndpointConfig:{endpoint:gke-331fc160950b490f8aa57aa47d944bf5b40b-1064665102650.asia-northeast3-a.gke.goog},ipEndpointsConfig:{authorizedNetworksConfig:{},enablePublicEndpoint:true,enabled:true,privateEndpoint:10.0.1.8,publicEndpoint:34.47.85.231}}"
+      },
+      {
+        "key": "CreateTime",
+        "value": "2026-08-20T06:15:59+00:00"
+      },
+      {
+        "key": "CurrentMasterVersion",
+        "value": "1.33.12-gke.1000000"
+      },
+      {
+        "key": "CurrentNodeCount",
+        "value": "2"
+      },
+      {
+        "key": "CurrentNodeVersion",
+        "value": "1.33.12-gke.1000000"
+      },
+      {
+        "key": "DatabaseEncryption",
+        "value": "{currentState:CURRENT_STATE_DECRYPTED,state:DECRYPTED}"
+      },
+      {
+        "key": "DefaultMaxPodsConstraint",
+        "value": "{maxPodsPerNode:110}"
+      },
+      {
+        "key": "EnableKubernetesAlpha",
+        "value": "false"
+      },
+      {
+        "key": "EnableTpu",
+        "value": "false"
+      },
+      {
+        "key": "Endpoint",
+        "value": "34.47.85.231"
+      },
+      {
+        "key": "EnterpriseConfig",
+        "value": "{clusterTier:STANDARD}"
+      },
+      {
+        "key": "Etag",
+        "value": "fb3b6858-b12a-4c44-b14d-d17d2f1e2744"
+      },
+      {
+        "key": "Id",
+        "value": "331fc160950b490f8aa57aa47d944bf5b40b2562089242069dca40971400e3ab"
+      },
+      {
+        "key": "InitialClusterVersion",
+        "value": "1.33.12-gke.1000000"
+      },
+      {
+        "key": "InitialNodeCount",
+        "value": "0"
+      },
+      {
+        "key": "InstanceGroupUrls",
+        "value": "https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instanceGroupManagers/gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp"
+      },
+      {
+        "key": "IpAllocationPolicy",
+        "value": "{clusterIpv4Cidr:10.8.0.0/14,clusterIpv4CidrBlock:10.8.0.0/14,clusterSecondaryRangeName:gke-tb4376joq2qqrv47qau4-pods-331fc160,defaultPodIpv4RangeUtilization:0.002,networkTierConfig:{networkTier:NETWORK_TIER_DEFAULT},podCidrOverprovisionConfig:{},servicesIpv4Cidr:34.118.224.0/20,servicesIpv4CidrBlock:34.118.224.0/20,stackType:IPV4,useIpAliases:true}"
+      },
+      {
+        "key": "LabelFingerprint",
+        "value": "17c2404d"
+      },
+      {
+        "key": "LegacyAbac",
+        "value": "{}"
+      },
+      {
+        "key": "Location",
+        "value": "asia-northeast3-a"
+      },
+      {
+        "key": "Locations",
+        "value": "asia-northeast3-a"
+      },
+      {
+        "key": "LoggingConfig",
+        "value": "{componentConfig:{enableComponents:[SYSTEM_COMPONENTS,WORKLOADS]}}"
+      },
+      {
+        "key": "LoggingService",
+        "value": "logging.googleapis.com/kubernetes"
+      },
+      {
+        "key": "MaintenancePolicy",
+        "value": "{resourceVersion:e3b0c442}"
+      },
+      {
+        "key": "MasterAuth",
+        "value": "{clientCertificateConfig:{},clusterCaCertificate:LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxJZTRTMTBNaTBFcWFRK3ZoZzlqUVV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1l6RXdZVFprTldZdFpUTm1PQzAwTVRka0xXRmtPVGd0T1dRNE0yRTROVEV6T1RBegpNQ0FYRFRJMk1EZ3lNREExTVRZd01Gb1lEekl3TlRZd09ERXlNRFl4TmpBd1dqQXZNUzB3S3dZRFZRUURFeVJqCk1UQmhObVExWmkxbE0yWTRMVFF4TjJRdFlXUTVPQzA1WkRnellUZzFNVE01TURNd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDaCtzWlRYTFJ0bk5hY284V1h5dmhuUUw3L1NKUmd2T042QnRZTQo0SjdBVSsyNE1IWlhQdEdXdVdYaU96dDV2Njh0c1I3TUZMcnFOaEp4M05uY21IbFRBbmI2TDgzcDBFNXhKeTBOCmZkSDdSSkdEKzJ5dmFCMGRVQTZPTkZQTjQ1YTduY1ZvOEowSnI4aTkxdUVyYzE3N3pxdlo1WWh0c0VxS1dMM2kKY3hrVVZhdkJxS2pNQi9hOFpQUC90eDRaeDBwNWxudDBKVUcyMWZWYlZiKytYUjc4OE5zbkVONkZWdWw1R2NwWgpkSVlGVE1IUjJtbkx1VnlFb3d1eFk2YnBoSVJaendFRnJvdmxaK1Z5Z1F3czlURnlyMWc1VHVhVTd0S1dXbVpoCmx2bnY1amNuVlBFeGZ4MXR1RXdNM0xDZGZCMngyYUIrSDRnelBWTUZlakE1THRDcnhtM3llR2I1aStNZlpGYWYKNHViNWM2R1llUnUwWGZFekQ4dXFyT0JVVm9HTHNtT25CTW16d1hEeFE5MDVmU3g2bGxWTXRpbmoyMFkvYklrRwpmc0pSek44cDBUWTV0cUN5bGJsc3E3WUJiMXA5UHpZZUE0clBjNERvTmJMM3E5SXJqeXdpc0poRHo2ZGZ1dVlwCkZpSHhweWlXaGNKMVlzam1iTmtQcmRjVlhJc0NBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGUHpKYi9pZis2TzFISnJLeHNaemFaeDhqQTljTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQlNsajJDaXZKa0x5REZHZThHN0ZuY1BvMXdhS3NPaktmZE5pRGpXZjNNCk9Hc1d6QWgxYW5DTVB2d3o0NzNEUHRuYzJQU3pBWDJ6aGxGYWVwcUJSSlgzeDJLOXZPbHhTaUtkRzMyeXA2alcKSVRjd21QcWx4N0NrV0tNSzJGZFBaQ2IyUm9nS3Fwc2lLN2dLbng3UGtMNzdINnpWSGJ2SUlWVHM2QjA0RVNYcQprZEZTLzhOWDhxbFoxd0V4TjNkOVFEYVVrRjBUUk90REVNdDJ0NWowRGtzMzQwcXhlNlVJZDArL0pvSDRXMXk3CnZDM0FuV0lJc3BKTDZ3dDEwN09CbUdsaEJpSC8vUHlrYjNwbzdERzEzdk9TYXhFVGJObjVHZjMzQ2hoVEthVGQKM2p2OC92cU4wQXRDY3ZoRWY0SHI2YmlUY2R2ZXBFenY5Z2dWajVXVzA3eEVPVlRlbko1MGxNZnpNaGtGYUFYRApLaVduckNlRUg1anhNUDZIRVI4MGtOVmd0bk5HZDJyeHdqS21naUFKN25nUnEybGNhQmhwMzI3YVFadmt0T3V4CmFpQ28yT3VHbllLWkV2OUNyMVdpaERMNW1INm4rMHZTbGdwdkZqdVl0ZDkvR25uNnJoTy9CZ3Q1Z2dWcFFuTzkKQTVXZnU1dmZFaTBXcjlrb2xxYWxWdFE9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K}"
+      },
+      {
+        "key": "MasterAuthorizedNetworksConfig",
+        "value": "{}"
+      },
+      {
+        "key": "MonitoringConfig",
+        "value": "{advancedDatapathObservabilityConfig:{},componentConfig:{enableComponents:[SYSTEM_COMPONENTS,STATEFULSET,JOBSET,STORAGE,HPA,POD,DAEMONSET,DEPLOYMENT,CADVISOR,KUBELET,DCGM]},managedPrometheusConfig:{enabled:true}}"
+      },
+      {
+        "key": "MonitoringService",
+        "value": "monitoring.googleapis.com/kubernetes"
+      },
+      {
+        "key": "Name",
+        "value": "tb4376joq2qqrv47qau4"
+      },
+      {
+        "key": "Network",
+        "value": "tb8e4ivjhph8tj8eq3c5"
+      },
+      {
+        "key": "NetworkConfig",
+        "value": "{network:projects/GCP_PROJECT_ID/global/networks/tb8e4ivjhph8tj8eq3c5,serviceExternalIpsConfig:{},subnetwork:projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbf74se4bdd1ilmjkavo}"
+      },
+      {
+        "key": "NodeConfig",
+        "value": "{bootDisk:{diskType:pd-balanced,sizeGb:100},diskSizeGb:100,diskType:pd-balanced,effectiveCgroupMode:EFFECTIVE_CGROUP_MODE_V2,imageType:COS_CONTAINERD,kubeletConfig:{maxParallelImagePulls:2},labels:{keypair:tb4jmnhc0vlt4svljbps},machineType:e2-standard-4,metadata:{disable-legacy-endpoints:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],resourceLabels:{goog-gke-node-pool-provisioning-model:on-demand},serviceAccount:default,shieldedInstanceConfig:{enableIntegrityMonitoring:true},tags:[tb5vuo31rrnng9587m1n],windowsNodeConfig:{}}"
+      },
+      {
+        "key": "NodeIpv4CidrSize",
+        "value": "0"
+      },
+      {
+        "key": "NodePoolAutoConfig",
+        "value": "{nodeKubeletConfig:{}}"
+      },
+      {
+        "key": "NodePoolDefaults",
+        "value": "{nodeConfigDefaults:{loggingConfig:{variantConfig:{variant:DEFAULT}},nodeKubeletConfig:{}}}"
+      },
+      {
+        "key": "NodePools",
+        "value": "{config:{bootDisk:{diskType:pd-balanced,sizeGb:100},diskSizeGb:100,diskType:pd-balanced,effectiveCgroupMode:EFFECTIVE_CGROUP_MODE_V2,imageType:COS_CONTAINERD,kubeletConfig:{maxParallelImagePulls:2},labels:{keypair:tb4jmnhc0vlt4svljbps},machineType:e2-standard-4,metadata:{disable-legacy-endpoints:true},oauthScopes:[https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/trace.append],resourceLabels:{goog-gke-node-pool-provisioning-model:on-demand},serviceAccount:default,shieldedInstanceConfig:{enableIntegrityMonitoring:true},tags:[tb5vuo31rrnng9587m1n],windowsNodeConfig:{}},etag:d9c380dd-9dd4-4d32-8d99-abfb1c62ba68,initialNodeCount:2,instanceGroupUrls:[https://www.googleapis.com/compute/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/instanceGroupManagers/gke-tb4376joq2qqrv47qau4-workers1-21b6f7d2-grp],locations:[asia-northeast3-a],management:{autoRepair:true,autoUpgrade:true},maxPodsConstraint:{maxPodsPerNode:110},name:workers1,networkConfig:{networkTierConfig:{networkTier:NETWORK_TIER_DEFAULT},podIpv4CidrBlock:10.8.0.0/14,podIpv4RangeUtilization:0.002,podRange:gke-tb4376joq2qqrv47qau4-pods-331fc160,subnetwork:projects/GCP_PROJECT_ID/regions/asia-northeast3/subnetworks/tbf74se4bdd1ilmjkavo},podIpv4CidrSize:24,selfLink:https://container.googleapis.com/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/clusters/tb4376joq2qqrv47qau4/nodePools/workers1,status:RUNNING,upgradeSettings:{maxSurge:1,strategy:SURGE},version:1.33.12-gke.1000000}"
+      },
+      {
+        "key": "NotificationConfig",
+        "value": "{pubsub:{}}"
+      },
+      {
+        "key": "PodAutoscaling",
+        "value": "{hpaProfile:PERFORMANCE}"
+      },
+      {
+        "key": "PrivateClusterConfig",
+        "value": "{privateEndpoint:10.0.1.8,publicEndpoint:34.47.85.231}"
+      },
+      {
+        "key": "RbacBindingConfig",
+        "value": "{enableInsecureBindingSystemAuthenticated:true,enableInsecureBindingSystemUnauthenticated:true}"
+      },
+      {
+        "key": "ReleaseChannel",
+        "value": "{channel:STABLE}"
+      },
+      {
+        "key": "ResourceLabels",
+        "value": "{cb-spider-pmks-securitygroup-0:tb5vuo31rrnng9587m1n}"
+      },
+      {
+        "key": "SatisfiesPzi",
+        "value": "false"
+      },
+      {
+        "key": "SatisfiesPzs",
+        "value": "false"
+      },
+      {
+        "key": "SecurityPostureConfig",
+        "value": "{mode:BASIC,vulnerabilityMode:VULNERABILITY_MODE_UNSPECIFIED}"
+      },
+      {
+        "key": "SelfLink",
+        "value": "https://container.googleapis.com/v1/projects/GCP_PROJECT_ID/zones/asia-northeast3-a/clusters/tb4376joq2qqrv47qau4"
+      },
+      {
+        "key": "ServicesIpv4Cidr",
+        "value": "34.118.224.0/20"
+      },
+      {
+        "key": "ShieldedNodes",
+        "value": "{enabled:true}"
+      },
+      {
+        "key": "Status",
+        "value": "RUNNING"
+      },
+      {
+        "key": "Subnetwork",
+        "value": "tbf74se4bdd1ilmjkavo"
+      },
+      {
+        "key": "UserManagedKeysConfig",
+        "value": "{}"
+      },
+      {
+        "key": "Zone",
+        "value": "asia-northeast3-a"
+      }
+    ]
+  }
+}
+```
+
+</details>
+

--- a/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-summary-all.md
+++ b/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-summary-all.md
@@ -1,0 +1,16 @@
+# CM-Beetle K8s Infra Migration Test Summary
+
+- CM-Beetle Version: v0.6.0
+- Test Date: 2026-08-20 15:15:35 KST
+
+| Target | CSP / Region | Steps Passed | Cluster ID | Result |
+|--------|--------------|--------------|------------|--------|
+| AWS-Seoul | aws / ap-northeast-2 | 7/7 | `mig01-on-prem-k8s-cluster` | ✅ PASS |
+| Azure-Busan | azure / koreasouth | 7/7 | `mig02-on-prem-k8s-cluster` | ✅ PASS |
+| GCP-Seoul | gcp / asia-northeast3 | 7/7 | `mig03-on-prem-k8s-cluster` | ✅ PASS |
+
+## Per-CSP Reports
+
+- [AWS-Seoul](k8s-infra-migration-test-results-aws.md)
+- [Azure-Busan](k8s-infra-migration-test-results-azure.md)
+- [GCP-Seoul](k8s-infra-migration-test-results-gcp.md)

--- a/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-summary-all.md
+++ b/cmd/test-cli/k8s-infra-migration/testresult/k8s-infra-migration-test-summary-all.md
@@ -1,16 +1,12 @@
 # CM-Beetle K8s Infra Migration Test Summary
 
-- CM-Beetle Version: v0.6.0
-- Test Date: 2026-08-20 15:15:35 KST
+- CM-Beetle Version: v0.6.0+ (1cfe558)
+- Test Date: 2026-08-21 11:40:25 KST
 
 | Target | CSP / Region | Steps Passed | Cluster ID | Result |
 |--------|--------------|--------------|------------|--------|
 | AWS-Seoul | aws / ap-northeast-2 | 7/7 | `mig01-on-prem-k8s-cluster` | ✅ PASS |
-| Azure-Busan | azure / koreasouth | 7/7 | `mig02-on-prem-k8s-cluster` | ✅ PASS |
-| GCP-Seoul | gcp / asia-northeast3 | 7/7 | `mig03-on-prem-k8s-cluster` | ✅ PASS |
 
 ## Per-CSP Reports
 
 - [AWS-Seoul](k8s-infra-migration-test-results-aws.md)
-- [Azure-Busan](k8s-infra-migration-test-results-azure.md)
-- [GCP-Seoul](k8s-infra-migration-test-results-gcp.md)

--- a/cmd/test-cli/k8s-infra-migration/workload.go
+++ b/cmd/test-cli/k8s-infra-migration/workload.go
@@ -1,0 +1,552 @@
+// Workload verification: prove the migrated cluster is actually usable, not merely created.
+//
+// This mirrors what cmd/test-cli/infra does for VM migration, where SSH connectivity is checked
+// on every migrated VM. The K8s equivalent is reaching the cluster's API server and running a
+// real workload on it.
+//
+// Beetle exposes no kubeconfig API, so CB-Tumblebug is called directly — the same arrangement
+// the VM CLI uses for its SSH check. Headlamp (used by cb-tumblebug's own k8s-test) is not
+// needed: it only forwards the bearer token to the API server unchanged, so calling the API
+// server directly does the same work without a Docker dependency.
+package main
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"gopkg.in/yaml.v3"
+)
+
+// kubeconfig captures only the fields needed to reach the API server directly.
+type kubeconfig struct {
+	Clusters []struct {
+		Name    string `yaml:"name"`
+		Cluster struct {
+			Server                   string `yaml:"server"`
+			CertificateAuthorityData string `yaml:"certificate-authority-data"`
+		} `yaml:"cluster"`
+	} `yaml:"clusters"`
+	Users []struct {
+		Name string `yaml:"name"`
+		User struct {
+			Token                 string      `yaml:"token"`
+			ClientCertificateData string      `yaml:"client-certificate-data"`
+			ClientKeyData         string      `yaml:"client-key-data"`
+			Exec                  interface{} `yaml:"exec"`
+		} `yaml:"user"`
+	} `yaml:"users"`
+}
+
+// authMethod is how a kubeconfig expects the caller to authenticate.
+type authMethod int
+
+const (
+	authStaticToken authMethod = iota // kubeconfig carries a bearer token
+	authClientCert                    // kubeconfig carries a client certificate/key pair
+	authExecPlugin                    // kubeconfig delegates to an exec credential plugin
+)
+
+func (a authMethod) String() string {
+	switch a {
+	case authStaticToken:
+		return "static token in kubeconfig"
+	case authClientCert:
+		return "client certificate in kubeconfig"
+	default:
+		return "exec credential plugin"
+	}
+}
+
+// nginxDeploymentName is fixed: the workload lives inside one cluster and is removed at the end
+// of the step, so it cannot collide with another target's run.
+const (
+	nginxDeploymentName = "beetle-test-nginx"
+	nginxServiceName    = "beetle-test-nginx-lb"
+)
+
+// stepWorkload fetches the cluster's kubeconfig, reaches its API server, and runs a real
+// workload on it. A cluster that reports Active but cannot schedule a pod has not actually
+// been migrated in any useful sense, which is what this step is here to catch.
+func stepWorkload(_ *resty.Client, cfg TestConfig, auth AuthConfig, report *CSPTestReport, _ []byte) StepResult {
+	res := StepResult{Number: 5, Name: "Workload verification (kubeconfig -> K8s API -> nginx)", StartTime: time.Now()}
+
+	if auth.TumblebugEndpoint == "" {
+		res.Duration = time.Since(res.StartTime)
+		res.Skipped, res.Success = true, true
+		res.Notes = append(res.Notes, "ℹ️  skipped: tumblebugEndpoint not set in auth config")
+		return res
+	}
+
+	tb := resty.New().SetTimeout(60 * time.Second).SetLogger(restyNoopLogger{})
+	if auth.TumblebugApiUsername != "" {
+		tb.SetBasicAuth(auth.TumblebugApiUsername, auth.TumblebugApiPassword)
+	}
+	base := fmt.Sprintf("%s/tumblebug/ns/%s/k8sCluster/%s", auth.TumblebugEndpoint, cfg.Beetle.NamespaceID, report.ClusterID)
+
+	// 1. Kubeconfig. The dedicated sub-resource is required: the generic cluster GET returns
+	// AccessInfo.Kubeconfig without the native flag, which never becomes ready on some CSPs.
+	// It also lags the Active status, so it is polled rather than read once.
+	kcYAML, err := fetchKubeconfig(tb, base+"/kubeconfig", cfg, &res)
+	if err != nil {
+		res.Duration = time.Since(res.StartTime)
+		res.Error = err.Error()
+		return res
+	}
+
+	access, err := parseKubeconfig(kcYAML)
+	if err != nil {
+		res.Duration = time.Since(res.StartTime)
+		res.Error = err.Error()
+		return res
+	}
+	server := access.Server
+	res.Notes = append(res.Notes,
+		fmt.Sprintf("✅ kubeconfig obtained (server: %s)", server),
+		fmt.Sprintf("ℹ️  auth method: %s", access.Auth))
+
+	// 2. Credential. Only an exec-plugin kubeconfig needs Tumblebug's token endpoint, and that
+	// endpoint is not implemented for every CSP — asking for it unconditionally fails on the
+	// ones whose kubeconfig already carries the credential.
+	if access.Auth == authExecPlugin {
+		token, err := fetchToken(tb, base+"/token")
+		if err != nil {
+			res.Duration = time.Since(res.StartTime)
+			res.Error = err.Error()
+			return res
+		}
+		access.Token = token
+		res.Notes = append(res.Notes, "✅ cluster token obtained from Tumblebug")
+	}
+
+	// 3. API client. The API server presents a certificate signed by the cluster's own CA, so
+	// that CA must be trusted explicitly.
+	k8s := resty.New().SetTimeout(60 * time.Second).SetLogger(restyNoopLogger{})
+	if access.CAPEM != "" {
+		k8s.SetRootCertificateFromString(access.CAPEM)
+	}
+	if access.Auth == authClientCert {
+		cert, certErr := tls.X509KeyPair([]byte(access.CertPEM), []byte(access.KeyPEM))
+		if certErr != nil {
+			res.Duration = time.Since(res.StartTime)
+			res.Error = fmt.Sprintf("failed to load client certificate from kubeconfig: %s", certErr)
+			return res
+		}
+		k8s.SetCertificates(cert)
+	} else {
+		k8s.SetAuthToken(access.Token)
+	}
+
+	// 4. Reachability, and node count cross-checked against the recommendation from inside the
+	// cluster — the same claim step 4 makes from Tumblebug's view, verified independently.
+	if err := checkAPIServer(k8s, server, report, &res); err != nil {
+		res.Duration = time.Since(res.StartTime)
+		res.Error = err.Error()
+		return res
+	}
+
+	// 5. Real workload, and — when enabled — reachability from outside the cluster.
+	if err := runNginxWorkload(k8s, server, cfg, &res); err != nil {
+		res.Duration = time.Since(res.StartTime)
+		res.Error = err.Error()
+		// Fall through to cleanup: half-created objects should not outlive the step.
+		deleteNginx(k8s, server, &res)
+		return res
+	}
+	if cfg.Workload.LoadBalancerEnabled {
+		if err := exposeAndVerifyNginx(k8s, server, cfg, &res); err != nil {
+			res.Duration = time.Since(res.StartTime)
+			res.Error = err.Error()
+			deleteNginx(k8s, server, &res)
+			return res
+		}
+	}
+	deleteNginx(k8s, server, &res)
+
+	res.Duration = time.Since(res.StartTime)
+	res.Success = true
+	return res
+}
+
+// fetchKubeconfig polls until the kubeconfig is ready; it becomes available some time after the
+// cluster reports Active, because the control-plane endpoint is still being provisioned.
+func fetchKubeconfig(tb *resty.Client, url string, cfg TestConfig, res *StepResult) (string, error) {
+	deadline := time.Now().Add(time.Duration(cfg.Workload.KubeconfigTimeoutSec) * time.Second)
+	interval := time.Duration(cfg.Workload.KubeconfigPollSec) * time.Second
+
+	for attempt := 1; ; attempt++ {
+		resp, err := tb.R().Get(url)
+		if err == nil && resp.StatusCode() == http.StatusOK {
+			var body struct {
+				Kubeconfig string `json:"kubeconfig"`
+			}
+			if jsonErr := json.Unmarshal(resp.Body(), &body); jsonErr == nil &&
+				strings.Contains(body.Kubeconfig, "apiVersion") {
+				return body.Kubeconfig, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("kubeconfig not ready within %ds", cfg.Workload.KubeconfigTimeoutSec)
+		}
+		fmt.Printf("      ... kubeconfig not ready yet, retrying in %v (attempt %d)\n", interval, attempt)
+		time.Sleep(interval)
+	}
+}
+
+// clusterAccess is everything needed to talk to a cluster's API server.
+type clusterAccess struct {
+	Server  string
+	CAPEM   string
+	Auth    authMethod
+	Token   string // set when Auth == authStaticToken
+	CertPEM string // set when Auth == authClientCert
+	KeyPEM  string // set when Auth == authClientCert
+}
+
+// parseKubeconfig extracts the API server endpoint, its CA, and how to authenticate.
+//
+// Which credential a kubeconfig carries is CSP-specific: EKS/GKE/NKS delegate to an exec
+// credential plugin and leave no usable secret in the file, whereas AKS and others embed the
+// credential directly. Reading it from the file is what tells the caller whether Tumblebug's
+// token endpoint is needed at all.
+func parseKubeconfig(kcYAML string) (clusterAccess, error) {
+	var access clusterAccess
+
+	var kc kubeconfig
+	if err := yaml.Unmarshal([]byte(kcYAML), &kc); err != nil {
+		return access, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+	if len(kc.Clusters) == 0 || kc.Clusters[0].Cluster.Server == "" {
+		return access, fmt.Errorf("kubeconfig carries no cluster server URL")
+	}
+	access.Server = strings.TrimSuffix(kc.Clusters[0].Cluster.Server, "/")
+
+	if data := kc.Clusters[0].Cluster.CertificateAuthorityData; data != "" {
+		decoded, err := base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			return access, fmt.Errorf("failed to decode certificate-authority-data: %w", err)
+		}
+		access.CAPEM = string(decoded)
+	}
+
+	if len(kc.Users) == 0 {
+		return access, fmt.Errorf("kubeconfig carries no user entry")
+	}
+	u := kc.Users[0].User
+
+	switch {
+	case u.Token != "":
+		access.Auth = authStaticToken
+		access.Token = u.Token
+	case u.ClientCertificateData != "" && u.ClientKeyData != "":
+		certPEM, err := base64.StdEncoding.DecodeString(u.ClientCertificateData)
+		if err != nil {
+			return access, fmt.Errorf("failed to decode client-certificate-data: %w", err)
+		}
+		keyPEM, err := base64.StdEncoding.DecodeString(u.ClientKeyData)
+		if err != nil {
+			return access, fmt.Errorf("failed to decode client-key-data: %w", err)
+		}
+		access.Auth = authClientCert
+		access.CertPEM = string(certPEM)
+		access.KeyPEM = string(keyPEM)
+	case u.Exec != nil:
+		access.Auth = authExecPlugin
+	default:
+		return access, fmt.Errorf("kubeconfig user entry carries no recognised credential")
+	}
+
+	return access, nil
+}
+
+func fetchToken(tb *resty.Client, url string) (string, error) {
+	resp, err := tb.R().Get(url)
+	if err != nil {
+		return "", fmt.Errorf("token request failed: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("token request returned HTTP %d: %s", resp.StatusCode(), truncate(string(resp.Body()), 200))
+	}
+	var body struct {
+		ExecCredential struct {
+			Status struct {
+				Token string `json:"token"`
+			} `json:"status"`
+		} `json:"execCredential"`
+	}
+	if err := json.Unmarshal(resp.Body(), &body); err != nil {
+		return "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+	if body.ExecCredential.Status.Token == "" {
+		return "", fmt.Errorf("token response carried no token")
+	}
+	return body.ExecCredential.Status.Token, nil
+}
+
+func checkAPIServer(k8s *resty.Client, server string, report *CSPTestReport, res *StepResult) error {
+	verResp, err := k8s.R().Get(server + "/version")
+	if err != nil {
+		return fmt.Errorf("cannot reach the K8s API server: %w", err)
+	}
+	if verResp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("K8s API /version returned HTTP %d: %s", verResp.StatusCode(), truncate(string(verResp.Body()), 200))
+	}
+	var version struct {
+		GitVersion string `json:"gitVersion"`
+	}
+	_ = json.Unmarshal(verResp.Body(), &version)
+	res.Notes = append(res.Notes, fmt.Sprintf("✅ API server reachable (%s)", version.GitVersion))
+
+	nodesResp, err := k8s.R().Get(server + "/api/v1/nodes")
+	if err != nil || nodesResp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("cannot list nodes via the K8s API")
+	}
+	var nodes struct {
+		Items []struct {
+			Status struct {
+				Conditions []struct {
+					Type   string `json:"type"`
+					Status string `json:"status"`
+				} `json:"conditions"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(nodesResp.Body(), &nodes); err != nil {
+		return fmt.Errorf("failed to parse node list: %w", err)
+	}
+
+	ready := 0
+	for _, n := range nodes.Items {
+		for _, c := range n.Status.Conditions {
+			if c.Type == "Ready" && c.Status == "True" {
+				ready++
+			}
+		}
+	}
+
+	want := 0
+	if report.Recommendation != nil {
+		for _, ng := range report.Recommendation.TargetK8sCluster.K8sNodeGroupList {
+			want += ng.DesiredNodeSize
+		}
+	}
+	if want > 0 && ready != want {
+		res.Notes = append(res.Notes, fmt.Sprintf("❌ %d/%d node(s) Ready, recommendation asked for %d", ready, len(nodes.Items), want))
+		return fmt.Errorf("cluster has %d ready node(s), expected %d", ready, want)
+	}
+	res.Notes = append(res.Notes, fmt.Sprintf("✅ %d node(s) Ready, matching the recommendation", ready))
+	return nil
+}
+
+// runNginxWorkload creates a Deployment and waits for its pod to run. Scope stops at Running:
+// a LoadBalancer Service would add per-CSP provisioning time as another variable.
+func runNginxWorkload(k8s *resty.Client, server string, cfg TestConfig, res *StepResult) error {
+	deployment := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": nginxDeploymentName},
+		"spec": map[string]interface{}{
+			"replicas": 1,
+			"selector": map[string]interface{}{"matchLabels": map[string]string{"app": nginxDeploymentName}},
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{"labels": map[string]string{"app": nginxDeploymentName}},
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{{
+						"name":  "nginx",
+						"image": "nginx:stable-alpine",
+						"ports": []map[string]interface{}{{"containerPort": 80}},
+					}},
+				},
+			},
+		},
+	}
+
+	resp, err := k8s.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(deployment).
+		Post(server + "/apis/apps/v1/namespaces/default/deployments")
+	if err != nil {
+		return fmt.Errorf("failed to create nginx Deployment: %w", err)
+	}
+	if resp.StatusCode() != http.StatusCreated && resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("nginx Deployment creation returned HTTP %d: %s", resp.StatusCode(), truncate(string(resp.Body()), 200))
+	}
+	res.Notes = append(res.Notes, "✅ nginx Deployment created")
+
+	deadline := time.Now().Add(time.Duration(cfg.Workload.PodReadyTimeoutSec) * time.Second)
+	interval := time.Duration(cfg.Workload.PodPollSec) * time.Second
+	podURL := fmt.Sprintf("%s/api/v1/namespaces/default/pods?labelSelector=app%%3D%s", server, nginxDeploymentName)
+
+	for attempt := 1; ; attempt++ {
+		time.Sleep(interval)
+
+		podsResp, podErr := k8s.R().Get(podURL)
+		if podErr == nil && podsResp.StatusCode() == http.StatusOK {
+			var pods struct {
+				Items []struct {
+					Status struct {
+						Phase string `json:"phase"`
+					} `json:"status"`
+				} `json:"items"`
+			}
+			if json.Unmarshal(podsResp.Body(), &pods) == nil {
+				for _, p := range pods.Items {
+					if p.Status.Phase == "Running" {
+						res.Notes = append(res.Notes, fmt.Sprintf("✅ nginx pod Running (attempt %d)", attempt))
+						return nil
+					}
+				}
+				if len(pods.Items) > 0 {
+					fmt.Printf("      ... nginx pod phase: %s (attempt %d)\n", pods.Items[0].Status.Phase, attempt)
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("nginx pod did not reach Running within %ds", cfg.Workload.PodReadyTimeoutSec)
+		}
+	}
+}
+
+// exposeAndVerifyNginx publishes the workload through a LoadBalancer Service and fetches it
+// from outside the cluster. Scheduling a pod proves the cluster can run work; this proves the
+// work is actually reachable, which is a distinct failure mode — a cluster can come up healthy
+// and still fail to provision a working load balancer.
+func exposeAndVerifyNginx(k8s *resty.Client, server string, cfg TestConfig, res *StepResult) error {
+	service := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]interface{}{"name": nginxServiceName},
+		"spec": map[string]interface{}{
+			"type":     "LoadBalancer",
+			"selector": map[string]string{"app": nginxDeploymentName},
+			"ports": []map[string]interface{}{{
+				"port": 80, "targetPort": 80, "protocol": "TCP",
+			}},
+		},
+	}
+
+	resp, err := k8s.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(service).
+		Post(server + "/api/v1/namespaces/default/services")
+	if err != nil {
+		return fmt.Errorf("failed to create LoadBalancer Service: %w", err)
+	}
+	if resp.StatusCode() != http.StatusCreated && resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("LoadBalancer Service creation returned HTTP %d: %s",
+			resp.StatusCode(), truncate(string(resp.Body()), 200))
+	}
+	res.Notes = append(res.Notes, "✅ LoadBalancer Service created")
+
+	address, err := waitForLoadBalancerAddress(k8s, server, cfg, res)
+	if err != nil {
+		return err
+	}
+	res.Notes = append(res.Notes, fmt.Sprintf("✅ LoadBalancer address assigned: %s", address))
+
+	return fetchThroughLoadBalancer(address, cfg, res)
+}
+
+// waitForLoadBalancerAddress polls the Service until the CSP assigns an ingress address. AWS
+// publishes a hostname, other CSPs an IP, so both fields are accepted.
+func waitForLoadBalancerAddress(k8s *resty.Client, server string, cfg TestConfig, res *StepResult) (string, error) {
+	deadline := time.Now().Add(time.Duration(cfg.Workload.LbAddressTimeoutSec) * time.Second)
+	interval := time.Duration(cfg.Workload.LbPollSec) * time.Second
+	url := server + "/api/v1/namespaces/default/services/" + nginxServiceName
+
+	for attempt := 1; ; attempt++ {
+		time.Sleep(interval)
+
+		resp, err := k8s.R().Get(url)
+		if err == nil && resp.StatusCode() == http.StatusOK {
+			var svc struct {
+				Status struct {
+					LoadBalancer struct {
+						Ingress []struct {
+							IP       string `json:"ip"`
+							Hostname string `json:"hostname"`
+						} `json:"ingress"`
+					} `json:"loadBalancer"`
+				} `json:"status"`
+			}
+			if json.Unmarshal(resp.Body(), &svc) == nil {
+				for _, ing := range svc.Status.LoadBalancer.Ingress {
+					if ing.IP != "" {
+						return ing.IP, nil
+					}
+					if ing.Hostname != "" {
+						return ing.Hostname, nil
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("LoadBalancer address was not assigned within %ds", cfg.Workload.LbAddressTimeoutSec)
+		}
+		fmt.Printf("      ... waiting for LoadBalancer address (attempt %d)\n", attempt)
+	}
+}
+
+// fetchThroughLoadBalancer retries until the endpoint serves. An address appears before the
+// load balancer is actually forwarding traffic — health checks must pass first, and an AWS
+// hostname additionally has to resolve — so the first attempts are expected to fail.
+func fetchThroughLoadBalancer(address string, cfg TestConfig, res *StepResult) error {
+	client := resty.New().SetTimeout(15 * time.Second).SetLogger(restyNoopLogger{})
+	url := "http://" + address + "/"
+
+	deadline := time.Now().Add(time.Duration(cfg.Workload.LbAccessTimeoutSec) * time.Second)
+	interval := time.Duration(cfg.Workload.LbPollSec) * time.Second
+	lastErr := "no attempt made"
+
+	for attempt := 1; ; attempt++ {
+		resp, err := client.R().Get(url)
+		switch {
+		case err != nil:
+			lastErr = err.Error()
+		case resp.StatusCode() == http.StatusOK:
+			res.Notes = append(res.Notes,
+				fmt.Sprintf("✅ nginx served over the LoadBalancer at %s (attempt %d)", url, attempt))
+			return nil
+		default:
+			lastErr = fmt.Sprintf("HTTP %d", resp.StatusCode())
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("LoadBalancer at %s did not serve within %ds (last: %s)",
+				url, cfg.Workload.LbAccessTimeoutSec, lastErr)
+		}
+		fmt.Printf("      ... LoadBalancer not serving yet: %s (attempt %d)\n", lastErr, attempt)
+		time.Sleep(interval)
+	}
+}
+
+// deleteNginx removes the Service first, then the Deployment.
+//
+// Order matters: a LoadBalancer Service holds a real, billable cloud load balancer, and deleting
+// it is what releases that. A failure here is reported prominently rather than shrugged off —
+// unlike the Deployment, a leaked load balancer keeps costing money after the run.
+func deleteNginx(k8s *resty.Client, server string, res *StepResult) {
+	svcResp, svcErr := k8s.R().Delete(server + "/api/v1/namespaces/default/services/" + nginxServiceName)
+	switch {
+	case svcErr != nil:
+		res.Notes = append(res.Notes, fmt.Sprintf("❌ LoadBalancer Service cleanup failed (%s) — check the CSP for a leaked load balancer", svcErr))
+	case svcResp.StatusCode() == http.StatusNotFound:
+		// Never created (LoadBalancer verification disabled or the Service creation failed).
+	case svcResp.StatusCode() != http.StatusOK:
+		res.Notes = append(res.Notes, fmt.Sprintf("❌ LoadBalancer Service cleanup returned HTTP %d — check the CSP for a leaked load balancer", svcResp.StatusCode()))
+	default:
+		res.Notes = append(res.Notes, "✅ LoadBalancer Service removed")
+	}
+
+	resp, err := k8s.R().Delete(server + "/apis/apps/v1/namespaces/default/deployments/" + nginxDeploymentName)
+	if err != nil || (resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNotFound) {
+		res.Notes = append(res.Notes, "ℹ️  nginx Deployment cleanup did not confirm; the cluster is deleted next anyway")
+		return
+	}
+	res.Notes = append(res.Notes, "✅ nginx Deployment removed")
+}

--- a/cmd/test-cli/k8s-infra-migration/workload.go
+++ b/cmd/test-cli/k8s-infra-migration/workload.go
@@ -74,7 +74,7 @@ const (
 // workload on it. A cluster that reports Active but cannot schedule a pod has not actually
 // been migrated in any useful sense, which is what this step is here to catch.
 func stepWorkload(_ *resty.Client, cfg TestConfig, auth AuthConfig, report *CSPTestReport, _ []byte) StepResult {
-	res := StepResult{Number: 5, Name: "Workload verification (kubeconfig -> K8s API -> nginx)", StartTime: time.Now()}
+	res := StepResult{Target: report.DisplayName, Number: 5, Name: "Workload verification (kubeconfig -> K8s API -> nginx)", StartTime: time.Now()}
 
 	if auth.TumblebugEndpoint == "" {
 		res.Duration = time.Since(res.StartTime)
@@ -193,7 +193,7 @@ func fetchKubeconfig(tb *resty.Client, url string, cfg TestConfig, res *StepResu
 		if time.Now().After(deadline) {
 			return "", fmt.Errorf("kubeconfig not ready within %ds", cfg.Workload.KubeconfigTimeoutSec)
 		}
-		fmt.Printf("      ... kubeconfig not ready yet, retrying in %v (attempt %d)\n", interval, attempt)
+		progressf(res.Target, "... kubeconfig not ready yet, retrying in %v (attempt %d)", interval, attempt)
 		time.Sleep(interval)
 	}
 }
@@ -402,7 +402,7 @@ func runNginxWorkload(k8s *resty.Client, server string, cfg TestConfig, res *Ste
 					}
 				}
 				if len(pods.Items) > 0 {
-					fmt.Printf("      ... nginx pod phase: %s (attempt %d)\n", pods.Items[0].Status.Phase, attempt)
+					progressf(res.Target, "... nginx pod phase: %s (attempt %d)", pods.Items[0].Status.Phase, attempt)
 				}
 			}
 		}
@@ -488,7 +488,7 @@ func waitForLoadBalancerAddress(k8s *resty.Client, server string, cfg TestConfig
 		if time.Now().After(deadline) {
 			return "", fmt.Errorf("LoadBalancer address was not assigned within %ds", cfg.Workload.LbAddressTimeoutSec)
 		}
-		fmt.Printf("      ... waiting for LoadBalancer address (attempt %d)\n", attempt)
+		progressf(res.Target, "... waiting for LoadBalancer address (attempt %d)", attempt)
 	}
 }
 
@@ -520,7 +520,7 @@ func fetchThroughLoadBalancer(address string, cfg TestConfig, res *StepResult) e
 			return fmt.Errorf("LoadBalancer at %s did not serve within %ds (last: %s)",
 				url, cfg.Workload.LbAccessTimeoutSec, lastErr)
 		}
-		fmt.Printf("      ... LoadBalancer not serving yet: %s (attempt %d)\n", lastErr, attempt)
+		progressf(res.Target, "... LoadBalancer not serving yet: %s (attempt %d)", lastErr, attempt)
 		time.Sleep(interval)
 	}
 }

--- a/cmd/test-cli/k8s-infra-recommendation/README.md
+++ b/cmd/test-cli/k8s-infra-recommendation/README.md
@@ -1,0 +1,146 @@
+# CM-Beetle K8s Infra Recommendation Test CLI
+
+Automated test tool for `POST /recommendation/k8sCluster` — the API that turns an on-premise
+Kubernetes cluster description into a target-cloud K8s infra design.
+
+Scoped to the recommendation call only: no validation, migration, or cleanup, since the endpoint
+provisions nothing. Migration is covered separately by `cmd/test-cli/k8s-infra-migration`.
+
+## What It Checks
+
+Each on-premise fixture is sent to every enabled CSP/region pair, and the response is checked
+against expectations declared in `testconf/test-config.yaml`:
+
+- **Status code** — required for every scenario (200 for positive cases, 400 for negative ones)
+- **Node group count** — how many node groups the worker set was folded into
+- **Total node size** — sum of `desiredNodeSize` across node groups, i.e. worker count reproduction
+- **Version prefix** — optional check on the recommended Kubernetes version
+
+For any 200 response, these structural checks always run:
+
+- `targetK8sCluster.name` and `.version` are non-empty
+- every node group has a non-empty `specId`
+- every node group has `desiredNodeSize >= 1`
+
+## Quick Start
+
+```bash
+# From the repository root
+make test-k8s-infra-recommendation
+```
+
+This copies `testconf/template-test-config.yaml` to `testconf/test-config.yaml` on first run.
+Edit it to point at your Beetle endpoint and enable the CSP/region pairs you want.
+
+Credentials go in `testconf/auth-config.json` (copy from `testconf/template-auth-config.json`).
+
+## Configuration
+
+`testconf/test-config.yaml` has three parts.
+
+### `test.set.mode`
+
+`parallel` (default) runs one goroutine per target so scenarios against a single CSP stay ordered
+and readable. `sequential` runs everything in order.
+
+### `test.cases` — target CSP/region pairs
+
+```yaml
+cases:
+  - csp: aws
+    region: ap-northeast-2
+    name: AWS-Seoul
+    execute: true
+```
+
+Recommendation costs nothing, so enabling several at once is cheap.
+
+### `test.scenarios` — fixtures and expectations
+
+```yaml
+scenarios:
+  - file: testconf/scenarios/honeybee-k8s-workers5.json
+    name: workers5
+    execute: true
+    expect:
+      statusCode: 200
+      nodeGroupCount: 1
+      totalNodeSize: 5
+```
+
+`expect.statusCode` is required. `nodeGroupCount`, `totalNodeSize`, and `versionPrefix` are
+optional — omit one to skip that check.
+
+Keeping expectations in config rather than in code matters here: the CLI must not encode what a
+good recommendation looks like per CSP, because that judgement is exactly what is under test.
+
+## Fixtures
+
+`testconf/scenarios/` holds 15 on-premise models captured from cm-honeybee `/infra/refined`,
+each isolating one recommendation behaviour.
+
+| Fixture | Workers | Distinct specs | Isolates |
+| --- | --- | --- | --- |
+| `honeybee-k8s-refined-infra.json` | 2 | 1 | Baseline |
+| `honeybee-k8s-workers0.json` | 0 | — | Control-plane only — no recommendation possible |
+| `honeybee-k8s-workers1.json` | 1 | 1 | Single worker |
+| `honeybee-k8s-workers5.json` | 5 | 1 | Same-spec workers fold into one group |
+| `honeybee-k8s-tiny.json` | 1 | 1 | Below minimum viable worker spec (2 vCPU / 4 GiB) |
+| `honeybee-k8s-3groups.json` | 3 | 3 | Three specs produce three node groups |
+| `honeybee-k8s-hetero.json` | 2 | 2 | Two specs produce two node groups |
+| `honeybee-k8s-arm64.json` | 2 | 1 | arm64 spec and matching node image |
+| `honeybee-k8s-mixed-arch.json` | 2 | 1 (arch differs) | Architecture-based grouping |
+| `honeybee-k8s-samecpu-diffdisk.json` | 2 | 1 (disk differs) | Whether disk size splits node groups |
+| `honeybee-k8s-spec-small.json` | 2 | 1 | Upscaling to a viable spec |
+| `honeybee-k8s-spec-large.json` | 2 | 1 | Large spec, no upscaling |
+| `honeybee-k8s-v134.json` | 2 | 1 | Version mapping |
+| `honeybee-k8s-v199.json` | 2 | 1 | Non-existent version falls back to latest |
+| `honeybee-k8s-norole.json` | 0 | — | No `role: worker` present |
+
+`nodeGroupCount` is deliberately left unset for `mixed-arch` and `samecpu-diffdisk` — the correct
+grouping for those inputs is still an open design question, so pinning a number would freeze the
+current behaviour rather than test it.
+
+### Negative fixtures
+
+`testconf/scenarios/negative/` holds three cm-honeybee payloads captured **before**
+`/infra/refined`. All three describe the same source cluster at different pipeline stages:
+
+```
+honeybee source_group response    →  honeybee-k8s-raw-source-group.json     (top-level array)
+  └ honeybee connection_info      →  honeybee-k8s-raw-connection-info.json  (full node labels)
+      └ labels/node_info trimmed  →  beetle-k8s-recommendation-request.json
+```
+
+None of them use the `onpremiseInfraModel` wrapper the API expects, so feeding them directly is a
+realistic user mistake. The API should reject each with a clean 400.
+
+## CLI Options
+
+```bash
+cd cmd/test-cli/k8s-infra-recommendation
+go run main.go -config testconf/test-config.yaml
+```
+
+| Option    | Default                     | Description                     |
+| --------- | --------------------------- | ------------------------------- |
+| `-config` | `testconf/test-config.yaml` | Path to test configuration file |
+
+Exit code is non-zero if any case fails, so the CLI can gate CI.
+
+## Results
+
+- Console: per-case pass/fail with the individual check outcomes
+- File: `testresult/k8s-infra-recommendation-test-report.md`
+
+The report opens with a scenario × target matrix, so a regression confined to one CSP or one
+scenario is visible at a glance, followed by per-case detail with the full response body.
+CSP account identifiers (Azure subscription IDs, GCP project IDs, email addresses) are masked.
+
+## Prerequisites
+
+1. CM-Beetle running at the configured endpoint
+2. CB-Tumblebug reachable by CM-Beetle, with the target CSPs' spec/image catalogs loaded
+3. Credentials configured in `testconf/auth-config.json`
+
+No CSP write permissions are needed — nothing is created.

--- a/cmd/test-cli/k8s-infra-recommendation/main.go
+++ b/cmd/test-cli/k8s-infra-recommendation/main.go
@@ -1,0 +1,664 @@
+// Package main is the starting point of CM-Beetle K8s Infra Recommendation Test CLI.
+//
+// Scoped to POST /recommendation/k8sCluster only: it sends each on-premise scenario fixture
+// to every configured CSP/region pair and checks the recommendation against declarative
+// expectations. Nothing is provisioned, so there is no migration, SSH, or cleanup step —
+// the same scoping rationale as cmd/test-cli/multi-infra-recommendation.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+
+	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
+	"github.com/cloud-barista/cm-beetle/pkg/api/rest/model"
+	"github.com/cloud-barista/cm-beetle/pkg/config"
+	"github.com/cloud-barista/cm-beetle/pkg/core/common"
+	"github.com/cloud-barista/cm-beetle/pkg/logger"
+)
+
+// restyNoopLogger silences all Resty log output (e.g. "Basic Auth in HTTP mode" warnings).
+type restyNoopLogger struct{}
+
+func (restyNoopLogger) Errorf(_ string, _ ...interface{}) {}
+func (restyNoopLogger) Warnf(_ string, _ ...interface{})  {}
+func (restyNoopLogger) Debugf(_ string, _ ...interface{}) {}
+
+// TestConfig holds test configuration.
+type TestConfig struct {
+	Test struct {
+		Set struct {
+			Mode string `yaml:"mode"` // parallel or sequential
+		} `yaml:"set"`
+		Cases     []TestCase `yaml:"cases"`
+		Scenarios []Scenario `yaml:"scenarios"`
+	} `yaml:"test"`
+	Beetle struct {
+		Endpoint       string `yaml:"endpoint"`
+		AuthConfigFile string `yaml:"authConfigFile"`
+	} `yaml:"beetle"`
+}
+
+// TestCase is one target CSP/region pair; only entries with Execute: true are used.
+type TestCase struct {
+	cloudmodel.CloudProperty `yaml:",inline"`
+	Name                     string `yaml:"name"`
+	Execute                  bool   `yaml:"execute"`
+}
+
+// Scenario is one on-premise fixture plus the expectations it must satisfy.
+type Scenario struct {
+	File    string `yaml:"file"`
+	Name    string `yaml:"name"`
+	Execute bool   `yaml:"execute"`
+	Expect  Expect `yaml:"expect"`
+}
+
+// Expect declares what a scenario's response must satisfy. Pointer fields are optional:
+// nil means "do not check". Keeping expectations in config avoids hardcoding per-CSP
+// values in this CLI, which would defeat the purpose of testing the recommender.
+type Expect struct {
+	StatusCode     int    `yaml:"statusCode"`     // required; 200 for positive, 4xx/5xx for negative
+	NodeGroupCount *int   `yaml:"nodeGroupCount"` // expected len(k8sNodeGroupList)
+	TotalNodeSize  *int   `yaml:"totalNodeSize"`  // expected sum of desiredNodeSize across node groups
+	VersionPrefix  string `yaml:"versionPrefix"`  // expected prefix of targetK8sCluster.version
+}
+
+// AuthConfig holds Beetle API credentials.
+type AuthConfig struct {
+	BeetleApiUsername string `json:"beetleApiUsername"`
+	BeetleApiPassword string `json:"beetleApiPassword"`
+}
+
+// CaseResult is one (scenario × CSP/region) execution result.
+type CaseResult struct {
+	ScenarioName string
+	ScenarioFile string
+	DisplayName  string
+	Csp          string
+	Region       string
+
+	StartTime time.Time
+	Duration  time.Duration
+
+	RequestURL   string
+	StatusCode   int
+	ResponseBody string
+
+	Passed  bool
+	Checks  []string // human-readable check outcomes, prefixed with ✅ / ❌
+	Failure string   // set when the case could not even be executed
+}
+
+// TestReport aggregates every case result for the markdown report.
+type TestReport struct {
+	TestDateTime  time.Time
+	BeetleURL     string
+	BeetleVersion string
+	GitHash       string
+	Targets       []TestCase
+	Scenarios     []Scenario
+	Results       []CaseResult
+}
+
+var configFile = flag.String("config", "testconf/test-config.yaml", "Path to config file")
+
+func init() {
+	config.Init()
+	l := logger.NewLogger(logger.Config{
+		LogLevel:    config.Beetle.LogLevel,
+		LogWriter:   config.Beetle.LogWriter,
+		LogFilePath: config.Beetle.LogFile.Path,
+		MaxSize:     config.Beetle.LogFile.MaxSize,
+		MaxBackups:  config.Beetle.LogFile.MaxBackups,
+		MaxAge:      config.Beetle.LogFile.MaxAge,
+		Compress:    config.Beetle.LogFile.Compress,
+	})
+	log.Logger = *l
+}
+
+func main() {
+	flag.Parse()
+
+	cfg, err := loadConfig(*configFile)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to load config")
+	}
+
+	targets := selectedTargets(cfg)
+	if len(targets) == 0 {
+		log.Fatal().Msg("At least 1 test case must have execute: true")
+	}
+	scenarios := selectedScenarios(cfg)
+	if len(scenarios) == 0 {
+		log.Fatal().Msg("At least 1 scenario must have execute: true")
+	}
+
+	client := resty.New().SetTimeout(2 * time.Minute).SetLogger(restyNoopLogger{})
+
+	if err := checkBeetleReadiness(client, cfg.Beetle.Endpoint); err != nil {
+		log.Fatal().Err(err).Msg("CM-Beetle readiness check failed")
+	}
+
+	auth, err := loadAuthConfig(cfg.Beetle.AuthConfigFile)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to load auth config; proceeding without auth")
+	} else if auth.BeetleApiUsername != "" {
+		client.SetBasicAuth(auth.BeetleApiUsername, auth.BeetleApiPassword)
+	}
+
+	report := &TestReport{
+		TestDateTime:  time.Now(),
+		BeetleURL:     cfg.Beetle.Endpoint,
+		BeetleVersion: getBeetleVersion(),
+		GitHash:       getGitHash(),
+		Targets:       targets,
+		Scenarios:     scenarios,
+	}
+
+	fmt.Println("=========================================================")
+	fmt.Println(" CM-Beetle K8s Infra Recommendation Test CLI")
+	fmt.Printf(" %d scenario(s) × %d target(s) = %d case(s), mode: %s\n",
+		len(scenarios), len(targets), len(scenarios)*len(targets), executionMode(cfg))
+	fmt.Println("=========================================================")
+
+	report.Results = runAllCases(client, cfg, targets, scenarios)
+
+	if err := generateMarkdownReport(report); err != nil {
+		log.Warn().Err(err).Msg("Failed to generate markdown report")
+	}
+
+	printFinalSummary(report)
+
+	for _, r := range report.Results {
+		if !r.Passed {
+			os.Exit(1)
+		}
+	}
+}
+
+// runAllCases executes every (target × scenario) pair, honouring the configured mode.
+// Parallelism is per target so that scenarios against one CSP stay ordered and readable.
+func runAllCases(client *resty.Client, cfg TestConfig, targets []TestCase, scenarios []Scenario) []CaseResult {
+	if executionMode(cfg) == "sequential" {
+		var all []CaseResult
+		for _, t := range targets {
+			all = append(all, runTargetCases(client, cfg, t, scenarios)...)
+		}
+		return all
+	}
+
+	// Each goroutine writes only its own slot, so results stay in target order without a mutex.
+	var wg sync.WaitGroup
+	perTarget := make([][]CaseResult, len(targets))
+	for i, t := range targets {
+		wg.Add(1)
+		go func(idx int, target TestCase) {
+			defer wg.Done()
+			perTarget[idx] = runTargetCases(client, cfg, target, scenarios)
+		}(i, t)
+	}
+	wg.Wait()
+
+	var all []CaseResult
+	for _, res := range perTarget {
+		all = append(all, res...)
+	}
+	return all
+}
+
+func runTargetCases(client *resty.Client, cfg TestConfig, target TestCase, scenarios []Scenario) []CaseResult {
+	results := make([]CaseResult, 0, len(scenarios))
+	for _, sc := range scenarios {
+		results = append(results, runCase(client, cfg, target, sc))
+	}
+	return results
+}
+
+// runCase posts one scenario fixture as a raw body. Sending raw bytes (rather than
+// marshalling through a Go struct) is required for the negative fixtures, whose shapes do
+// not map onto RecommendK8sInfraRequest at all.
+func runCase(client *resty.Client, cfg TestConfig, target TestCase, sc Scenario) CaseResult {
+	res := CaseResult{
+		ScenarioName: sc.Name,
+		ScenarioFile: sc.File,
+		DisplayName:  target.Name,
+		Csp:          target.Csp,
+		Region:       target.Region,
+		StartTime:    time.Now(),
+	}
+
+	body, err := os.ReadFile(sc.File)
+	if err != nil {
+		res.Duration = time.Since(res.StartTime)
+		res.Failure = fmt.Sprintf("failed to read scenario file: %s", err)
+		fmt.Printf("❌ [%s] %s — %s\n", target.Name, sc.Name, res.Failure)
+		return res
+	}
+
+	url := cfg.Beetle.Endpoint + "/beetle/recommendation/k8sCluster"
+	res.RequestURL = fmt.Sprintf("%s?desiredProvider=%s&desiredRegion=%s", url, target.Csp, target.Region)
+
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetQueryParam("desiredProvider", target.Csp).
+		SetQueryParam("desiredRegion", target.Region).
+		SetBody(body).
+		Post(url)
+
+	res.Duration = time.Since(res.StartTime)
+
+	if err != nil {
+		res.Failure = fmt.Sprintf("request failed: %s", err)
+		fmt.Printf("❌ [%s] %s — %s\n", target.Name, sc.Name, res.Failure)
+		return res
+	}
+
+	res.StatusCode = resp.StatusCode()
+	res.ResponseBody = string(resp.Body())
+
+	res.Checks, res.Passed = evaluate(sc.Expect, res.StatusCode, resp.Body())
+
+	icon := "✅"
+	if !res.Passed {
+		icon = "❌"
+	}
+	fmt.Printf("%s [%s] %-20s HTTP %d (%v)\n", icon, target.Name, sc.Name,
+		res.StatusCode, res.Duration.Truncate(time.Millisecond))
+	for _, c := range res.Checks {
+		fmt.Printf("      %s\n", c)
+	}
+
+	return res
+}
+
+// evaluate applies the scenario's declared expectations plus the structural checks that
+// every successful recommendation must satisfy.
+func evaluate(exp Expect, statusCode int, body []byte) (checks []string, passed bool) {
+	passed = true
+
+	if statusCode == exp.StatusCode {
+		checks = append(checks, fmt.Sprintf("✅ status code %d as expected", statusCode))
+	} else {
+		passed = false
+		checks = append(checks, fmt.Sprintf("❌ status code %d, want %d", statusCode, exp.StatusCode))
+		// Keep going: the body may still explain the mismatch in the report.
+	}
+
+	// Nothing further to assert for negative scenarios.
+	if exp.StatusCode != 200 {
+		return checks, passed
+	}
+	if statusCode != 200 {
+		return checks, passed
+	}
+
+	var apiResp model.ApiResponse[cloudmodel.RecommendedInfra]
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return append(checks, fmt.Sprintf("❌ failed to parse response: %s", err)), false
+	}
+	if !apiResp.Success {
+		return append(checks, fmt.Sprintf("❌ response success=false: %s", apiResp.Error)), false
+	}
+
+	cluster := apiResp.Data.TargetK8sCluster
+
+	if cluster.Name == "" {
+		passed = false
+		checks = append(checks, "❌ targetK8sCluster.name is empty")
+	}
+	if cluster.Version == "" {
+		passed = false
+		checks = append(checks, "❌ targetK8sCluster.version is empty")
+	} else {
+		checks = append(checks, fmt.Sprintf("✅ version: %s", cluster.Version))
+	}
+
+	if exp.VersionPrefix != "" {
+		if strings.HasPrefix(cluster.Version, exp.VersionPrefix) {
+			checks = append(checks, fmt.Sprintf("✅ version has prefix %q", exp.VersionPrefix))
+		} else {
+			passed = false
+			checks = append(checks, fmt.Sprintf("❌ version %q lacks prefix %q", cluster.Version, exp.VersionPrefix))
+		}
+	}
+
+	groups := cluster.K8sNodeGroupList
+	if exp.NodeGroupCount != nil {
+		if len(groups) == *exp.NodeGroupCount {
+			checks = append(checks, fmt.Sprintf("✅ node group count: %d", len(groups)))
+		} else {
+			passed = false
+			checks = append(checks, fmt.Sprintf("❌ node group count %d, want %d", len(groups), *exp.NodeGroupCount))
+		}
+	} else {
+		checks = append(checks, fmt.Sprintf("ℹ️  node group count: %d", len(groups)))
+	}
+
+	total := 0
+	for i, ng := range groups {
+		total += ng.DesiredNodeSize
+		if ng.SpecId == "" {
+			passed = false
+			checks = append(checks, fmt.Sprintf("❌ node group[%d] %q has empty specId", i, ng.Name))
+		}
+		if ng.DesiredNodeSize < 1 {
+			passed = false
+			checks = append(checks, fmt.Sprintf("❌ node group[%d] %q desiredNodeSize=%d (< 1)", i, ng.Name, ng.DesiredNodeSize))
+		}
+		checks = append(checks, fmt.Sprintf("ℹ️  node group[%d] %q spec=%s image=%s nodes=%d",
+			i, ng.Name, ng.SpecId, emptyAsDash(ng.ImageId), ng.DesiredNodeSize))
+	}
+
+	if exp.TotalNodeSize != nil {
+		if total == *exp.TotalNodeSize {
+			checks = append(checks, fmt.Sprintf("✅ total node size: %d", total))
+		} else {
+			passed = false
+			checks = append(checks, fmt.Sprintf("❌ total node size %d, want %d", total, *exp.TotalNodeSize))
+		}
+	}
+
+	return checks, passed
+}
+
+func emptyAsDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func executionMode(cfg TestConfig) string {
+	if strings.EqualFold(cfg.Test.Set.Mode, "sequential") {
+		return "sequential"
+	}
+	return "parallel"
+}
+
+func selectedTargets(cfg TestConfig) []TestCase {
+	var out []TestCase
+	for _, c := range cfg.Test.Cases {
+		if c.Execute {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func selectedScenarios(cfg TestConfig) []Scenario {
+	var out []Scenario
+	for _, s := range cfg.Test.Scenarios {
+		if s.Execute {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func printFinalSummary(report *TestReport) {
+	passed := 0
+	for _, r := range report.Results {
+		if r.Passed {
+			passed++
+		}
+	}
+	fmt.Println("\n=========================================================")
+	fmt.Println(" OVERALL TEST SUMMARY")
+	fmt.Println("=========================================================")
+	fmt.Printf(" Total Cases : %d\n", len(report.Results))
+	fmt.Printf(" Passed      : %d\n", passed)
+	fmt.Printf(" Failed      : %d\n", len(report.Results)-passed)
+	if passed == len(report.Results) {
+		fmt.Println(" ✅ All recommendation checks passed.")
+	} else {
+		fmt.Println(" ❌ Some checks failed. See testresult/ for details.")
+	}
+	fmt.Println("=========================================================")
+}
+
+// checkBeetleReadiness checks if CM-Beetle is ready using GET /beetle/readyz.
+func checkBeetleReadiness(client *resty.Client, beetleURL string) error {
+	fmt.Println("🔍 Checking CM-Beetle readiness...")
+	url := beetleURL + "/beetle/readyz"
+
+	var response map[string]interface{}
+	var emptyBody interface{} = common.NoBody
+	err := common.ExecuteHttpRequest(client, "GET", url, nil, common.SetUseBody(emptyBody), &emptyBody, &response, 0)
+	if err != nil {
+		return fmt.Errorf("CM-Beetle readiness check failed: %w", err)
+	}
+	if message, ok := response["message"].(string); ok && strings.Contains(message, "NOT ready") {
+		return fmt.Errorf("CM-Beetle is not ready: %s", message)
+	}
+	fmt.Println("✅ CM-Beetle is ready!")
+	return nil
+}
+
+func loadConfig(configPath string) (TestConfig, error) {
+	var cfg TestConfig
+	file, err := os.Open(configPath)
+	if err != nil {
+		return cfg, err
+	}
+	defer file.Close()
+	if err := yaml.NewDecoder(file).Decode(&cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func loadAuthConfig(authConfigPath string) (AuthConfig, error) {
+	var auth AuthConfig
+	file, err := os.Open(authConfigPath)
+	if err != nil {
+		return auth, err
+	}
+	defer file.Close()
+	if err := json.NewDecoder(file).Decode(&auth); err != nil {
+		return auth, fmt.Errorf("failed to decode auth config: %w", err)
+	}
+	return auth, nil
+}
+
+// getGitHash returns the current git commit hash.
+func getGitHash() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// getBeetleVersion returns the CM-Beetle version from git tags or commit hash.
+// Only beetle release tags (v[0-9]*) are matched to avoid picking up imdl/*, transx/* tags.
+func getBeetleVersion() string {
+	commitHash := getGitHash()
+
+	if exactTag, err := exec.Command("git", "describe", "--tags", "--exact-match", "--match", "v[0-9]*").Output(); err == nil {
+		return strings.TrimSpace(string(exactTag))
+	}
+	if tag, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*").Output(); err == nil {
+		if tagStr := strings.TrimSpace(string(tag)); tagStr != "" {
+			if commitHash != "unknown" {
+				return fmt.Sprintf("%s+ (%s)", tagStr, commitHash)
+			}
+			return tagStr + "+"
+		}
+	}
+	if commitHash != "unknown" {
+		return fmt.Sprintf("main (%s)", commitHash)
+	}
+	return "main (unknown)"
+}
+
+// maskSensitiveInfo removes CSP account identifiers from report content.
+func maskSensitiveInfo(content string) string {
+	reSub := regexp.MustCompile(`(?i)/subscriptions/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
+	content = reSub.ReplaceAllString(content, "/subscriptions/AZURE_SUBSCRIPTION_ID")
+
+	reGCP := regexp.MustCompile(`projects/([a-z0-9\-]+)/`)
+	content = reGCP.ReplaceAllStringFunc(content, func(match string) string {
+		parts := strings.Split(match, "/")
+		if len(parts) >= 2 && (parts[1] == "compute" || parts[1] == "v1") {
+			return match
+		}
+		return "projects/GCP_PROJECT_ID/"
+	})
+
+	reEmail := regexp.MustCompile(`[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}`)
+	return reEmail.ReplaceAllString(content, "MASKED_EMAIL")
+}
+
+// generateMarkdownReport writes the full result matrix and per-case details to
+// testresult/k8s-infra-recommendation-test-report.md.
+func generateMarkdownReport(report *TestReport) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(cwd, "testresult")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	path := filepath.Join(dir, "k8s-infra-recommendation-test-report.md")
+	if err := os.WriteFile(path, []byte(maskSensitiveInfo(buildMarkdown(report))), 0644); err != nil {
+		return err
+	}
+	log.Info().Str("file", path).Msg("✅ Test report generated and saved")
+	return nil
+}
+
+func buildMarkdown(report *TestReport) string {
+	var sb strings.Builder
+
+	sb.WriteString("# CM-Beetle K8s Infra Recommendation Test Results\n\n")
+	sb.WriteString("> [!NOTE]\n")
+	sb.WriteString("> Verifies `POST /recommendation/k8sCluster` against on-premise scenario fixtures.\n")
+	sb.WriteString("> No resources are provisioned by this test.\n\n")
+
+	sb.WriteString("## Environment\n\n")
+	sb.WriteString(fmt.Sprintf("- CM-Beetle URL: %s\n", report.BeetleURL))
+	sb.WriteString(fmt.Sprintf("- CM-Beetle Version: %s\n", report.BeetleVersion))
+	sb.WriteString(fmt.Sprintf("- Git Commit: %s\n", report.GitHash))
+	sb.WriteString(fmt.Sprintf("- Test Date: %s\n", report.TestDateTime.Format("2006-01-02 15:04:05 MST")))
+
+	var targetList []string
+	for _, t := range report.Targets {
+		targetList = append(targetList, fmt.Sprintf("%s/%s", t.Csp, t.Region))
+	}
+	sb.WriteString(fmt.Sprintf("- Targets (%d): %s\n", len(report.Targets), strings.Join(targetList, ", ")))
+	sb.WriteString(fmt.Sprintf("- Scenarios: %d\n\n", len(report.Scenarios)))
+
+	writeSummaryMatrix(&sb, report)
+	writeCaseDetails(&sb, report)
+
+	return sb.String()
+}
+
+// writeSummaryMatrix renders a scenario × target pass/fail grid so a regression in one CSP
+// or one scenario is visible at a glance.
+func writeSummaryMatrix(sb *strings.Builder, report *TestReport) {
+	sb.WriteString("## Summary Matrix\n\n")
+
+	sb.WriteString("| Scenario |")
+	for _, t := range report.Targets {
+		sb.WriteString(fmt.Sprintf(" %s |", t.Name))
+	}
+	sb.WriteString("\n|---|")
+	for range report.Targets {
+		sb.WriteString("---|")
+	}
+	sb.WriteString("\n")
+
+	index := make(map[string]CaseResult, len(report.Results))
+	for _, r := range report.Results {
+		index[r.ScenarioName+"|"+r.DisplayName] = r
+	}
+
+	passed := 0
+	for _, sc := range report.Scenarios {
+		sb.WriteString(fmt.Sprintf("| `%s` |", sc.Name))
+		for _, t := range report.Targets {
+			r, ok := index[sc.Name+"|"+t.Name]
+			switch {
+			case !ok:
+				sb.WriteString(" — |")
+			case r.Passed:
+				passed++
+				sb.WriteString(fmt.Sprintf(" ✅ %d |", r.StatusCode))
+			default:
+				sb.WriteString(fmt.Sprintf(" ❌ %d |", r.StatusCode))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(fmt.Sprintf("\n**Overall Result**: %d/%d cases passed", passed, len(report.Results)))
+	if passed == len(report.Results) {
+		sb.WriteString(" ✅\n\n")
+	} else {
+		sb.WriteString(" ❌\n\n")
+	}
+	sb.WriteString("---\n\n")
+}
+
+func writeCaseDetails(sb *strings.Builder, report *TestReport) {
+	sb.WriteString("## Case Details\n\n")
+
+	for _, r := range report.Results {
+		status := "✅ PASS"
+		if !r.Passed {
+			status = "❌ FAIL"
+		}
+		sb.WriteString(fmt.Sprintf("### %s — %s (%s)\n\n", r.ScenarioName, r.DisplayName, status))
+		sb.WriteString(fmt.Sprintf("- **Fixture**: `%s`\n", r.ScenarioFile))
+		sb.WriteString(fmt.Sprintf("- **Request**: `POST %s`\n", r.RequestURL))
+		sb.WriteString(fmt.Sprintf("- **Status Code**: %d\n", r.StatusCode))
+		sb.WriteString(fmt.Sprintf("- **Duration**: %v\n", r.Duration.Truncate(time.Millisecond)))
+		if r.Failure != "" {
+			sb.WriteString(fmt.Sprintf("- **Failure**: %s\n", r.Failure))
+		}
+		sb.WriteString("\n")
+
+		if len(r.Checks) > 0 {
+			sb.WriteString("**Checks**:\n\n")
+			for _, c := range r.Checks {
+				sb.WriteString(fmt.Sprintf("- %s\n", c))
+			}
+			sb.WriteString("\n")
+		}
+
+		if r.ResponseBody != "" {
+			sb.WriteString("<details>\n  <summary> <ins>Click to see the response body</ins> </summary>\n\n```json\n")
+			sb.WriteString(prettyJSON(r.ResponseBody))
+			sb.WriteString("\n```\n\n</details>\n\n")
+		}
+		sb.WriteString("---\n\n")
+	}
+}
+
+func prettyJSON(raw string) string {
+	var v interface{}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return raw
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return raw
+	}
+	return string(out)
+}

--- a/cmd/test-cli/k8s-infra-recommendation/main.go
+++ b/cmd/test-cli/k8s-infra-recommendation/main.go
@@ -82,6 +82,40 @@ type AuthConfig struct {
 	BeetleApiPassword string `json:"beetleApiPassword"`
 }
 
+// caseOutcome separates "did the API do the right thing" from "did it use the declared status
+// code". An input the API correctly rejects but reports with the wrong status is a contract
+// defect, not a broken recommendation — collapsing both into "failed" hides that difference and
+// makes a working scenario look like a malfunction.
+type caseOutcome int
+
+const (
+	outcomeAsExpected caseOutcome = iota // outcome and status code both match the expectation
+	outcomeDeviation                     // outcome matches, status code does not (known API gap)
+	outcomeUnexpected                    // the API accepted what should be rejected, or vice versa
+)
+
+func (o caseOutcome) icon() string {
+	switch o {
+	case outcomeAsExpected:
+		return "✅"
+	case outcomeDeviation:
+		return "⚠️ "
+	default:
+		return "❌"
+	}
+}
+
+func (o caseOutcome) label() string {
+	switch o {
+	case outcomeAsExpected:
+		return "as expected"
+	case outcomeDeviation:
+		return "as expected, non-conforming status code"
+	default:
+		return "UNEXPECTED"
+	}
+}
+
 // CaseResult is one (scenario × CSP/region) execution result.
 type CaseResult struct {
 	ScenarioName string
@@ -97,8 +131,9 @@ type CaseResult struct {
 	StatusCode   int
 	ResponseBody string
 
-	Passed  bool
-	Checks  []string // human-readable check outcomes, prefixed with ✅ / ❌
+	Outcome caseOutcome
+	Passed  bool     // Outcome != outcomeUnexpected
+	Checks  []string // human-readable check outcomes, prefixed with ✅ / ⚠️ / ❌
 	Failure string   // set when the case could not even be executed
 }
 
@@ -269,14 +304,11 @@ func runCase(client *resty.Client, cfg TestConfig, target TestCase, sc Scenario)
 	res.StatusCode = resp.StatusCode()
 	res.ResponseBody = string(resp.Body())
 
-	res.Checks, res.Passed = evaluate(sc.Expect, res.StatusCode, resp.Body())
+	res.Checks, res.Outcome = evaluate(sc.Expect, res.StatusCode, resp.Body())
+	res.Passed = res.Outcome != outcomeUnexpected
 
-	icon := "✅"
-	if !res.Passed {
-		icon = "❌"
-	}
-	fmt.Printf("%s [%s] %-20s HTTP %d (%v)\n", icon, target.Name, sc.Name,
-		res.StatusCode, res.Duration.Truncate(time.Millisecond))
+	fmt.Printf("%s [%s] %-22s HTTP %d — %s (%v)\n", res.Outcome.icon(), target.Name, sc.Name,
+		res.StatusCode, res.Outcome.label(), res.Duration.Truncate(time.Millisecond))
 	for _, c := range res.Checks {
 		fmt.Printf("      %s\n", c)
 	}
@@ -284,43 +316,59 @@ func runCase(client *resty.Client, cfg TestConfig, target TestCase, sc Scenario)
 	return res
 }
 
+// wantsAcceptance reports whether the scenario expects the recommendation to succeed.
+func (e Expect) wantsAcceptance() bool { return e.StatusCode == 200 }
+
+// accepted reports whether the API produced a recommendation rather than rejecting the input.
+func accepted(statusCode int) bool { return statusCode >= 200 && statusCode < 300 }
+
 // evaluate applies the scenario's declared expectations plus the structural checks that
 // every successful recommendation must satisfy.
-func evaluate(exp Expect, statusCode int, body []byte) (checks []string, passed bool) {
-	passed = true
+//
+// The outcome (accepted vs rejected) is judged separately from the status code, so a correctly
+// rejected input reported with the wrong status is distinguishable from a genuinely wrong
+// recommendation. Only the former is a contract defect; the latter means the recommender broke.
+func evaluate(exp Expect, statusCode int, body []byte) (checks []string, outcome caseOutcome) {
+	outcomeMatches := exp.wantsAcceptance() == accepted(statusCode)
 
-	if statusCode == exp.StatusCode {
+	switch {
+	case !outcomeMatches && exp.wantsAcceptance():
+		checks = append(checks, fmt.Sprintf("❌ input was rejected (HTTP %d) but a recommendation was expected", statusCode))
+		return checks, outcomeUnexpected
+	case !outcomeMatches:
+		checks = append(checks, fmt.Sprintf("❌ input was accepted (HTTP %d) but rejection was expected", statusCode))
+		return checks, outcomeUnexpected
+	case statusCode == exp.StatusCode:
 		checks = append(checks, fmt.Sprintf("✅ status code %d as expected", statusCode))
-	} else {
-		passed = false
-		checks = append(checks, fmt.Sprintf("❌ status code %d, want %d", statusCode, exp.StatusCode))
-		// Keep going: the body may still explain the mismatch in the report.
+		outcome = outcomeAsExpected
+	default:
+		checks = append(checks,
+			fmt.Sprintf("✅ input rejected as expected"),
+			fmt.Sprintf("⚠️  status code %d, but the API declares %d for this case", statusCode, exp.StatusCode))
+		outcome = outcomeDeviation
 	}
 
-	// Nothing further to assert for negative scenarios.
-	if exp.StatusCode != 200 {
-		return checks, passed
-	}
-	if statusCode != 200 {
-		return checks, passed
+	// Nothing further to assert for scenarios that expect rejection.
+	if !exp.wantsAcceptance() {
+		return checks, outcome
 	}
 
 	var apiResp model.ApiResponse[cloudmodel.RecommendedInfra]
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return append(checks, fmt.Sprintf("❌ failed to parse response: %s", err)), false
+		return append(checks, fmt.Sprintf("❌ failed to parse response: %s", err)), outcomeUnexpected
 	}
 	if !apiResp.Success {
-		return append(checks, fmt.Sprintf("❌ response success=false: %s", apiResp.Error)), false
+		return append(checks, fmt.Sprintf("❌ response success=false: %s", apiResp.Error)), outcomeUnexpected
 	}
 
 	cluster := apiResp.Data.TargetK8sCluster
 
 	if cluster.Name == "" {
-		passed = false
+		outcome = outcomeUnexpected
 		checks = append(checks, "❌ targetK8sCluster.name is empty")
 	}
 	if cluster.Version == "" {
-		passed = false
+		outcome = outcomeUnexpected
 		checks = append(checks, "❌ targetK8sCluster.version is empty")
 	} else {
 		checks = append(checks, fmt.Sprintf("✅ version: %s", cluster.Version))
@@ -330,7 +378,7 @@ func evaluate(exp Expect, statusCode int, body []byte) (checks []string, passed 
 		if strings.HasPrefix(cluster.Version, exp.VersionPrefix) {
 			checks = append(checks, fmt.Sprintf("✅ version has prefix %q", exp.VersionPrefix))
 		} else {
-			passed = false
+			outcome = outcomeUnexpected
 			checks = append(checks, fmt.Sprintf("❌ version %q lacks prefix %q", cluster.Version, exp.VersionPrefix))
 		}
 	}
@@ -340,7 +388,7 @@ func evaluate(exp Expect, statusCode int, body []byte) (checks []string, passed 
 		if len(groups) == *exp.NodeGroupCount {
 			checks = append(checks, fmt.Sprintf("✅ node group count: %d", len(groups)))
 		} else {
-			passed = false
+			outcome = outcomeUnexpected
 			checks = append(checks, fmt.Sprintf("❌ node group count %d, want %d", len(groups), *exp.NodeGroupCount))
 		}
 	} else {
@@ -351,11 +399,11 @@ func evaluate(exp Expect, statusCode int, body []byte) (checks []string, passed 
 	for i, ng := range groups {
 		total += ng.DesiredNodeSize
 		if ng.SpecId == "" {
-			passed = false
+			outcome = outcomeUnexpected
 			checks = append(checks, fmt.Sprintf("❌ node group[%d] %q has empty specId", i, ng.Name))
 		}
 		if ng.DesiredNodeSize < 1 {
-			passed = false
+			outcome = outcomeUnexpected
 			checks = append(checks, fmt.Sprintf("❌ node group[%d] %q desiredNodeSize=%d (< 1)", i, ng.Name, ng.DesiredNodeSize))
 		}
 		checks = append(checks, fmt.Sprintf("ℹ️  node group[%d] %q spec=%s image=%s nodes=%d",
@@ -366,12 +414,12 @@ func evaluate(exp Expect, statusCode int, body []byte) (checks []string, passed 
 		if total == *exp.TotalNodeSize {
 			checks = append(checks, fmt.Sprintf("✅ total node size: %d", total))
 		} else {
-			passed = false
+			outcome = outcomeUnexpected
 			checks = append(checks, fmt.Sprintf("❌ total node size %d, want %d", total, *exp.TotalNodeSize))
 		}
 	}
 
-	return checks, passed
+	return checks, outcome
 }
 
 func emptyAsDash(s string) string {
@@ -408,23 +456,45 @@ func selectedScenarios(cfg TestConfig) []Scenario {
 	return out
 }
 
-func printFinalSummary(report *TestReport) {
-	passed := 0
-	for _, r := range report.Results {
-		if r.Passed {
-			passed++
+// countOutcomes tallies the three judgement states across all cases.
+func countOutcomes(results []CaseResult) (exact, deviation, unexpected int) {
+	for _, r := range results {
+		switch r.Outcome {
+		case outcomeAsExpected:
+			exact++
+		case outcomeDeviation:
+			deviation++
+		default:
+			unexpected++
 		}
 	}
+	return exact, deviation, unexpected
+}
+
+func printFinalSummary(report *TestReport) {
+	exact, deviation, unexpected := countOutcomes(report.Results)
+	total := len(report.Results)
+
 	fmt.Println("\n=========================================================")
 	fmt.Println(" OVERALL TEST SUMMARY")
 	fmt.Println("=========================================================")
-	fmt.Printf(" Total Cases : %d\n", len(report.Results))
-	fmt.Printf(" Passed      : %d\n", passed)
-	fmt.Printf(" Failed      : %d\n", len(report.Results)-passed)
-	if passed == len(report.Results) {
-		fmt.Println(" ✅ All recommendation checks passed.")
-	} else {
-		fmt.Println(" ❌ Some checks failed. See testresult/ for details.")
+	fmt.Printf(" Total cases            : %d\n", total)
+	fmt.Printf(" Behaved as expected    : %d\n", exact+deviation)
+	fmt.Printf("   ├ fully conforming   : %d\n", exact)
+	fmt.Printf("   └ status code differs: %d\n", deviation)
+	fmt.Printf(" Unexpected behaviour   : %d\n", unexpected)
+	fmt.Println("=========================================================")
+
+	switch {
+	case unexpected > 0:
+		fmt.Printf(" ❌ %d case(s) did not behave as expected. See testresult/ for details.\n", unexpected)
+	case deviation > 0:
+		fmt.Printf(" ✅ All %d case(s) behaved as expected.\n", total)
+		fmt.Printf(" ⚠️  %d of them are rejected with a status code the API does not declare\n", deviation)
+		fmt.Println("    (input validation errors returned as 500 where 400 is declared).")
+		fmt.Println("    The recommendation logic is correct; only the status code deviates.")
+	default:
+		fmt.Printf(" ✅ All %d case(s) behaved as expected, with conforming status codes.\n", total)
 	}
 	fmt.Println("=========================================================")
 }
@@ -589,29 +659,44 @@ func writeSummaryMatrix(sb *strings.Builder, report *TestReport) {
 		index[r.ScenarioName+"|"+r.DisplayName] = r
 	}
 
-	passed := 0
 	for _, sc := range report.Scenarios {
 		sb.WriteString(fmt.Sprintf("| `%s` |", sc.Name))
 		for _, t := range report.Targets {
 			r, ok := index[sc.Name+"|"+t.Name]
-			switch {
-			case !ok:
+			if !ok {
 				sb.WriteString(" — |")
-			case r.Passed:
-				passed++
-				sb.WriteString(fmt.Sprintf(" ✅ %d |", r.StatusCode))
-			default:
-				sb.WriteString(fmt.Sprintf(" ❌ %d |", r.StatusCode))
+				continue
 			}
+			sb.WriteString(fmt.Sprintf(" %s %d |", r.Outcome.icon(), r.StatusCode))
 		}
 		sb.WriteString("\n")
 	}
 
-	sb.WriteString(fmt.Sprintf("\n**Overall Result**: %d/%d cases passed", passed, len(report.Results)))
-	if passed == len(report.Results) {
+	exact, deviation, unexpected := countOutcomes(report.Results)
+	total := len(report.Results)
+
+	sb.WriteString("\n| Legend | Meaning |\n|---|---|\n")
+	sb.WriteString("| ✅ | Behaved as expected, with the status code the API declares |\n")
+	sb.WriteString("| ⚠️ | Behaved as expected (input correctly accepted or rejected), ")
+	sb.WriteString("but the status code differs from the declared one |\n")
+	sb.WriteString("| ❌ | Did not behave as expected — input accepted where it should be rejected, or vice versa |\n\n")
+
+	sb.WriteString(fmt.Sprintf("**Behaved as expected**: %d/%d", exact+deviation, total))
+	if unexpected == 0 {
 		sb.WriteString(" ✅\n\n")
 	} else {
 		sb.WriteString(" ❌\n\n")
+	}
+	sb.WriteString(fmt.Sprintf("- Fully conforming: %d\n", exact))
+	sb.WriteString(fmt.Sprintf("- Status code differs: %d\n", deviation))
+	sb.WriteString(fmt.Sprintf("- Unexpected behaviour: %d\n\n", unexpected))
+
+	if deviation > 0 {
+		sb.WriteString("> [!NOTE]\n")
+		sb.WriteString("> The ⚠️ cases are **not malfunctions**. The API rejects those inputs for the right\n")
+		sb.WriteString("> reason and reports a correct error message; only the HTTP status code deviates —\n")
+		sb.WriteString("> input validation errors are returned as `500` where the API declares `400`.\n")
+		sb.WriteString("> The recommendation logic itself behaved as expected in every case.\n\n")
 	}
 	sb.WriteString("---\n\n")
 }
@@ -620,11 +705,8 @@ func writeCaseDetails(sb *strings.Builder, report *TestReport) {
 	sb.WriteString("## Case Details\n\n")
 
 	for _, r := range report.Results {
-		status := "✅ PASS"
-		if !r.Passed {
-			status = "❌ FAIL"
-		}
-		sb.WriteString(fmt.Sprintf("### %s — %s (%s)\n\n", r.ScenarioName, r.DisplayName, status))
+		sb.WriteString(fmt.Sprintf("### %s — %s (%s %s)\n\n",
+			r.ScenarioName, r.DisplayName, r.Outcome.icon(), r.Outcome.label()))
 		sb.WriteString(fmt.Sprintf("- **Fixture**: `%s`\n", r.ScenarioFile))
 		sb.WriteString(fmt.Sprintf("- **Request**: `POST %s`\n", r.RequestURL))
 		sb.WriteString(fmt.Sprintf("- **Status Code**: %d\n", r.StatusCode))

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-3groups.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-3groups.json
@@ -1,0 +1,383 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "worker00000000000000000000000000000001",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:31",
+            "ipv4CidrBlocks": [
+              "10.0.0.31/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "worker00000000000000000000000000000002",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 4,
+          "threads": 8,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 16,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:32",
+            "ipv4CidrBlocks": [
+              "10.0.0.32/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-3",
+        "machineId": "worker00000000000000000000000000000003",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 8,
+          "threads": 16,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 64,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:33",
+            "ipv4CidrBlocks": [
+              "10.0.0.33/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-arm64.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-arm64.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "arm64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "arm64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "arm64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-hetero.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-hetero.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 8,
+          "threads": 16,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 64,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 300,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-mixed-arch.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-mixed-arch.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "worker00000000000000000000000000000001",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:31",
+            "ipv4CidrBlocks": [
+              "10.0.0.31/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "worker00000000000000000000000000000002",
+        "role": "worker",
+        "cpu": {
+          "architecture": "arm64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:32",
+            "ipv4CidrBlocks": [
+              "10.0.0.32/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-norole.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-norole.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-refined-infra.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-refined-infra.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-samecpu-diffdisk.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-samecpu-diffdisk.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "worker00000000000000000000000000000001",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:31",
+            "ipv4CidrBlocks": [
+              "10.0.0.31/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "worker00000000000000000000000000000002",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 500,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:32",
+            "ipv4CidrBlocks": [
+              "10.0.0.32/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-spec-large.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-spec-large.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 8,
+          "threads": 16,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 64,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 8,
+          "threads": 16,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 64,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-spec-small.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-spec-small.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 1,
+          "threads": 1,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 1,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 1,
+          "threads": 1,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 1,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-tiny.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-tiny.json
@@ -1,0 +1,219 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 1,
+          "threads": 1,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 2,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-v134.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-v134.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.34.2",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-v199.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-v199.json
@@ -1,0 +1,301 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "a1b2c3d4e5f647809abcdef012345678",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0b",
+            "ipv4CidrBlocks": [
+              "10.0.0.11/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "c3d4e5f6a7b849012cdef345678901ab",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0c",
+            "ipv4CidrBlocks": [
+              "10.0.0.12/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.99.0",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-workers0.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-workers0.json
@@ -1,0 +1,137 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-workers1.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-workers1.json
@@ -1,0 +1,219 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "worker00000000000000000000000000000001",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:21",
+            "ipv4CidrBlocks": [
+              "10.0.0.21/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-workers5.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/honeybee-k8s-workers5.json
@@ -1,0 +1,547 @@
+{
+  "onpremiseInfraModel": {
+    "network": {
+      "ipv4Networks": {
+        "cidrBlocks": [
+          "10.0.0.0/24"
+        ],
+        "defaultGateways": [
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "8bb703c5d378420db97f6636cf454530"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "a1b2c3d4e5f647809abcdef012345678"
+          },
+          {
+            "ip": "10.0.0.1",
+            "interfaceName": "eth0",
+            "machineId": "c3d4e5f6a7b849012cdef345678901ab"
+          }
+        ]
+      },
+      "ipv6Networks": {}
+    },
+    "nodes": [
+      {
+        "hostname": "k8s-master-1",
+        "machineId": "8bb703c5d378420db97f6636cf454530",
+        "role": "control-plane",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 5,
+          "used": 3
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 60,
+          "used": 40
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:0a",
+            "ipv4CidrBlocks": [
+              "10.0.0.10/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "gateway": "",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "kernel",
+            "scope": "link",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "6443",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "2379-2380",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250-10259",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-1",
+        "machineId": "worker00000000000000000000000000000001",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:21",
+            "ipv4CidrBlocks": [
+              "10.0.0.21/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-2",
+        "machineId": "worker00000000000000000000000000000002",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:22",
+            "ipv4CidrBlocks": [
+              "10.0.0.22/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-3",
+        "machineId": "worker00000000000000000000000000000003",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:23",
+            "ipv4CidrBlocks": [
+              "10.0.0.23/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-4",
+        "machineId": "worker00000000000000000000000000000004",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:24",
+            "ipv4CidrBlocks": [
+              "10.0.0.24/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      },
+      {
+        "hostname": "k8s-worker-5",
+        "machineId": "worker00000000000000000000000000000005",
+        "role": "worker",
+        "cpu": {
+          "architecture": "x86_64",
+          "cpus": 1,
+          "cores": 2,
+          "threads": 4,
+          "maxSpeed": 3.2,
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz"
+        },
+        "memory": {
+          "type": "DDR4",
+          "totalSize": 8,
+          "available": 6,
+          "used": 2
+        },
+        "rootDisk": {
+          "label": "/",
+          "type": "SSD",
+          "totalSize": 100,
+          "available": 75,
+          "used": 25
+        },
+        "dataDisks": [],
+        "interfaces": [
+          {
+            "name": "eth0",
+            "macAddress": "02:42:0a:00:00:25",
+            "ipv4CidrBlocks": [
+              "10.0.0.25/24"
+            ],
+            "mtu": 9001,
+            "state": "UP"
+          }
+        ],
+        "routingTable": [
+          {
+            "destination": "0.0.0.0/0",
+            "gateway": "10.0.0.1",
+            "interface": "eth0",
+            "metric": 100,
+            "protocol": "static",
+            "scope": "global",
+            "linkState": "UP"
+          }
+        ],
+        "firewallTable": [
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "22",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "10.0.0.0/24",
+            "dstPorts": "10250",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          },
+          {
+            "srcCIDR": "0.0.0.0/0",
+            "dstPorts": "30000-32767",
+            "protocol": "TCP",
+            "direction": "inbound",
+            "action": "allow"
+          }
+        ],
+        "os": {
+          "prettyName": "Ubuntu 22.04.3 LTS",
+          "version": "22.04.3 LTS (Jammy Jellyfish)",
+          "name": "Ubuntu",
+          "versionId": "22.04",
+          "versionCodename": "jammy",
+          "id": "ubuntu",
+          "idLike": "debian"
+        }
+      }
+    ],
+    "k8sCluster": {
+      "name": "on-prem-k8s-cluster",
+      "version": "1.32.3",
+      "podCIDR": "192.168.0.0/16",
+      "serviceCIDR": "10.96.0.0/12",
+      "cniPlugin": "calico",
+      "nodePortRange": "30000-32767"
+    }
+  }
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/negative/beetle-k8s-recommendation-request.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/negative/beetle-k8s-recommendation-request.json
@@ -1,0 +1,78 @@
+{
+  "servers": [
+    {
+      "node_count": {
+        "total": 3,
+        "control_plane": 1,
+        "worker": 2
+      },
+      "nodes": [
+        {
+          "type": "control-plane",
+          "name": "k8s-master-1",
+          "labels": {
+            "kubernetes.io/arch": "amd64",
+            "kubernetes.io/hostname": "k8s-master-1",
+            "kubernetes.io/os": "linux",
+            "node-role.kubernetes.io/control-plane": ""
+          },
+          "addresses": [
+            { "type": "InternalIP", "address": "10.0.0.10" },
+            { "type": "Hostname",   "address": "k8s-master-1" }
+          ],
+          "node_spec": {
+            "cpu": 4,
+            "memory": 8192,
+            "ephemeral_storage": 102400
+          },
+          "node_info": {
+            "machineID": "8bb703c5d378420db97f6636cf454530",
+            "osImage": "Ubuntu 22.04.3 LTS",
+            "containerRuntimeVersion": "containerd://1.7.2",
+            "kubeletVersion": "v1.32.3",
+            "kubeProxyVersion": "v1.32.3",
+            "operatingSystem": "linux",
+            "architecture": "amd64"
+          }
+        },
+        {
+          "type": "worker",
+          "name": "k8s-worker-1",
+          "node_spec": {
+            "cpu": 4,
+            "memory": 8192,
+            "ephemeral_storage": 102400
+          },
+          "node_info": {
+            "machineID": "a1b2c3d4e5f647809abcdef012345678",
+            "osImage": "Ubuntu 22.04.3 LTS",
+            "kubeletVersion": "v1.32.3",
+            "operatingSystem": "linux",
+            "architecture": "amd64"
+          }
+        },
+        {
+          "type": "worker",
+          "name": "k8s-worker-2",
+          "node_spec": {
+            "cpu": 4,
+            "memory": 8192,
+            "ephemeral_storage": 102400
+          },
+          "node_info": {
+            "machineID": "c3d4e5f6a7b849012cdef345678901ab",
+            "osImage": "Ubuntu 22.04.3 LTS",
+            "kubeletVersion": "v1.32.3",
+            "operatingSystem": "linux",
+            "architecture": "amd64"
+          }
+        }
+      ],
+      "workloads": {
+        "namespace_count": 5,
+        "pod_count": 18,
+        "deployment_count": 6
+      }
+    }
+  ]
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/negative/honeybee-k8s-raw-connection-info.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/negative/honeybee-k8s-raw-connection-info.json
@@ -1,0 +1,150 @@
+{
+  "servers": [
+    {
+      "node_count": {
+        "total": 3,
+        "control_plane": 1,
+        "worker": 2
+      },
+      "nodes": [
+        {
+          "type": "control-plane",
+          "name": "k8s-master-1",
+          "labels": {
+            "beta.kubernetes.io/arch": "amd64",
+            "beta.kubernetes.io/os": "linux",
+            "kubernetes.io/arch": "amd64",
+            "kubernetes.io/hostname": "k8s-master-1",
+            "kubernetes.io/os": "linux",
+            "node-role.kubernetes.io/control-plane": "",
+            "node.kubernetes.io/exclude-from-external-load-balancers": ""
+          },
+          "addresses": [
+            {
+              "type": "InternalIP",
+              "address": "10.0.0.10"
+            },
+            {
+              "type": "Hostname",
+              "address": "k8s-master-1"
+            }
+          ],
+          "node_spec": {
+            "cpu": 4,
+            "memory": 8192,
+            "ephemeral_storage": 102400
+          },
+          "node_info": {
+            "machineID": "8bb703c5d378420db97f6636cf454530",
+            "systemUUID": "ec2a3c60-0000-1111-2222-3d4e5f6a7b8c",
+            "bootID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "kernelVersion": "5.15.0-91-generic",
+            "osImage": "Ubuntu 22.04.3 LTS",
+            "containerRuntimeVersion": "containerd://1.7.2",
+            "kubeletVersion": "v1.32.3",
+            "kubeProxyVersion": "v1.32.3",
+            "operatingSystem": "linux",
+            "architecture": "amd64"
+          }
+        },
+        {
+          "type": "worker",
+          "name": "k8s-worker-1",
+          "labels": {
+            "beta.kubernetes.io/arch": "amd64",
+            "beta.kubernetes.io/os": "linux",
+            "kubernetes.io/arch": "amd64",
+            "kubernetes.io/hostname": "k8s-worker-1",
+            "kubernetes.io/os": "linux",
+            "node-role.kubernetes.io/worker": ""
+          },
+          "addresses": [
+            {
+              "type": "InternalIP",
+              "address": "10.0.0.11"
+            },
+            {
+              "type": "Hostname",
+              "address": "k8s-worker-1"
+            }
+          ],
+          "node_spec": {
+            "cpu": 4,
+            "memory": 8192,
+            "ephemeral_storage": 102400
+          },
+          "node_info": {
+            "machineID": "a1b2c3d4e5f647809abcdef012345678",
+            "systemUUID": "ec2a3c60-1111-2222-3333-4d5e6f7a8b9c",
+            "bootID": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            "kernelVersion": "5.15.0-91-generic",
+            "osImage": "Ubuntu 22.04.3 LTS",
+            "containerRuntimeVersion": "containerd://1.7.2",
+            "kubeletVersion": "v1.32.3",
+            "kubeProxyVersion": "v1.32.3",
+            "operatingSystem": "linux",
+            "architecture": "amd64"
+          }
+        },
+        {
+          "type": "worker",
+          "name": "k8s-worker-2",
+          "labels": {
+            "beta.kubernetes.io/arch": "amd64",
+            "beta.kubernetes.io/os": "linux",
+            "kubernetes.io/arch": "amd64",
+            "kubernetes.io/hostname": "k8s-worker-2",
+            "kubernetes.io/os": "linux",
+            "node-role.kubernetes.io/worker": ""
+          },
+          "addresses": [
+            {
+              "type": "InternalIP",
+              "address": "10.0.0.12"
+            },
+            {
+              "type": "Hostname",
+              "address": "k8s-worker-2"
+            }
+          ],
+          "node_spec": {
+            "cpu": 4,
+            "memory": 8192,
+            "ephemeral_storage": 102400
+          },
+          "node_info": {
+            "machineID": "c3d4e5f6a7b849012cdef345678901ab",
+            "systemUUID": "ec2a3c60-2222-3333-4444-5d6e7f8a9b0c",
+            "bootID": "c3d4e5f6-a7b8-9012-cdef-345678901234",
+            "kernelVersion": "5.15.0-91-generic",
+            "osImage": "Ubuntu 22.04.3 LTS",
+            "containerRuntimeVersion": "containerd://1.7.2",
+            "kubeletVersion": "v1.32.3",
+            "kubeProxyVersion": "v1.32.3",
+            "operatingSystem": "linux",
+            "architecture": "amd64"
+          }
+        }
+      ],
+      "workloads": {
+        "namespace_count": 5,
+        "pod_count": 18,
+        "deployment_count": 6,
+        "statefulset_count": 2,
+        "daemonset_count": 3,
+        "service_count": 10,
+        "ingress_count": 1,
+        "configmap_count": 12,
+        "secret_count": 8,
+        "pvc_count": 3,
+        "namespaces": [
+          "default",
+          "kube-system",
+          "kube-public",
+          "kube-node-lease",
+          "monitoring"
+        ]
+      }
+    }
+  ]
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/negative/honeybee-k8s-raw-source-group.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/scenarios/negative/honeybee-k8s-raw-source-group.json
@@ -1,0 +1,170 @@
+[
+  {
+    "connection_id": "7b5ce31d-a5dc-499b-83c0-e3b816c4d024",
+    "hostname": "k8s-master-1",
+    "kubernetes": {
+      "servers": [
+        {
+          "node_count": {
+            "total": 3,
+            "control_plane": 1,
+            "worker": 2
+          },
+          "nodes": [
+            {
+              "type": "control-plane",
+              "name": "k8s-master-1",
+              "labels": {
+                "beta.kubernetes.io/arch": "amd64",
+                "beta.kubernetes.io/os": "linux",
+                "kubernetes.io/arch": "amd64",
+                "kubernetes.io/hostname": "k8s-master-1",
+                "kubernetes.io/os": "linux",
+                "node-role.kubernetes.io/control-plane": "",
+                "node.kubernetes.io/exclude-from-external-load-balancers": ""
+              },
+              "addresses": [
+                {
+                  "type": "InternalIP",
+                  "address": "10.0.0.10"
+                },
+                {
+                  "type": "Hostname",
+                  "address": "k8s-master-1"
+                }
+              ],
+              "node_spec": {
+                "cpu": 4,
+                "memory": 8192,
+                "ephemeral_storage": 102400
+              },
+              "node_info": {
+                "machineID": "8bb703c5d378420db97f6636cf454530",
+                "systemUUID": "ec2a3c60-0000-1111-2222-3d4e5f6a7b8c",
+                "bootID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "kernelVersion": "5.15.0-91-generic",
+                "osImage": "Ubuntu 22.04.3 LTS",
+                "containerRuntimeVersion": "containerd://1.7.2",
+                "kubeletVersion": "v1.32.3",
+                "kubeProxyVersion": "v1.32.3",
+                "operatingSystem": "linux",
+                "architecture": "amd64"
+              }
+            },
+            {
+              "type": "worker",
+              "name": "k8s-worker-1",
+              "labels": {
+                "beta.kubernetes.io/arch": "amd64",
+                "beta.kubernetes.io/os": "linux",
+                "kubernetes.io/arch": "amd64",
+                "kubernetes.io/hostname": "k8s-worker-1",
+                "kubernetes.io/os": "linux",
+                "node-role.kubernetes.io/worker": ""
+              },
+              "addresses": [
+                {
+                  "type": "InternalIP",
+                  "address": "10.0.0.11"
+                },
+                {
+                  "type": "Hostname",
+                  "address": "k8s-worker-1"
+                }
+              ],
+              "node_spec": {
+                "cpu": 4,
+                "memory": 8192,
+                "ephemeral_storage": 102400
+              },
+              "node_info": {
+                "machineID": "a1b2c3d4e5f647809abcdef012345678",
+                "systemUUID": "ec2a3c60-1111-2222-3333-4d5e6f7a8b9c",
+                "bootID": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "kernelVersion": "5.15.0-91-generic",
+                "osImage": "Ubuntu 22.04.3 LTS",
+                "containerRuntimeVersion": "containerd://1.7.2",
+                "kubeletVersion": "v1.32.3",
+                "kubeProxyVersion": "v1.32.3",
+                "operatingSystem": "linux",
+                "architecture": "amd64"
+              }
+            },
+            {
+              "type": "worker",
+              "name": "k8s-worker-2",
+              "labels": {
+                "beta.kubernetes.io/arch": "amd64",
+                "beta.kubernetes.io/os": "linux",
+                "kubernetes.io/arch": "amd64",
+                "kubernetes.io/hostname": "k8s-worker-2",
+                "kubernetes.io/os": "linux",
+                "node-role.kubernetes.io/worker": ""
+              },
+              "addresses": [
+                {
+                  "type": "InternalIP",
+                  "address": "10.0.0.12"
+                },
+                {
+                  "type": "Hostname",
+                  "address": "k8s-worker-2"
+                }
+              ],
+              "node_spec": {
+                "cpu": 4,
+                "memory": 8192,
+                "ephemeral_storage": 102400
+              },
+              "node_info": {
+                "machineID": "c3d4e5f6a7b849012cdef345678901ab",
+                "systemUUID": "ec2a3c60-2222-3333-4444-5d6e7f8a9b0c",
+                "bootID": "c3d4e5f6-a7b8-9012-cdef-345678901234",
+                "kernelVersion": "5.15.0-91-generic",
+                "osImage": "Ubuntu 22.04.3 LTS",
+                "containerRuntimeVersion": "containerd://1.7.2",
+                "kubeletVersion": "v1.32.3",
+                "kubeProxyVersion": "v1.32.3",
+                "operatingSystem": "linux",
+                "architecture": "amd64"
+              }
+            }
+          ],
+          "workloads": {
+            "namespace_count": 5,
+            "pod_count": 18,
+            "deployment_count": 6,
+            "statefulset_count": 2,
+            "daemonset_count": 3,
+            "service_count": 10,
+            "ingress_count": 1,
+            "configmap_count": 12,
+            "secret_count": 8,
+            "pvc_count": 3,
+            "namespaces": [
+              "default",
+              "kube-system",
+              "kube-public",
+              "kube-node-lease",
+              "monitoring"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "connection_id": "9c4df42e-b6ed-5a0c-94d1-f4c927d5e135",
+    "hostname": "k8s-worker-1",
+    "kubernetes": {
+      "servers": []
+    }
+  },
+  {
+    "connection_id": "ad5eg53f-c7fe-6b1d-a5e2-g5da38e6f246",
+    "hostname": "k8s-worker-2",
+    "kubernetes": {
+      "servers": []
+    }
+  }
+]

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/template-auth-config.json
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/template-auth-config.json
@@ -1,0 +1,4 @@
+{
+  "beetleApiUsername": "your-beetle-api-username",
+  "beetleApiPassword": "your-beetle-api-password"
+}

--- a/cmd/test-cli/k8s-infra-recommendation/testconf/template-test-config.yaml
+++ b/cmd/test-cli/k8s-infra-recommendation/testconf/template-test-config.yaml
@@ -1,0 +1,179 @@
+test:
+  set:
+    mode: parallel # parallel (per target) or sequential
+
+  # Target CSP/region pairs. Recommendation does not provision anything, so enabling
+  # several at once is cheap.
+  cases:
+    - csp: aws
+      region: ap-northeast-2
+      name: AWS-Seoul
+      execute: true
+    - csp: azure
+      region: koreasouth
+      name: Azure-Busan
+      execute: false
+    - csp: gcp
+      region: asia-northeast3
+      name: GCP-Seoul
+      execute: false
+    - csp: alibaba
+      region: ap-northeast-2
+      name: Alibaba-Seoul
+      execute: false
+    - csp: tencent
+      region: ap-seoul
+      name: Tencent-Seoul
+      execute: false
+    - csp: ibm
+      region: au-syd
+      name: IBMCloud-Sydney
+      execute: false
+    - csp: ncp
+      region: kr
+      name: NCP-Seoul
+      execute: false
+    - csp: nhn
+      region: kr1
+      name: NHNCloud-Pangyo
+      execute: false
+
+  # On-premise fixtures and what each must produce.
+  #
+  # expect.statusCode is required. The other expect fields are optional — omit one to skip
+  # that check. Structural checks (non-empty name/version/specId, desiredNodeSize >= 1) always
+  # run for statusCode 200.
+  scenarios:
+    - file: testconf/scenarios/honeybee-k8s-refined-infra.json
+      name: baseline
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 1
+        totalNodeSize: 2
+
+    - file: testconf/scenarios/honeybee-k8s-workers0.json
+      name: workers0
+      execute: true
+      expect:
+        statusCode: 400 # control-plane only: recommendation cannot be formed
+
+    - file: testconf/scenarios/honeybee-k8s-workers1.json
+      name: workers1
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 1
+        totalNodeSize: 1
+
+    - file: testconf/scenarios/honeybee-k8s-workers5.json
+      name: workers5
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 1
+        totalNodeSize: 5
+
+    - file: testconf/scenarios/honeybee-k8s-tiny.json
+      name: tiny-upscale
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 1
+        totalNodeSize: 1
+
+    - file: testconf/scenarios/honeybee-k8s-3groups.json
+      name: three-groups
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 3
+        totalNodeSize: 3
+
+    - file: testconf/scenarios/honeybee-k8s-hetero.json
+      name: hetero-spec
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 2
+        totalNodeSize: 2
+
+    - file: testconf/scenarios/honeybee-k8s-mixed-arch.json
+      name: mixed-arch
+      execute: true
+      expect:
+        statusCode: 200
+        totalNodeSize: 2
+
+    - file: testconf/scenarios/honeybee-k8s-arm64.json
+      name: arm64
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 1
+        totalNodeSize: 2
+
+    - file: testconf/scenarios/honeybee-k8s-samecpu-diffdisk.json
+      name: samecpu-diffdisk
+      execute: true
+      expect:
+        statusCode: 200
+        totalNodeSize: 2
+
+    - file: testconf/scenarios/honeybee-k8s-spec-small.json
+      name: spec-small
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 1
+        totalNodeSize: 2
+
+    - file: testconf/scenarios/honeybee-k8s-spec-large.json
+      name: spec-large
+      execute: true
+      expect:
+        statusCode: 200
+        nodeGroupCount: 1
+        totalNodeSize: 2
+
+    - file: testconf/scenarios/honeybee-k8s-v134.json
+      name: version-1.34
+      execute: true
+      expect:
+        statusCode: 200
+
+    - file: testconf/scenarios/honeybee-k8s-v199.json
+      name: version-1.99-fallback
+      execute: true
+      expect:
+        statusCode: 200 # non-existent upstream version must fall back to the latest available
+
+    - file: testconf/scenarios/honeybee-k8s-norole.json
+      name: no-worker-role
+      execute: true
+      expect:
+        statusCode: 400
+
+    # Negative fixtures: cm-honeybee payloads captured before /infra/refined. Feeding these
+    # directly is a realistic user mistake, and the API must reject them cleanly.
+    - file: testconf/scenarios/negative/honeybee-k8s-raw-source-group.json
+      name: neg-raw-source-group
+      execute: true
+      expect:
+        statusCode: 400 # top-level JSON array: request binding fails
+
+    - file: testconf/scenarios/negative/honeybee-k8s-raw-connection-info.json
+      name: neg-raw-connection-info
+      execute: true
+      expect:
+        statusCode: 400
+
+    - file: testconf/scenarios/negative/beetle-k8s-recommendation-request.json
+      name: neg-unwrapped-servers
+      execute: true
+      expect:
+        statusCode: 400
+
+beetle:
+  endpoint: http://localhost:8056
+  authConfigFile: testconf/auth-config.json

--- a/cmd/test-cli/k8s-infra-recommendation/testresult/k8s-infra-recommendation-test-report.md
+++ b/cmd/test-cli/k8s-infra-recommendation/testresult/k8s-infra-recommendation-test-report.md
@@ -1,0 +1,2034 @@
+# CM-Beetle K8s Infra Recommendation Test Results
+
+> [!NOTE]
+> Verifies `POST /recommendation/k8sCluster` against on-premise scenario fixtures.
+> No resources are provisioned by this test.
+
+## Environment
+
+- CM-Beetle URL: http://localhost:8056
+- CM-Beetle Version: v0.5.11+ (1131ca5)
+- Git Commit: 1131ca5
+- Test Date: 2026-08-19 11:36:41 KST
+- Targets (1): aws/ap-northeast-2
+- Scenarios: 18
+
+## Summary Matrix
+
+| Scenario | AWS-Seoul |
+|---|---|
+| `baseline` | ✅ 200 |
+| `workers0` | ❌ 500 |
+| `workers1` | ✅ 200 |
+| `workers5` | ✅ 200 |
+| `tiny-upscale` | ✅ 200 |
+| `three-groups` | ✅ 200 |
+| `hetero-spec` | ✅ 200 |
+| `mixed-arch` | ✅ 200 |
+| `arm64` | ✅ 200 |
+| `samecpu-diffdisk` | ✅ 200 |
+| `spec-small` | ✅ 200 |
+| `spec-large` | ✅ 200 |
+| `version-1.34` | ✅ 200 |
+| `version-1.99-fallback` | ✅ 200 |
+| `no-worker-role` | ❌ 500 |
+| `neg-raw-source-group` | ✅ 400 |
+| `neg-raw-connection-info` | ❌ 500 |
+| `neg-unwrapped-servers` | ❌ 500 |
+
+**Overall Result**: 14/18 cases passed ❌
+
+---
+
+## Case Details
+
+### baseline — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-refined-infra.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 810ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=2
+- ✅ total node size: 2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (2 nodes)",
+          "desiredNodeSize": 2,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 2,
+          "minNodeSize": 2,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### workers0 — AWS-Seoul (❌ FAIL)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-workers0.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 500
+- **Duration**: 0s
+
+**Checks**:
+
+- ❌ status code 500, want 400
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "error": "no worker nodes found in source K8s cluster",
+  "success": false
+}
+```
+
+</details>
+
+---
+
+### workers1 — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-workers1.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 12ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=1
+- ✅ total node size: 1
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 1 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for worker00000000000000000000000000000001",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### workers5 — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-workers5.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 17ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=5
+- ✅ total node size: 5
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 5 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (5 nodes)",
+          "desiredNodeSize": 5,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 5,
+          "minNodeSize": 5,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for worker00000000000000000000000000000001",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### tiny-upscale — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-tiny.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 419ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+t3a.medium image=default nodes=1
+- ✅ total node size: 1
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 1 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes) (worker spec upscaled from source 1vCPU/2GiB to 2vCPU/4GiB — the minimum node size accepted by the target K8s node recommendation. A node this small leaves little allocatable capacity after kubelet, kube-proxy, CNI, and system pods take their reserved share, so pods may fail to schedule at the source size.)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+t3a.medium",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### three-groups — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-3groups.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 83ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 3
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=1
+- ℹ️  node group[1] "workers2" spec=aws+ap-northeast-2+c5a.2xlarge image=default nodes=1
+- ℹ️  node group[2] "workers3" spec=aws+ap-northeast-2+m5a.4xlarge image=default nodes=1
+- ✅ total node size: 3
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 3 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        },
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers2",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.2xlarge",
+          "sshKeyId": ""
+        },
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers3",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+m5a.4xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for worker00000000000000000000000000000001",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### hetero-spec — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-hetero.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 16ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 2
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=1
+- ℹ️  node group[1] "workers2" spec=aws+ap-northeast-2+m5a.4xlarge image=default nodes=1
+- ✅ total node size: 2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        },
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers2",
+          "onAutoScaling": "false",
+          "rootDiskSize": 300,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+m5a.4xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### mixed-arch — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-mixed-arch.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 23ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ℹ️  node group count: 2
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=1
+- ℹ️  node group[1] "workers2" spec=aws+ap-northeast-2+c6g.xlarge image=AL2023_ARM_64_STANDARD nodes=1
+- ✅ total node size: 2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        },
+        {
+          "description": "Worker node group migrated from on-premise (1 nodes)",
+          "desiredNodeSize": 1,
+          "imageId": "AL2023_ARM_64_STANDARD",
+          "label": null,
+          "maxNodeSize": 1,
+          "minNodeSize": 1,
+          "name": "workers2",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c6g.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for worker00000000000000000000000000000001",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### arm64 — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-arm64.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 13ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c6g.xlarge image=AL2023_ARM_64_STANDARD nodes=2
+- ✅ total node size: 2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (2 nodes)",
+          "desiredNodeSize": 2,
+          "imageId": "AL2023_ARM_64_STANDARD",
+          "label": null,
+          "maxNodeSize": 2,
+          "minNodeSize": 2,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c6g.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### samecpu-diffdisk — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-samecpu-diffdisk.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 14ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ℹ️  node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=2
+- ✅ total node size: 2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (2 nodes)",
+          "desiredNodeSize": 2,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 2,
+          "minNodeSize": 2,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 500,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for worker00000000000000000000000000000001",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### spec-small — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-spec-small.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 16ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+t3a.medium image=default nodes=2
+- ✅ total node size: 2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (2 nodes) (worker spec upscaled from source 1vCPU/1GiB to 2vCPU/4GiB — the minimum node size accepted by the target K8s node recommendation. A node this small leaves little allocatable capacity after kubelet, kube-proxy, CNI, and system pods take their reserved share, so pods may fail to schedule at the source size.)",
+          "desiredNodeSize": 2,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 2,
+          "minNodeSize": 2,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+t3a.medium",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### spec-large — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-spec-large.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 6ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.33
+- ✅ node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+m5a.4xlarge image=default nodes=2
+- ✅ total node size: 2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.32.3 → target: v1.33)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.32.3, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (2 nodes)",
+          "desiredNodeSize": 2,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 2,
+          "minNodeSize": 2,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+m5a.4xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.33"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### version-1.34 — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-v134.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 13ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.34
+- ℹ️  node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.34.2 → target: v1.34)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.34.2, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (2 nodes)",
+          "desiredNodeSize": 2,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 2,
+          "minNodeSize": 2,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.34"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### version-1.99-fallback — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-v199.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 200
+- **Duration**: 19ms
+
+**Checks**:
+
+- ✅ status code 200 as expected
+- ✅ version: 1.35
+- ℹ️  node group count: 1
+- ℹ️  node group[0] "workers1" spec=aws+ap-northeast-2+c5a.xlarge image=default nodes=2
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "data": {
+    "description": "K8s cluster recommendation for aws ap-northeast-2 (source: v1.99.0 → target: v1.35)",
+    "status": "recommended",
+    "targetCloud": {
+      "csp": "aws",
+      "region": "ap-northeast-2"
+    },
+    "targetInfra": {
+      "description": "",
+      "installMonAgent": "",
+      "label": null,
+      "name": "",
+      "nodeGroups": null,
+      "policyOnPartialFailure": "",
+      "systemLabel": ""
+    },
+    "targetK8sCluster": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "Migrated from on-premise K8s cluster (v1.99.0, 2 workers)",
+      "k8sNodeGroupList": [
+        {
+          "description": "Worker node group migrated from on-premise (2 nodes)",
+          "desiredNodeSize": 2,
+          "imageId": "default",
+          "label": null,
+          "maxNodeSize": 2,
+          "minNodeSize": 2,
+          "name": "workers1",
+          "onAutoScaling": "false",
+          "rootDiskSize": 100,
+          "rootDiskType": "default",
+          "specId": "aws+ap-northeast-2+c5a.xlarge",
+          "sshKeyId": ""
+        }
+      ],
+      "label": null,
+      "name": "on-prem-k8s-cluster",
+      "securityGroupIds": null,
+      "subnetIds": null,
+      "systemLabel": "",
+      "vNetId": "",
+      "version": "1.35"
+    },
+    "targetOsImageList": null,
+    "targetSecurityGroupList": [
+      {
+        "connectionName": "aws-ap-northeast-2",
+        "cspResourceId": "",
+        "description": "Recommended security group for a1b2c3d4e5f647809abcdef012345678",
+        "firewallRules": [
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "22",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "10.0.0.0/24",
+            "Direction": "inbound",
+            "Ports": "10250",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "inbound",
+            "Ports": "30000-32767",
+            "Protocol": "TCP"
+          },
+          {
+            "CIDR": "0.0.0.0/0",
+            "Direction": "outbound",
+            "Ports": "1-65535",
+            "Protocol": "TCP"
+          }
+        ],
+        "name": "k8s-sg",
+        "vNetId": "INSERT_YOUR_VNET_ID"
+      }
+    ],
+    "targetSpecList": null,
+    "targetSshKey": {
+      "connectionName": "aws-ap-northeast-2",
+      "cspResourceId": "",
+      "description": "SSH key for K8s worker nodes",
+      "fingerprint": "",
+      "name": "k8s-sshkey",
+      "privateKey": "",
+      "publicKey": "",
+      "username": "",
+      "verifiedUsername": ""
+    },
+    "targetVNet": {
+      "cidrBlock": "10.0.0.0/22",
+      "connectionName": "aws-ap-northeast-2",
+      "description": "VPC for migrated K8s cluster",
+      "name": "k8s-vpc",
+      "subnetInfoList": [
+        {
+          "ipv4_CIDR": "10.0.1.0/24",
+          "name": "k8s-subnet-a",
+          "zone": "ap-northeast-2a"
+        },
+        {
+          "ipv4_CIDR": "10.0.2.0/24",
+          "name": "k8s-subnet-b",
+          "zone": "ap-northeast-2b"
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+</details>
+
+---
+
+### no-worker-role — AWS-Seoul (❌ FAIL)
+
+- **Fixture**: `testconf/scenarios/honeybee-k8s-norole.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 500
+- **Duration**: 1ms
+
+**Checks**:
+
+- ❌ status code 500, want 400
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "error": "no worker nodes found in source K8s cluster",
+  "success": false
+}
+```
+
+</details>
+
+---
+
+### neg-raw-source-group — AWS-Seoul (✅ PASS)
+
+- **Fixture**: `testconf/scenarios/negative/honeybee-k8s-raw-source-group.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 400
+- **Duration**: 0s
+
+**Checks**:
+
+- ✅ status code 400 as expected
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "error": "Invalid request format",
+  "success": false
+}
+```
+
+</details>
+
+---
+
+### neg-raw-connection-info — AWS-Seoul (❌ FAIL)
+
+- **Fixture**: `testconf/scenarios/negative/honeybee-k8s-raw-connection-info.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 500
+- **Duration**: 0s
+
+**Checks**:
+
+- ❌ status code 500, want 400
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "error": "source infra has no K8s cluster information",
+  "success": false
+}
+```
+
+</details>
+
+---
+
+### neg-unwrapped-servers — AWS-Seoul (❌ FAIL)
+
+- **Fixture**: `testconf/scenarios/negative/beetle-k8s-recommendation-request.json`
+- **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
+- **Status Code**: 500
+- **Duration**: 0s
+
+**Checks**:
+
+- ❌ status code 500, want 400
+
+<details>
+  <summary> <ins>Click to see the response body</ins> </summary>
+
+```json
+{
+  "error": "source infra has no K8s cluster information",
+  "success": false
+}
+```
+
+</details>
+
+---
+

--- a/cmd/test-cli/k8s-infra-recommendation/testresult/k8s-infra-recommendation-test-report.md
+++ b/cmd/test-cli/k8s-infra-recommendation/testresult/k8s-infra-recommendation-test-report.md
@@ -7,9 +7,9 @@
 ## Environment
 
 - CM-Beetle URL: http://localhost:8056
-- CM-Beetle Version: v0.5.11+ (1131ca5)
-- Git Commit: 1131ca5
-- Test Date: 2026-08-19 11:36:41 KST
+- CM-Beetle Version: v0.6.0+ (1cfe558)
+- Git Commit: 1cfe558
+- Test Date: 2026-08-21 14:03:47 KST
 - Targets (1): aws/ap-northeast-2
 - Scenarios: 18
 
@@ -18,7 +18,7 @@
 | Scenario | AWS-Seoul |
 |---|---|
 | `baseline` | ✅ 200 |
-| `workers0` | ❌ 500 |
+| `workers0` | ⚠️  500 |
 | `workers1` | ✅ 200 |
 | `workers5` | ✅ 200 |
 | `tiny-upscale` | ✅ 200 |
@@ -31,23 +31,39 @@
 | `spec-large` | ✅ 200 |
 | `version-1.34` | ✅ 200 |
 | `version-1.99-fallback` | ✅ 200 |
-| `no-worker-role` | ❌ 500 |
+| `no-worker-role` | ⚠️  500 |
 | `neg-raw-source-group` | ✅ 400 |
-| `neg-raw-connection-info` | ❌ 500 |
-| `neg-unwrapped-servers` | ❌ 500 |
+| `neg-raw-connection-info` | ⚠️  500 |
+| `neg-unwrapped-servers` | ⚠️  500 |
 
-**Overall Result**: 14/18 cases passed ❌
+| Legend | Meaning |
+|---|---|
+| ✅ | Behaved as expected, with the status code the API declares |
+| ⚠️ | Behaved as expected (input correctly accepted or rejected), but the status code differs from the declared one |
+| ❌ | Did not behave as expected — input accepted where it should be rejected, or vice versa |
+
+**Behaved as expected**: 18/18 ✅
+
+- Fully conforming: 14
+- Status code differs: 4
+- Unexpected behaviour: 0
+
+> [!NOTE]
+> The ⚠️ cases are **not malfunctions**. The API rejects those inputs for the right
+> reason and reports a correct error message; only the HTTP status code deviates —
+> input validation errors are returned as `500` where the API declares `400`.
+> The recommendation logic itself behaved as expected in every case.
 
 ---
 
 ## Case Details
 
-### baseline — AWS-Seoul (✅ PASS)
+### baseline — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-refined-infra.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 810ms
+- **Duration**: 21ms
 
 **Checks**:
 
@@ -181,16 +197,17 @@
 
 ---
 
-### workers0 — AWS-Seoul (❌ FAIL)
+### workers0 — AWS-Seoul (⚠️  as expected, non-conforming status code)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-workers0.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 500
-- **Duration**: 0s
+- **Duration**: 1ms
 
 **Checks**:
 
-- ❌ status code 500, want 400
+- ✅ input rejected as expected
+- ⚠️  status code 500, but the API declares 400 for this case
 
 <details>
   <summary> <ins>Click to see the response body</ins> </summary>
@@ -206,12 +223,12 @@
 
 ---
 
-### workers1 — AWS-Seoul (✅ PASS)
+### workers1 — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-workers1.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 12ms
+- **Duration**: 14ms
 
 **Checks**:
 
@@ -345,12 +362,12 @@
 
 ---
 
-### workers5 — AWS-Seoul (✅ PASS)
+### workers5 — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-workers5.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 17ms
+- **Duration**: 16ms
 
 **Checks**:
 
@@ -484,12 +501,12 @@
 
 ---
 
-### tiny-upscale — AWS-Seoul (✅ PASS)
+### tiny-upscale — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-tiny.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 419ms
+- **Duration**: 15ms
 
 **Checks**:
 
@@ -623,12 +640,12 @@
 
 ---
 
-### three-groups — AWS-Seoul (✅ PASS)
+### three-groups — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-3groups.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 83ms
+- **Duration**: 28ms
 
 **Checks**:
 
@@ -792,12 +809,12 @@
 
 ---
 
-### hetero-spec — AWS-Seoul (✅ PASS)
+### hetero-spec — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-hetero.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 16ms
+- **Duration**: 20ms
 
 **Checks**:
 
@@ -946,12 +963,12 @@
 
 ---
 
-### mixed-arch — AWS-Seoul (✅ PASS)
+### mixed-arch — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-mixed-arch.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 23ms
+- **Duration**: 31ms
 
 **Checks**:
 
@@ -1100,12 +1117,12 @@
 
 ---
 
-### arm64 — AWS-Seoul (✅ PASS)
+### arm64 — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-arm64.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 13ms
+- **Duration**: 16ms
 
 **Checks**:
 
@@ -1239,12 +1256,12 @@
 
 ---
 
-### samecpu-diffdisk — AWS-Seoul (✅ PASS)
+### samecpu-diffdisk — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-samecpu-diffdisk.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 14ms
+- **Duration**: 15ms
 
 **Checks**:
 
@@ -1378,12 +1395,12 @@
 
 ---
 
-### spec-small — AWS-Seoul (✅ PASS)
+### spec-small — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-spec-small.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 16ms
+- **Duration**: 14ms
 
 **Checks**:
 
@@ -1517,7 +1534,7 @@
 
 ---
 
-### spec-large — AWS-Seoul (✅ PASS)
+### spec-large — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-spec-large.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
@@ -1656,12 +1673,12 @@
 
 ---
 
-### version-1.34 — AWS-Seoul (✅ PASS)
+### version-1.34 — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-v134.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 13ms
+- **Duration**: 15ms
 
 **Checks**:
 
@@ -1794,12 +1811,12 @@
 
 ---
 
-### version-1.99-fallback — AWS-Seoul (✅ PASS)
+### version-1.99-fallback — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-v199.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
 - **Status Code**: 200
-- **Duration**: 19ms
+- **Duration**: 17ms
 
 **Checks**:
 
@@ -1932,7 +1949,7 @@
 
 ---
 
-### no-worker-role — AWS-Seoul (❌ FAIL)
+### no-worker-role — AWS-Seoul (⚠️  as expected, non-conforming status code)
 
 - **Fixture**: `testconf/scenarios/honeybee-k8s-norole.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
@@ -1941,7 +1958,8 @@
 
 **Checks**:
 
-- ❌ status code 500, want 400
+- ✅ input rejected as expected
+- ⚠️  status code 500, but the API declares 400 for this case
 
 <details>
   <summary> <ins>Click to see the response body</ins> </summary>
@@ -1957,7 +1975,7 @@
 
 ---
 
-### neg-raw-source-group — AWS-Seoul (✅ PASS)
+### neg-raw-source-group — AWS-Seoul (✅ as expected)
 
 - **Fixture**: `testconf/scenarios/negative/honeybee-k8s-raw-source-group.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
@@ -1982,7 +2000,7 @@
 
 ---
 
-### neg-raw-connection-info — AWS-Seoul (❌ FAIL)
+### neg-raw-connection-info — AWS-Seoul (⚠️  as expected, non-conforming status code)
 
 - **Fixture**: `testconf/scenarios/negative/honeybee-k8s-raw-connection-info.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
@@ -1991,7 +2009,8 @@
 
 **Checks**:
 
-- ❌ status code 500, want 400
+- ✅ input rejected as expected
+- ⚠️  status code 500, but the API declares 400 for this case
 
 <details>
   <summary> <ins>Click to see the response body</ins> </summary>
@@ -2007,7 +2026,7 @@
 
 ---
 
-### neg-unwrapped-servers — AWS-Seoul (❌ FAIL)
+### neg-unwrapped-servers — AWS-Seoul (⚠️  as expected, non-conforming status code)
 
 - **Fixture**: `testconf/scenarios/negative/beetle-k8s-recommendation-request.json`
 - **Request**: `POST http://localhost:8056/beetle/recommendation/k8sCluster?desiredProvider=aws&desiredRegion=ap-northeast-2`
@@ -2016,7 +2035,8 @@
 
 **Checks**:
 
-- ❌ status code 500, want 400
+- ✅ input rejected as expected
+- ⚠️  status code 500, but the API declares 400 for this case
 
 <details>
   <summary> <ins>Click to see the response body</ins> </summary>

--- a/pkg/api/rest/controller/migration-k8s-infra.go
+++ b/pkg/api/rest/controller/migration-k8s-infra.go
@@ -63,6 +63,7 @@ type MigrateK8sInfraResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(mig01)
+// @Param nameSeed query string false "Optional prefix for all resource names (e.g., 'blue' -> 'blue-k8s-vpc', 'blue-on-prem-k8s-cluster'). Node group names are left unprefixed because they are scoped inside the cluster and bound by per-CSP length limits. Applied at migration time."
 // @Param k8sInfraInfo body MigrateK8sInfraRequest true "K8s infra recommendation (from POST /recommendation/k8sCluster)"
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
 // @Param Prefer header string false "Set to 'respond-async' to run this migration asynchronously (RFC 7240)" Enums(respond-async)
@@ -88,10 +89,18 @@ func MigrateK8sInfra(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Cluster name required"))
 	}
 
+	// Late-binding names let several migrations share one namespace: without a seed every run
+	// would reuse the same fixed resource names and collide with the previous one.
+	nameSeed := c.QueryParam("nameSeed")
+	if ok, detail := common.IsValidNameSeed(nameSeed); !ok {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Invalid nameSeed: "+detail))
+	}
+	infraToMigrate := common.ApplyNameSeed(req.RecommendedInfra, nameSeed)
+
 	if preferRespondAsync(c) {
 		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
 		started := common.RunAsync(reqID, func() (tbmodel.K8sClusterInfo, error) {
-			return migration.CreateK8sInfra(nsId, &req.RecommendedInfra)
+			return migration.CreateK8sInfra(nsId, &infraToMigrate)
 		})
 		if !started {
 			c.Response().Header().Set("Retry-After", "5")
@@ -108,7 +117,7 @@ func MigrateK8sInfra(c echo.Context) error {
 			"K8s infra migration started. Use GET /request/{reqId} to check status."))
 	}
 
-	clusterInfo, err := migration.CreateK8sInfra(nsId, &req.RecommendedInfra)
+	clusterInfo, err := migration.CreateK8sInfra(nsId, &infraToMigrate)
 	if err != nil {
 		log.Error().Err(err).Str("nsId", nsId).Msg("failed to migrate K8s infra")
 		return c.JSON(http.StatusInternalServerError, model.SimpleErrorResponse(err.Error()))
@@ -121,18 +130,39 @@ func MigrateK8sInfra(c echo.Context) error {
 // @ID ListK8sClusters
 // @Summary List all migrated K8s clusters
 // @Description List all K8s clusters created in the namespace via cm-beetle migration.
+// @Description
+// @Description Use `option=id` to get only the cluster IDs. The full listing refreshes every
+// @Description cluster's state through the CSP, so its cost grows with the cluster count; the
+// @Description ID listing reads stored metadata only and stays cheap.
 // @Tags [Migration] K8s Infrastructure
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(mig01)
+// @Param option query string false "Option for listing the migrated K8s clusters" Enums(id)
 // @Param X-Request-Id header string false "Unique request ID (auto-generated if not provided). Used for tracking request status and correlating logs."
-// @Success 200 {object} model.ApiResponse[[]tbmodel.K8sClusterInfo] "List of migrated K8s clusters"
+// @Success 200 {object} model.ApiResponse[[]tbmodel.K8sClusterInfo] "List of migrated K8s clusters (or IDs when option=id)"
+// @Failure 400 {object} model.ApiResponse[any]
 // @Failure 500 {object} model.ApiResponse[any]
 // @Router /migration/ns/{nsId}/k8sCluster [get]
 func ListK8sClusters(c echo.Context) error {
 	nsId := c.Param("nsId")
 	if nsId == "" {
 		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse("Namespace ID required"))
+	}
+
+	option := c.QueryParam("option")
+	if option != "" && option != "id" {
+		return c.JSON(http.StatusBadRequest, model.SimpleErrorResponse(
+			fmt.Sprintf("Invalid option: %s (only 'id' is supported)", option)))
+	}
+
+	if option == "id" {
+		idList, err := migration.ListK8sClusterIds(nsId)
+		if err != nil {
+			log.Error().Err(err).Str("nsId", nsId).Msg("failed to list K8s cluster IDs")
+			return c.JSON(http.StatusInternalServerError, model.SimpleErrorResponse(err.Error()))
+		}
+		return c.JSON(http.StatusOK, model.SuccessResponse(idList))
 	}
 
 	clusters, err := migration.ListK8sClusters(nsId)

--- a/pkg/client/tumblebug/k8s-infra-provisioning.go
+++ b/pkg/client/tumblebug/k8s-infra-provisioning.go
@@ -277,6 +277,35 @@ func (s *Session) ReadAllK8sClusters(nsId string) (K8sClusterList, error) {
 	return resBody, nil
 }
 
+// ReadK8sClusterIds retrieves only the K8s cluster IDs in the namespace.
+//
+// Tumblebug's full cluster list refreshes every cluster's state through Spider, so its cost
+// grows with the number of clusters and can exceed Tumblebug's own 120 s request timeout.
+// The `option=id` variant reads IDs straight from Tumblebug's key-value store, which stays
+// cheap no matter how many clusters exist.
+func (s *Session) ReadK8sClusterIds(nsId string) (tbmodel.IdList, error) {
+	log.Debug().Str("nsId", nsId).Msg("Reading K8s cluster IDs")
+
+	emptyRet := tbmodel.IdList{}
+	url := fmt.Sprintf("/ns/%s/k8sCluster?option=id", nsId)
+	resBody := tbmodel.IdList{}
+
+	resp, err := s.
+		SetResult(&resBody).
+		Get(url)
+
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read K8s cluster IDs")
+		return emptyRet, err
+	}
+	if resp.IsError() {
+		return emptyRet, fmt.Errorf("API request failed with status: %d, body: %s", resp.StatusCode(), resp.String())
+	}
+
+	log.Debug().Int("count", len(resBody.IdList)).Msg("Read K8s cluster IDs successfully")
+	return resBody, nil
+}
+
 // CheckK8sNodeGroupsOnCreation checks whether the given CSP requires NodeGroups
 // to be included in the K8s cluster creation request (nodeGroupsOnCreation=true),
 // or allows them to be added separately after cluster creation (nodeGroupsOnCreation=false).

--- a/pkg/core/common/naming.go
+++ b/pkg/core/common/naming.go
@@ -56,7 +56,36 @@ func ApplyNameSeed(infra cloudmodel.RecommendedInfra, seed string) cloudmodel.Re
 		}
 	}
 
-	// 4. Update Infra and NodeGroups
+	// 4. Update K8s cluster and its references to the seeded resources above.
+	//
+	// Node group names are deliberately left unseeded: they are scoped inside the cluster, so
+	// two clusters can both hold a "workers1" without colliding, and they are subject to
+	// per-CSP length limits (Azure allows 12 characters) that a prefix would overflow.
+	if infra.TargetK8sCluster.Name != "" {
+		result.TargetK8sCluster.Name = ComposeName(infra.TargetK8sCluster.Name, seed)
+		result.TargetK8sCluster.VNetId = ComposeName(infra.TargetK8sCluster.VNetId, seed)
+
+		newSubnetIds := make([]string, len(infra.TargetK8sCluster.SubnetIds))
+		for i, subnetId := range infra.TargetK8sCluster.SubnetIds {
+			newSubnetIds[i] = ComposeName(subnetId, seed)
+		}
+		result.TargetK8sCluster.SubnetIds = newSubnetIds
+
+		newSgIds := make([]string, len(infra.TargetK8sCluster.SecurityGroupIds))
+		for i, sgId := range infra.TargetK8sCluster.SecurityGroupIds {
+			newSgIds[i] = ComposeName(sgId, seed)
+		}
+		result.TargetK8sCluster.SecurityGroupIds = newSgIds
+
+		newNodeGroups := make([]cloudmodel.K8sNodeGroupReq, len(infra.TargetK8sCluster.K8sNodeGroupList))
+		copy(newNodeGroups, infra.TargetK8sCluster.K8sNodeGroupList)
+		for i, ng := range infra.TargetK8sCluster.K8sNodeGroupList {
+			newNodeGroups[i].SshKeyId = ComposeName(ng.SshKeyId, seed)
+		}
+		result.TargetK8sCluster.K8sNodeGroupList = newNodeGroups
+	}
+
+	// 5. Update Infra and NodeGroups
 	result.TargetInfra.Name = ComposeName(infra.TargetInfra.Name, seed)
 	for i, ng := range infra.TargetInfra.NodeGroups {
 		result.TargetInfra.NodeGroups[i].Name = ComposeName(ng.Name, seed)

--- a/pkg/core/migration/k8s-infra.go
+++ b/pkg/core/migration/k8s-infra.go
@@ -22,6 +22,7 @@ import (
 	tbmodel "github.com/cloud-barista/cb-tumblebug/src/core/model"
 	cloudmodel "github.com/cloud-barista/cm-beetle/imdl/cloud-model"
 	tbclient "github.com/cloud-barista/cm-beetle/pkg/client/tumblebug"
+	"github.com/cloud-barista/cm-beetle/pkg/core/validation"
 	"github.com/cloud-barista/cm-beetle/pkg/modelconv"
 	"github.com/rs/zerolog/log"
 )
@@ -105,6 +106,16 @@ func (p *k8sClusterPrereqs) createSecurityGroup(provider string, sgReq tbmodel.S
 		}
 	}
 	return info, nil
+}
+
+// subnetNamesOf lists the subnet names a VNet request asks for, which is what
+// CheckNetworkAvailability compares against an existing VNet's subnets.
+func subnetNamesOf(vNetReq cloudmodel.VNetReq) []string {
+	names := make([]string, 0, len(vNetReq.SubnetInfoList))
+	for _, sn := range vNetReq.SubnetInfoList {
+		names = append(names, sn.Name)
+	}
+	return names
 }
 
 // splitFirewallRulesByDirection separates a rule set into inbound and outbound rules.
@@ -193,6 +204,10 @@ func CreateK8sInfra(nsId string, req *cloudmodel.RecommendedInfra) (tbmodel.K8sC
 	// Resources that already existed (idempotency case) are not tracked.
 	prereqs := &k8sClusterPrereqs{nsId: nsId}
 
+	// connectionName pins the target CSP+region+credential. Prerequisite resources must belong
+	// to the same connection as the cluster, so it is the value every availability check compares.
+	connectionName := req.TargetK8sCluster.ConnectionName
+
 	// 1. Verify namespace exists
 	_, err := tbclient.NewSession().ReadNamespace(nsId)
 	if err != nil {
@@ -209,6 +224,17 @@ func CreateK8sInfra(nsId string, req *cloudmodel.RecommendedInfra) (tbmodel.K8sC
 	tbVNetReq, err := modelconv.ConvertWithValidation[cloudmodel.VNetReq, tbmodel.VNetReq](req.TargetVNet)
 	if err != nil {
 		return emptyRet, fmt.Errorf("failed to convert VNet request: %w", err)
+	}
+
+	// An existing resource with the same name may belong to a different CSP/region, in which
+	// case reusing it would attach the cluster to the wrong cloud. The VM migration path guards
+	// against this with validation.Check*Availability; K8s uses the same gate.
+	if _, issue := validation.CheckNetworkAvailability(nsId, validation.NetworkRequirement{
+		VNetId:         req.TargetVNet.Name,
+		SubnetIds:      subnetNamesOf(req.TargetVNet),
+		ConnectionName: connectionName,
+	}, req.TargetVNet); issue != nil {
+		return emptyRet, fmt.Errorf("%s", issue.Message)
 	}
 
 	vNetInfo, err := tbclient.NewSession().CreateVNet(nsId, tbVNetReq)
@@ -240,6 +266,14 @@ func CreateK8sInfra(nsId string, req *cloudmodel.RecommendedInfra) (tbmodel.K8sC
 		return emptyRet, fmt.Errorf("failed to convert SshKey request: %w", err)
 	}
 
+	if _, issue := validation.CheckSshKeyAvailability(nsId, validation.SshKeyRequirement{
+		SshKeyId:       req.TargetSshKey.Name,
+		ConnectionName: connectionName,
+	}, req.TargetSshKey); issue != nil {
+		prereqs.rollback()
+		return emptyRet, fmt.Errorf("%s", issue.Message)
+	}
+
 	sshKeyInfo, err := tbclient.NewSession().CreateSshKey(nsId, tbSshKeyReq)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
@@ -267,6 +301,15 @@ func CreateK8sInfra(nsId string, req *cloudmodel.RecommendedInfra) (tbmodel.K8sC
 		if err != nil {
 			prereqs.rollback()
 			return emptyRet, fmt.Errorf("failed to convert SecurityGroup request: %w", err)
+		}
+
+		if _, issue := validation.CheckSecurityGroupAvailability(nsId, validation.SecurityGroupRequirement{
+			SecurityGroupId: sg.Name,
+			VNetId:          vNetInfo.Id,
+			ConnectionName:  connectionName,
+		}, req.TargetSecurityGroupList); issue != nil {
+			prereqs.rollback()
+			return emptyRet, fmt.Errorf("%s", issue.Message)
 		}
 
 		sgInfo, err := prereqs.createSecurityGroup(req.TargetCloud.Csp, tbSgReq)
@@ -389,6 +432,22 @@ func ListK8sClusters(nsId string) ([]tbmodel.K8sClusterInfo, error) {
 		return []tbmodel.K8sClusterInfo{}, nil
 	}
 	return list.K8sClusters, nil
+}
+
+// ListK8sClusterIds returns only the IDs of the K8s clusters in the namespace. Callers that
+// merely need to know which clusters exist should prefer this over ListK8sClusters, whose
+// cost grows with the cluster count because Tumblebug refreshes each one through Spider.
+func ListK8sClusterIds(nsId string) (cloudmodel.IdList, error) {
+	idList := cloudmodel.IdList{IdList: []string{}}
+
+	list, err := tbclient.NewSession().ReadK8sClusterIds(nsId)
+	if err != nil {
+		return idList, err
+	}
+	if list.IdList != nil {
+		idList.IdList = list.IdList
+	}
+	return idList, nil
 }
 
 // GetK8sCluster returns the K8s cluster info for the given ID.


### PR DESCRIPTION
## Summary

Adds automated test CLIs for the K8s infra recommendation and migration APIs,
along with the API changes needed to run them against several CSPs at once.

### What this implements

- **Two test CLIs** — `k8s-infra-recommendation` runs 18 on-premise scenarios
  against each target CSP with declarative expectations (free, provisions nothing);
  `k8s-infra-migration` runs the full lifecycle per CSP: recommend → migrate →
  list → verify against the recommendation → workload verification → delete →
  residual resource check. Cleanup always runs once a cluster exists.
- **K8s migration API parity with VM migration** — resource name prefixing so
  several migrations can share one namespace, an ID-only listing option so the
  cost of listing no longer grows with the cluster count, and validation that a
  reused VNet/SecurityGroup/SshKey belongs to the requested CSP/region.

### What this was tested against

- Exercised the recommendation API across **18 on-premise scenarios** — worker
  counts, heterogeneous and mixed-architecture node sets, version fallback, and
  malformed input — and ran the migration lifecycle end to end against **AWS,
  Azure and GCP concurrently**, creating and deleting real clusters. This covers
  both cluster creation strategies (node groups created with the cluster, and
  added afterwards), confirms the created node groups match what was recommended,
  and verifies each cluster is actually usable — reaching its own API server,
  running nginx, publishing it through a LoadBalancer, and fetching it from
  outside the cluster.



